### PR TITLE
use no-op PathTranslator when transforming single input string

### DIFF
--- a/core/shared/src/main/scala/laika/api/Renderer.scala
+++ b/core/shared/src/main/scala/laika/api/Renderer.scala
@@ -23,7 +23,7 @@ import laika.ast._
 import laika.factory.{ MarkupFormat, RenderContext, RenderFormat, TwoPhaseRenderFormat }
 import laika.parse.markup.DocumentParser.RendererError
 import laika.rewrite.OutputContext
-import laika.rewrite.nav.{ BasicPathTranslator, PathTranslator }
+import laika.rewrite.nav.{ NoOpPathTranslator, PathTranslator }
 
 /** Performs a render operation from a document AST to a target format
   * as a string. The document AST may be obtained by a preceding parse
@@ -68,7 +68,7 @@ abstract class Renderer(val config: OperationConfig, skipRewrite: Boolean = fals
       }
     )
 
-  private val defaultPathTranslator: PathTranslator = BasicPathTranslator(format.fileSuffix)
+  private val defaultPathTranslator: PathTranslator = NoOpPathTranslator
 
   /** Renders the specified document as a String.
     */

--- a/core/shared/src/main/scala/laika/rewrite/nav/PathTranslator.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/PathTranslator.scala
@@ -259,11 +259,19 @@ private[laika] class TargetLookup(cursor: RootCursor) extends (Path => Option[Pa
 
 }
 
-/** Basic path translator implementation that only replaces the suffix of the path.
+/** Path translator implementation that returns all paths unmodified.
   *
   * Used in scenarios where only a single document gets rendered and there is no use case for
   * cross references or static or versioned documents.
   */
+object NoOpPathTranslator extends PathTranslator {
+  def getAttributes(path: Path): Option[PathAttributes] = None
+  def translate(input: Path): Path                      = input
+  def translate(input: RelativePath): RelativePath      = input
+  def forReferencePath(path: Path): PathTranslator      = this
+}
+
+@deprecated("use NoOpPathTranslator for transforming a single input", "0.19.2")
 case class BasicPathTranslator(outputSuffix: String) extends PathTranslator {
   private val defaultAttributes = Some(PathAttributes(isStatic = false, isVersioned = false))
   def getAttributes(path: Path): Option[PathAttributes] = defaultAttributes

--- a/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
+++ b/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
@@ -281,11 +281,11 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
             NavigationItem(
               SpanSequence("Link-2"),
               Nil,
-              Some(NavigationLink(InternalTarget(Root / "doc-2").relativeTo(refPath))),
+              Some(NavigationLink(InternalTarget(Root / "doc-2.html").relativeTo(refPath))),
               options = Style.level(2)
             )
           ),
-          Some(NavigationLink(InternalTarget(Root / "doc-1").relativeTo(refPath))),
+          Some(NavigationLink(InternalTarget(Root / "doc-1.html").relativeTo(refPath))),
           options = Style.level(1)
         ),
         NavigationItem(
@@ -295,7 +295,10 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
               SpanSequence("Link-4"),
               Nil,
               Some(
-                NavigationLink(InternalTarget(Root / "doc-4").relativeTo(refPath), selfLink = true)
+                NavigationLink(
+                  InternalTarget(Root / "doc-4.html").relativeTo(refPath),
+                  selfLink = true
+                )
               ),
               options = Style.level(2)
             )
@@ -305,7 +308,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
         NavigationItem(
           SpanSequence("Link-5"),
           Nil,
-          Some(NavigationLink(InternalTarget(Root / "doc-5").relativeTo(refPath))),
+          Some(NavigationLink(InternalTarget(Root / "doc-5.html").relativeTo(refPath))),
           options = Style.level(1)
         )
       )
@@ -605,17 +608,12 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   }
 
   test("render a paragraph containing a internal link with a fragment part") {
-    val elem = testPar(SpanLink.internal("/bar#foo")(Text("link"), Emphasized("text")))
+    val elem = testPar(SpanLink.internal("/bar.html#foo")(Text("link"), Emphasized("text")))
     run(elem, """<p>some <a href="bar.html#foo">link<em>text</em></a> span</p>""")
   }
 
   test("render a paragraph containing a internal link without a fragment part") {
-    val elem = testPar(SpanLink.internal("/bar")(Text("link"), Emphasized("text")))
-    run(elem, """<p>some <a href="bar.html">link<em>text</em></a> span</p>""")
-  }
-
-  test("render a paragraph containing a internal link with an input filename without suffix") {
-    val elem = testPar(SpanLink.internal("/bar")(Text("link"), Emphasized("text")))
+    val elem = testPar(SpanLink.internal("/bar.html")(Text("link"), Emphasized("text")))
     run(elem, """<p>some <a href="bar.html">link<em>text</em></a> span</p>""")
   }
 
@@ -623,7 +621,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     "render a paragraph containing an internal link while ignoring the restricted type parameter"
   ) {
     val target = ResolvedInternalTarget(
-      Path.parse("/doc#foo"),
+      Path.parse("/doc.html#foo"),
       RelativePath.parse("#foo"),
       TargetFormats.Selected("html")
     )
@@ -642,7 +640,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   }
 
   test("render a raw internal link") {
-    val elem = testPar(RawLink.internal("/doc#foo"))
+    val elem = testPar(RawLink.internal("/doc.html#foo"))
     run(elem, """<p>some #foo span</p>""")
   }
 

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -46,7 +46,7 @@ import laika.render._
 import laika.render.fo.TestTheme
 import laika.render.fo.TestTheme.staticHTMLPaths
 import laika.rewrite.ReferenceResolver.CursorKeys
-import laika.rewrite.nav.{ BasicPathTranslator, PrettyURLs, TargetFormats }
+import laika.rewrite.nav.{ NoOpPathTranslator, PrettyURLs, TargetFormats }
 import laika.rewrite.{ DefaultTemplatePath, OutputContext, Version, VersionScannerConfig, Versions }
 import munit.CatsEffectSuite
 
@@ -120,9 +120,7 @@ class TreeRendererSpec extends CatsEffectSuite
       TemplateRoot.fallback,
       Config.empty,
       outputContext,
-      BasicPathTranslator(
-        outputContext.fileSuffix
-      ), // not part of the assertions, so not reflecting actual instance
+      NoOpPathTranslator,
       coverDocument = coverDocument,
       staticDocuments = staticDocuments.map(Inputs.ByteInput.empty(_))
     )

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -47,7 +47,7 @@ import laika.parse.text.TextParsers
 import laika.render.fo.TestTheme
 import laika.rewrite.{ DefaultTemplatePath, OutputContext }
 import laika.rewrite.link.SlugBuilder
-import laika.rewrite.nav.BasicPathTranslator
+import laika.rewrite.nav.NoOpPathTranslator
 import laika.theme.ThemeProvider
 import munit.CatsEffectSuite
 
@@ -186,7 +186,7 @@ class TreeTransformerSpec extends CatsEffectSuite
     TemplateRoot.fallback,
     Config.empty,
     outputContext,
-    BasicPathTranslator(outputContext.fileSuffix),
+    NoOpPathTranslator,
     coverDocument = coverDocument,
     staticDocuments = staticDocuments.map(ByteInput.empty(_))
   )

--- a/io/src/test/scala/laika/render/epub/InputTreeBuilder.scala
+++ b/io/src/test/scala/laika/render/epub/InputTreeBuilder.scala
@@ -20,11 +20,10 @@ import cats.effect.IO
 import laika.config.{ Config, ConfigBuilder, LaikaKeys }
 import laika.ast.Path.Root
 import laika.ast._
-import laika.format.EPUB.ScriptedTemplate
 import laika.io.model._
 import laika.io.helper.InputBuilder
 import laika.rewrite.OutputContext
-import laika.rewrite.nav.BasicPathTranslator
+import laika.rewrite.nav.NoOpPathTranslator
 
 trait InputTreeBuilder extends InputBuilder {
 
@@ -62,14 +61,13 @@ trait InputTreeBuilder extends InputBuilder {
     ConfigBuilder.empty.withValue(LaikaKeys.title, s"Tree $num").build
 
   def rootTree(path: Path, titleNum: Int, docs: RenderContent*): RenderedTreeRoot[IO] = {
-    val outputContext  = OutputContext("ignored")
-    val pathTranslator = BasicPathTranslator(outputContext.fileSuffix)
+    val outputContext = OutputContext("ignored")
     RenderedTreeRoot(
       tree(path, titleNum, docs: _*),
       TemplateRoot.empty,
       Config.empty,
       outputContext,
-      pathTranslator
+      NoOpPathTranslator // not reflecting real result, but not part of any assertions
     )
   }
 

--- a/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
+++ b/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
@@ -29,8 +29,8 @@ import laika.parse.code.CodeCategory
 import laika.parse.markup.DocumentParser.RendererError
 import laika.rewrite.OutputContext
 import laika.rewrite.nav.{
-  BasicPathTranslator,
   ConfigurablePathTranslator,
+  NoOpPathTranslator,
   PathAttributes,
   TargetFormats,
   TranslatorConfig
@@ -38,8 +38,6 @@ import laika.rewrite.nav.{
 import munit.FunSuite
 
 class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with TestSourceBuilders {
-
-  private val pathTranslator = BasicPathTranslator(XSLFO.fileSuffix)
 
   private val defaultRenderer = Renderer.of(XSLFO).build
 
@@ -50,7 +48,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
     """<fo:block space-after="3mm"><fo:leader leader-length="100%" leader-pattern="rule" rule-style="solid" rule-thickness="2pt"></fo:leader></fo:block>"""
 
   def render(elem: Element, style: StyleDeclarationSet): Either[RendererError, String] =
-    defaultRenderer.render(elem, Root / "doc", pathTranslator, style)
+    defaultRenderer.render(elem, Root / "doc", NoOpPathTranslator, style)
 
   def run(input: Element, expectedFO: String)(implicit loc: munit.Location): Unit =
     assertEquals(render(input, TestTheme.foStyles), Right(expectedFO))
@@ -64,7 +62,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
       loc: munit.Location
   ): Unit =
     assertEquals(
-      defaultRenderer.render(input, Root / "doc", pathTranslator, style),
+      defaultRenderer.render(input, Root / "doc", NoOpPathTranslator, style),
       Right(expectedFO)
     )
 
@@ -74,7 +72,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
     val res = Renderer.of(XSLFO).renderMessages(messageFilter).build.render(
       elem,
       Root / "doc",
-      pathTranslator,
+      NoOpPathTranslator,
       TestTheme.foStyles
     )
     assertEquals(res, Right(expectedFO))
@@ -84,7 +82,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
     val res = Renderer.of(XSLFO).unformatted.build.render(
       input,
       Root / "doc",
-      pathTranslator,
+      NoOpPathTranslator,
       TestTheme.foStyles
     )
     assertEquals(res, Right(expectedFO))

--- a/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
@@ -28,7 +28,7 @@ import laika.bundle.{ BundleOrigin, BundleProvider, ExtensionBundle }
 import laika.format.{ HTML, Markdown }
 import laika.io.helper.TestThemeBuilder
 import laika.rewrite.OutputContext
-import laika.rewrite.nav.BasicPathTranslator
+import laika.rewrite.nav.NoOpPathTranslator
 import munit.FunSuite
 
 /** @author Jens Halm
@@ -121,7 +121,7 @@ class ThemeBundleSpec extends FunSuite {
       DocumentTreeRoot(DocumentTree(Root, Seq(Document(Root / "doc.md", RootElement.empty))))
     val compoundTranslator = config(themeBundles, appBundles)
       .pathTranslatorFor(testTree, OutputContext("html"))
-      .getOrElse(BasicPathTranslator("html"))
+      .getOrElse(NoOpPathTranslator)
     assertEquals(compoundTranslator.translate(Root / "doc.md"), Root / "doc-theme-app.html")
   }
 

--- a/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
+++ b/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
@@ -28,7 +28,7 @@ import laika.parse.markup.DocumentParser.InvalidDocument
 import laika.render.fo.TestTheme
 import laika.render.pdf.FOConcatenation
 import laika.rewrite.OutputContext
-import laika.rewrite.nav.BasicPathTranslator
+import laika.rewrite.nav.NoOpPathTranslator
 import munit.FunSuite
 
 /** @author Jens Halm
@@ -46,7 +46,7 @@ class FOConcatenationSpec extends FunSuite with TestSourceBuilders {
     defaultTemplate = TemplateRoot(TemplateElement(invalidElement)),
     config = Config.empty,
     outputContext = OutputContext(XSLFO),
-    pathTranslator = BasicPathTranslator("fo"),
+    pathTranslator = NoOpPathTranslator,
     styles = TestTheme.foStyles
   )
 


### PR DESCRIPTION
When transforming a single input string (as opposed to an entire directory of inputs), link validation and path translation should be skipped as the transformer does not have the necessary context for performing these actions.

Also adjusts a few tests that had expectations based on some translation occurring.

Fixes #408 

