### PR TITLE
HTML: avoid compound effect of relative font sizes for pre and code

### DIFF
--- a/io/src/main/resources/laika/helium/css/code.css
+++ b/io/src/main/resources/laika/helium/css/code.css
@@ -4,8 +4,7 @@ pre {
   border-radius: 5px;
   padding: 12px 9px 9px 15px;
   margin: 0 0 var(--block-spacing);
-  font-size: var(--code-font-size);
-  line-height: 21px;
+  line-height: 1.4;
   word-break: break-all;
   word-wrap: break-word;
   white-space: pre-wrap;
@@ -19,7 +18,6 @@ code {
   padding: 0 0.1em;
 }
 pre code {
-  font-size: var(--code-font-size);
   color: var(--syntax-base5);
   background-color: transparent;
   padding: 0;


### PR DESCRIPTION
When 0.19.1 introduced a new default for the code font size, making it relative to fix problems with code spans in headers, it triggered an undesired compound effect of the relative size being assigned to both `pre` and `code` tags inside code blocks. The result was that the font was significantly smaller in 0.19.2 than in 0.19.1.

This PR simply removes the `font-size` attribute from the CSS for `pre`.

Note that the font is still a tiny bit smaller than in 0.19.0. The exact same rendering would be achieved by using `0.9333em` instead of `0.9em`, but I've chosen to round the value as I feel that it still looks good.

The PR also improves the `line-height` attribute, which is now also relative. This means when users change the code font size in Helium configuration, the line height will adjust accordingly.