### PR TITLE
avoid fs2 3.7.0 deprecation warnings about Files.apply

### DIFF
--- a/io/src/main/scala/laika/io/config/ResourceLoader.scala
+++ b/io/src/main/scala/laika/io/config/ResourceLoader.scala
@@ -61,7 +61,7 @@ object ResourceLoader {
       )
     }
 
-    Files[F].exists(file.toFS2Path).ifM(
+    Files.forAsync[F].exists(file.toFS2Path).ifM(
       load.map(Option(_)),
       Async[F].pure(None)
     )

--- a/io/src/main/scala/laika/io/model/BinaryInput.scala
+++ b/io/src/main/scala/laika/io/model/BinaryInput.scala
@@ -59,7 +59,7 @@ object BinaryInput {
       mountPoint: Path = Root / "doc",
       targetFormats: TargetFormats = TargetFormats.All
   ): BinaryInput[F] = {
-    val stream = Files[F].readAll(file.toFS2Path)
+    val stream = Files.forAsync[F].readAll(file.toFS2Path)
     BinaryInput(stream, mountPoint, targetFormats, Some(file))
   }
 

--- a/io/src/main/scala/laika/io/model/DirectoryInput.scala
+++ b/io/src/main/scala/laika/io/model/DirectoryInput.scala
@@ -43,7 +43,7 @@ object DirectoryInput {
   /** A filter that selects files that are hidden in a platform-dependent way.
     */
   val hiddenFileFilter: FileFilter = new FileFilter {
-    def filter[F[_]: Async](file: FilePath) = Files[F].isHidden(file.toFS2Path)
+    def filter[F[_]: Async](file: FilePath) = Files.forAsync[F].isHidden(file.toFS2Path)
   }
 
   @deprecated("use apply(FilePath)", "0.19.0")

--- a/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
+++ b/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
@@ -164,7 +164,7 @@ class InputTreeBuilder[F[_]](
   def addDirectory(dir: FilePath, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
     addStep(Some(dir)) {
       Kleisli { ctx =>
-        Files[F].isDirectory(dir.toFS2Path).ifM(
+        Files.forAsync[F].isDirectory(dir.toFS2Path).ifM(
           DirectoryScanner
             .scanDirectories[F](
               new DirectoryInput(Seq(dir), codec, ctx.docTypeMatcher, ctx.exclude, mountPoint)

--- a/io/src/main/scala/laika/io/model/TextInput.scala
+++ b/io/src/main/scala/laika/io/model/TextInput.scala
@@ -68,7 +68,7 @@ object TextInput {
       docType: TextDocumentType = DocumentType.Markup
   )(implicit codec: Codec): TextInput[F] = {
 
-    val input = readAll(Files[F].readAll(file.toFS2Path), codec)
+    val input = readAll(Files.forAsync[F].readAll(file.toFS2Path), codec)
     TextInput[F](input, mountPoint, docType, Some(file))
   }
 

--- a/io/src/main/scala/laika/io/model/TextOutput.scala
+++ b/io/src/main/scala/laika/io/model/TextOutput.scala
@@ -59,7 +59,7 @@ object TextOutput {
   def forFile[F[_]: Async](file: FilePath, path: Path = Root / "doc")(implicit
       codec: Codec
   ): TextOutput[F] =
-    TextOutput[F](writeAll(Files[F].writeAll(file.toFS2Path), codec), path, Some(file))
+    TextOutput[F](writeAll(Files.forAsync[F].writeAll(file.toFS2Path), codec), path, Some(file))
 
   def forStream[F[_]: Async](
       stream: F[OutputStream],

--- a/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
+++ b/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
@@ -36,7 +36,7 @@ object DirectoryScanner {
   /** Scans the specified directory passing all child paths to the given function.
     */
   def scanDirectory[F[_]: Async, A](directory: FilePath)(f: Seq[FilePath] => F[A]): F[A] =
-    fs2.io.file.Files[F]
+    fs2.io.file.Files.forAsync[F]
       .list(directory.toFS2Path)
       .map(FilePath.fromFS2Path)
       .compile
@@ -70,7 +70,7 @@ object DirectoryScanner {
 
       input.fileFilter.filter(filePath).ifM(
         InputTree.empty[F].pure[F],
-        Files[F].isDirectory(filePath.toFS2Path).ifM(
+        Files.forAsync[F].isDirectory(filePath.toFS2Path).ifM(
           scanDirectory(filePath)(asInputCollection(childPath, input)),
           input.docTypeMatcher(childPath) match {
             case docType: TextDocumentType =>

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -137,7 +137,7 @@ object RendererRuntime {
       val result: RenderResult = Left(translatedDoc)
       dir.map(file(_, translatedDoc.path)) match {
         case Some(outFile) if !doc.sourceFile.contains(outFile) =>
-          val out = Files[F].writeAll(outFile.toFS2Path)
+          val out = Files.forAsync[F].writeAll(outFile.toFS2Path)
           doc.input.through(out).compile.drain.as(result)
         case _                                                  =>
           Sync[F].pure(result)
@@ -154,7 +154,8 @@ object RendererRuntime {
       val styles = finalRoot.styles(fileSuffix) ++ getThemeStyles(themeInputs.parsedResults)
       val pathTranslatorF = pathTranslator.translate(_: Path)
 
-      def createDirectory(file: FilePath): F[Unit] = Files[F].createDirectories(file.toFS2Path)
+      def createDirectory(file: FilePath): F[Unit] =
+        Files.forAsync[F].createDirectories(file.toFS2Path)
 
       op.output match {
         case StringTreeOutput            =>

--- a/preview/src/main/scala/laika/preview/SourceChangeWatcher.scala
+++ b/preview/src/main/scala/laika/preview/SourceChangeWatcher.scala
@@ -45,7 +45,7 @@ private[preview] class SourceChangeWatcher[F[_]: Async](
     DirectoryScanner.scanDirectory[F, List[FilePath]](dir) {
       _.toList
         .traverse { childPath =>
-          (Files[F].isDirectory(childPath.toFS2Path), fileFilter.filter(childPath)).tupled
+          (Files.forAsync[F].isDirectory(childPath.toFS2Path), fileFilter.filter(childPath)).tupled
             .flatMap { case (isDir, exclude) =>
               if (isDir && !exclude) scanDirectory(childPath) else List.empty[FilePath].pure[F]
             }
@@ -77,7 +77,7 @@ private[preview] class SourceChangeWatcher[F[_]: Async](
 
     val groupedInputs = inputs
       .traverse { input =>
-        Files[F].isDirectory(input.toFS2Path).map(
+        Files.forAsync[F].isDirectory(input.toFS2Path).map(
           if (_) (input, None)
           else (FilePath.fromNioPath(input.toNioPath.getParent), Some(input))
         )
@@ -124,7 +124,7 @@ private[preview] class SourceChangeWatcher[F[_]: Async](
       case p: java.nio.file.Path =>
         val file   = FilePath.fromNioPath(p)
         val target = targets.get(watchKey)
-        (fileFilter.filter(file), Files[F].isDirectory(file.toFS2Path)).tupled.flatMap {
+        (fileFilter.filter(file), Files.forAsync[F].isDirectory(file.toFS2Path)).tupled.flatMap {
           case (exclude, isDir) =>
             (exclude, isDir, target) match {
               case (false, true, Some(_))  => Async[F].pure(Some(Left(file)))

--- a/preview/src/main/scala/laika/preview/StaticFileScanner.scala
+++ b/preview/src/main/scala/laika/preview/StaticFileScanner.scala
@@ -40,7 +40,7 @@ private[preview] object StaticFileScanner {
           val vChild                        = vPath / filePath.name
           def result: (Path, SiteResult[F]) =
             (vChild, StaticResult(BinaryInput.fromFile(filePath, vPath).input))
-          Files[F].isDirectory(filePath.toFS2Path).ifM(
+          Files.forAsync[F].isDirectory(filePath.toFS2Path).ifM(
             collect(filePath, vChild),
             Async[F].pure(List(result))
           )


### PR DESCRIPTION
This PR just changes `Files[F]` to `Files.forAsync[F]` in place to avoid introducing any signature changes in a patch release.