### PR TITLE
remove all deprecated APIs and their documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           
       - name: Build and test
         run: |
-          sbt -v +test +mimaReportBinaryIssues scalafmtCheckAll docs/mdoc docs/laikaSite scripted
+          sbt -v +test scalafmtCheckAll docs/mdoc docs/laikaSite scripted
           rm -rf "$HOME/.ivy2/local" || true
           find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
           find $HOME/.ivy2/cache                       -name "*-LM-SNAPSHOT*"       -delete || true

--- a/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
@@ -163,7 +163,4 @@ trait TransformerBuilderOps[FMT] extends ParserBuilderOps with RendererBuilderOp
 
   })
 
-  @deprecated("use buildingRules", "0.19.0")
-  def buildingRule(newRules: RewriteRulesBuilder): ThisType = buildingRules(newRules)
-
 }

--- a/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
@@ -85,7 +85,6 @@ object ReferenceResolver {
         rootKey.child("currentDocument"),
         ObjectValue(
           Seq(
-            Field("path", StringValue(document.path.toString)), // deprecated since 0.19.0
             Field("sourcePath", StringValue(document.path.toString)),
             Field("content", ASTValue(document.content), config.origin),
             Field("title", ASTValue(document.title.getOrElse(emptyTitle)), config.origin),
@@ -129,11 +128,6 @@ object ReferenceResolver {
             Seq(
               Field("path", ASTValue(RawLink.internal(doc.path))),
               Field("sourcePath", sourcePath),
-              Field("absolutePath", sourcePath), // deprecated since 0.19.0
-              Field(
-                "relativePath",
-                StringValue(doc.path.relativeTo(document.path).toString)
-              ),                                 // deprecated since 0.19.0
               Field("title", ASTValue(doc.title.getOrElse(emptyTitle)))
             )
           )

--- a/core/shared/src/main/scala/laika/rewrite/nav/PathTranslator.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/PathTranslator.scala
@@ -270,12 +270,3 @@ object NoOpPathTranslator extends PathTranslator {
   def translate(input: RelativePath): RelativePath      = input
   def forReferencePath(path: Path): PathTranslator      = this
 }
-
-@deprecated("use NoOpPathTranslator for transforming a single input", "0.19.2")
-case class BasicPathTranslator(outputSuffix: String) extends PathTranslator {
-  private val defaultAttributes = Some(PathAttributes(isStatic = false, isVersioned = false))
-  def getAttributes(path: Path): Option[PathAttributes] = defaultAttributes
-  def translate(input: Path): Path                      = input.withSuffix(outputSuffix)
-  def translate(input: RelativePath): RelativePath      = input.withSuffix(outputSuffix)
-  def forReferencePath(path: Path): PathTranslator      = this
-}

--- a/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
@@ -112,42 +112,6 @@ class StandardDirectiveSpec extends FunSuite
     run(input, p(Text("aa "), SpanSequence(Nil), Text(" bb")))
   }
 
-  test("path directive - translate a relative path") {
-    val input = """aa @:path(theme.css) bb"""
-    runTemplate(
-      input,
-      "laika.links.excludeFromValidation = [\"/\"]",
-      TemplateString("aa "),
-      TemplateElement(RawLink.internal("../theme/theme.css")),
-      TemplateString(" bb")
-    )
-  }
-
-  test("path directive - translate an absolute path") {
-    val input = """aa @:path(/theme/theme.css) bb"""
-    runTemplate(
-      input,
-      "laika.links.excludeFromValidation = [\"/\"]",
-      TemplateString("aa "),
-      TemplateElement(RawLink.internal("../theme/theme.css")),
-      TemplateString(" bb")
-    )
-  }
-
-  test("path directive - fail with an invalid target") {
-    val dirSrc = "@:path(/theme/theme.css)"
-    val input  = s"""aa $dirSrc bb"""
-    val msg    =
-      "One or more errors processing directive 'path': unresolved internal reference: ../theme/theme.css"
-    runTemplate(
-      input,
-      "",
-      TemplateString("aa "),
-      TemplateElement(InvalidSpan(msg, source(dirSrc, input)).copy(fallback = Literal(dirSrc))),
-      TemplateString(" bb")
-    )
-  }
-
   private val resolvedTarget = ResolvedInternalTarget(
     absolutePath = Path.parse("/theme/theme.css"),
     relativePath = RelativePath.parse("../theme/theme.css")

--- a/docs/src/07-reference/01-standard-directives.md
+++ b/docs/src/07-reference/01-standard-directives.md
@@ -76,14 +76,6 @@ Example:
 See [Disabling Validation] when you only want the path translation without the validation.
 
 
-### `@:path`
-
-Can only be used in templates.
-
-Deprecated since version 0.19.0 - use the `@:target` directive which is a superset of the functionality
-of the old `@:path` directive which did not support external targets.
-
-
 Inclusions
 ----------
 

--- a/docs/src/07-reference/02-substitution-variables.md
+++ b/docs/src/07-reference/02-substitution-variables.md
@@ -68,8 +68,6 @@ This is a complete list of values exposed in the `cursor` namespace:
 
     * `sourcePath`: the absolute (virtual) path of the document in the input tree.
 
-    * `path` (deprecated since 0.19.0): use `sourcePath`.
-    
 * Access to surrounding documents via `cursor.parentDocument`, `cursor.previousDocument`, `cursor.nextDocument`,
   `cursor.flattenedSiblings.previousDocument` and `cursor.flattenedSiblings.nextDocument`.
   Any of these references may be empty, depending on the position of the current document.
@@ -86,10 +84,6 @@ This is a complete list of values exposed in the `cursor` namespace:
     * `path`: the path of the document in the generated output, e.g. `../herbs/parsley.html`.
 
     * `sourcePath`: the absolute (virtual) path of the document in the input tree, e.g. `/herbs/parsley.md`.
-    
-    * `absolutePath` (deprecated since 0.19.0): use `sourcePath`.
-    
-    * `relativePath` (deprecated since 0.19.0): use `sourcePath`.
     
 * `root.title`: The title of the root node, usually the title of the website or e-book.
     

--- a/io/src/main/resources/laika/helium/templates/includes/pageNav.template.html
+++ b/io/src/main/resources/laika/helium/templates/includes/pageNav.template.html
@@ -8,6 +8,6 @@
     ]
   }
 
-  <p class="footer">@:for(helium.site.pageNavigation.sourceEditLinks)<a href="${_.baseURL}${cursor.currentDocument.path}">${_.icon}${_.text}</a>@:@</p>
+  <p class="footer">@:for(helium.site.pageNavigation.sourceEditLinks)<a href="${_.baseURL}${cursor.currentDocument.sourcePath}">${_.icon}${_.text}</a>@:@</p>
 </nav>
 @:@

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -633,21 +633,6 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     copyWith(helium.siteSettings.copy(content = newContent))
   }
 
-  @deprecated
-  def pageNavigation(
-      enabled: Boolean,
-      depth: Int,
-      sourceBaseURL: Option[String],
-      sourceLinkText: String
-  ): Helium =
-    pageNavigation(
-      enabled,
-      depth,
-      sourceBaseURL,
-      sourceLinkText,
-      currentContent.pageNavigation.keepOnSmallScreens
-    )
-
   /** Adds a dedicated page for a table of content, in addition to the left navigation bar.
     *
     * @param title the title to display on the page and in navigation that links to the page
@@ -684,12 +669,6 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
       )
     copyWith(helium.siteSettings.copy(content = newContent))
   }
-
-  @deprecated("use the corresponding properties of the new pageNavigation method", "0.19.0")
-  def markupEditLinks(text: String, baseURL: String): Helium = pageNavigation(
-    sourceLinkText = text,
-    sourceBaseURL = Some(baseURL)
-  )
 
   /** Adds a dedicated landing page to the site that is tailored for software documentation sites.
     * By default no landing page will be included and the site will render the homepage (if present)

--- a/io/src/main/scala/laika/io/model/DirectoryInput.scala
+++ b/io/src/main/scala/laika/io/model/DirectoryInput.scala
@@ -22,7 +22,6 @@ import laika.ast.{ DocumentType, Path }
 import laika.ast.Path.Root
 import laika.bundle.DocumentTypeMatcher
 
-import java.io.File
 import scala.io.Codec
 
 /** A directory in the file system containing input documents for a tree transformation.
@@ -45,11 +44,6 @@ object DirectoryInput {
   val hiddenFileFilter: FileFilter = new FileFilter {
     def filter[F[_]: Async](file: FilePath) = Files.forAsync[F].isHidden(file.toFS2Path)
   }
-
-  @deprecated("use apply(FilePath)", "0.19.0")
-  def apply(directory: File)(implicit codec: Codec): DirectoryInput = apply(
-    FilePath.fromJavaFile(directory)
-  )
 
   /** Creates a new instance using the library's defaults for the `docTypeMatcher` and
     * `fileFilter` properties.

--- a/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
+++ b/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
@@ -44,7 +44,7 @@ import laika.io.runtime.TreeResultBuilder.{
   TemplateResult
 }
 
-import java.io.{ File, InputStream }
+import java.io.InputStream
 import scala.io.Codec
 import scala.reflect.ClassTag
 
@@ -146,18 +146,10 @@ class InputTreeBuilder[F[_]](
   def addDirectory(name: String, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
     addDirectory(FilePath.parse(name), mountPoint)
 
-  @deprecated("use addDirectory(String) or addDirectory(FilePath)", "0.19.0")
-  def addDirectory(dir: File)(implicit codec: Codec): InputTreeBuilder[F] =
-    addDirectory(FilePath.fromJavaFile(dir), Root)
-
   /** Adds the specified directories to the input tree, placing it in the virtual root.
     */
   def addDirectory(dir: FilePath)(implicit codec: Codec): InputTreeBuilder[F] =
     addDirectory(dir, Root)
-
-  @deprecated("use addDirectory(String, Path) or addDirectory(FilePath, Path)", "0.19.0")
-  def addDirectory(dir: File, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
-    addDirectory(FilePath.fromJavaFile(dir), mountPoint)
 
   /** Adds the specified directories to the input tree, placing it at the specified mount point in the virtual tree.
     */
@@ -182,10 +174,6 @@ class InputTreeBuilder[F[_]](
     */
   def addFile(name: String, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
     addFile(FilePath.parse(name), mountPoint)
-
-  @deprecated("use addFile(String) or addFile(FilePath)", "0.19.0")
-  def addFile(file: File, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
-    addFile(FilePath.fromJavaFile(file), mountPoint)
 
   /** Adds the specified file to the input tree, placing it at the specified mount point in the virtual tree.
     *
@@ -236,17 +224,6 @@ class InputTreeBuilder[F[_]](
       case docType: TextDocumentType    =>
         _ + TextInput.fromClassLoaderResource(name, mountPoint, docType, classLoader)
     }
-
-  @deprecated("Use addClassResource or addClassLoaderResource", "0.19.0")
-  def addClasspathResource(name: String, mountPoint: Path)(implicit
-      codec: Codec
-  ): InputTreeBuilder[F] =
-    addClassLoaderResource(name, mountPoint)
-
-  @deprecated("use addInputStream", "0.19.0")
-  def addStream(stream: F[InputStream], mountPoint: Path, autoClose: Boolean = true)(implicit
-      codec: Codec
-  ): InputTreeBuilder[F] = addInputStream(stream, mountPoint, autoClose)
 
   /** Adds the specified input stream to the input tree, placing it at the specified mount point in the virtual tree.
     *

--- a/io/src/main/scala/laika/io/ops/BinaryOutputOps.scala
+++ b/io/src/main/scala/laika/io/ops/BinaryOutputOps.scala
@@ -20,7 +20,7 @@ import cats.effect.Async
 import laika.ast.Path.Root
 import laika.io.model.{ BinaryOutput, FilePath }
 
-import java.io.{ File, OutputStream }
+import java.io.OutputStream
 
 /** API for specifying the output for a binary format like EPUB or PDF.
   *
@@ -41,9 +41,6 @@ trait BinaryOutputOps[F[_]] {
     *  @param name the name of the file to write to
     */
   def toFile(name: String): Result = toFile(FilePath.parse(name))
-
-  @deprecated("use toFile(String) or toFile(FilePath)", "0.19.0")
-  def toFile(file: File): Result = toFile(FilePath.fromJavaFile(file))
 
   /** Builder step that instructs the runtime to render
     * to the specified file.

--- a/io/src/main/scala/laika/io/ops/InputOps.scala
+++ b/io/src/main/scala/laika/io/ops/InputOps.scala
@@ -20,7 +20,6 @@ import cats.effect.Async
 import laika.api.builder.OperationConfig
 import laika.io.model.{ DirectoryInput, FileFilter, FilePath, InputTree, InputTreeBuilder }
 
-import java.io.File
 import scala.io.Codec
 
 /** API for specifying the tree of character inputs for a parsing operation.
@@ -70,10 +69,6 @@ trait InputOps[F[_]] {
   def fromDirectory(dir: FilePath)(implicit codec: Codec): Result =
     fromDirectory(dir, DirectoryInput.hiddenFileFilter)(codec)
 
-  @deprecated("use fromDirectory(String) or fromDirectory(FilePath)", "0.19.0")
-  def fromDirectory(dir: File)(implicit codec: Codec): Result =
-    fromDirectory(FilePath.fromJavaFile(dir), DirectoryInput.hiddenFileFilter)(codec)
-
   /**  Builder step that instructs the runtime to parse files from the
     *  specified directory and its subdirectories.
     *
@@ -83,13 +78,6 @@ trait InputOps[F[_]] {
     */
   def fromDirectory(dir: FilePath, exclude: FileFilter)(implicit codec: Codec): Result =
     fromDirectories(Seq(dir), exclude)(codec)
-
-  @deprecated(
-    "use fromDirectory(String, FileFilter) or fromDirectory(FilePath, FileFilter)",
-    "0.19.0"
-  )
-  def fromDirectory(dir: File, exclude: FileFilter)(implicit codec: Codec): Result =
-    fromDirectories(Seq(FilePath.fromJavaFile(dir)), exclude)(codec)
 
   /**  Builder step that instructs the runtime to parse files from the
     *  specified directories and its subdirectories, merging them into
@@ -111,15 +99,6 @@ trait InputOps[F[_]] {
     */
   def fromDirectories(roots: Seq[FilePath], exclude: FileFilter)(implicit codec: Codec): Result =
     fromInput(InputTree[F](exclude)(F).addDirectories(roots))
-
-  @deprecated(
-    "use fromDirectory(String) or fromDirectory(FilePath) using a relative path",
-    "0.19.0"
-  )
-  def fromWorkingDirectory(exclude: FileFilter = DirectoryInput.hiddenFileFilter)(implicit
-      codec: Codec
-  ): Result =
-    fromDirectories(Seq(FilePath.parse(System.getProperty("user.dir"))), exclude)
 
   /** Builder step that instructs the runtime to use the specified input builder for all parsing operations.
     *

--- a/io/src/main/scala/laika/io/ops/TextOutputOps.scala
+++ b/io/src/main/scala/laika/io/ops/TextOutputOps.scala
@@ -16,7 +16,6 @@
 
 package laika.io.ops
 
-import java.io.File
 import cats.effect.Sync
 import laika.io.model.{ DirectoryOutput, FilePath, TreeOutput }
 
@@ -58,15 +57,6 @@ trait TextOutputOps[F[_]] {
   def toDirectory(dir: FilePath)(implicit codec: Codec): Result = toOutput(
     DirectoryOutput(dir, codec)
   )
-
-  @deprecated("use toDirectory(String) or toDirectory(FilePath)", "0.19.0")
-  def toDirectory(dir: File)(implicit codec: Codec): Result = toDirectory(
-    FilePath.fromJavaFile(dir)
-  )
-
-  @deprecated("use toDirectory(String) or toDirectory(FilePath) using a relative path", "0.19.0")
-  def toWorkingDirectory(implicit codec: Codec): Result =
-    toOutput(DirectoryOutput(FilePath.parse(System.getProperty("user.dir")), codec))
 
   /** Builder step that instructs the runtime to render
     * to the specified tree output.

--- a/io/src/main/scala/laika/theme/config/Font.scala
+++ b/io/src/main/scala/laika/theme/config/Font.scala
@@ -16,7 +16,6 @@
 
 package laika.theme.config
 
-import java.io.File
 import laika.ast.Path.Root
 import laika.ast.{ Path, VirtualPath }
 import laika.config._
@@ -43,9 +42,6 @@ case class Font private (embedResource: Option[EmbeddedFont], webCSS: Option[Str
     * not a path from the library's virtual path.
     */
   def embedFile(file: FilePath): Font = new Font(Some(EmbeddedFontFile(file)), webCSS)
-
-  @deprecated("use embedFile(String) or embedFile(FilePath)", "0.19.0")
-  def embedFile(file: File): Font = embedFile(FilePath.fromJavaFile(file))
 
   /** Specifies a font file as a classpath resource that can be used for embedding in EPUB or PDF.
     * For theme authors classpath resources are the recommended way of providing default fonts.
@@ -83,9 +79,6 @@ object Font {
     * not a path from the library's virtual path.
     */
   def embedFile(file: FilePath): Font = new Font(Some(EmbeddedFontFile(file)), None)
-
-  @deprecated("use embedFile(String) or embedFile(FilePath)", "0.19.0")
-  def embedFile(file: File): Font = embedFile(FilePath.fromJavaFile(file))
 
   /** Specifies a font file as a classpath resource that can be used for embedding in EPUB or PDF.
     * For theme authors classpath resources are the recommended way of providing default fonts.

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -16,7 +16,7 @@
 
 package laika.preview
 
-import java.io.{ File, PrintWriter, StringWriter }
+import java.io.{ PrintWriter, StringWriter }
 import cats.data.{ Kleisli, OptionT }
 import cats.effect._
 import cats.syntax.all._
@@ -215,9 +215,6 @@ class ServerConfig private (
     * This step is only necessary if you want to test links to API documentation with the preview server.
     */
   def withAPIDirectory(dir: FilePath): ServerConfig = copy(newAPIDir = Some(dir))
-
-  @deprecated("use withAPIDirectory(FilePath)", "0.19.0")
-  def withAPIDirectory(dir: File): ServerConfig = copy(newAPIDir = Some(FilePath.fromJavaFile(dir)))
 
   /** Indicates that each served page and each detected file change should be logged to the console.
     */

--- a/sbt/src/sbt-test/site/inputs/build.sbt
+++ b/sbt/src/sbt-test/site/inputs/build.sbt
@@ -1,6 +1,6 @@
 import cats.effect.IO
 import laika.ast.Path.Root
-import laika.io.model.InputTree
+import laika.io.model.{ FilePath, InputTree }
 
 name := "site-inputs"
 
@@ -9,8 +9,14 @@ version := "0.1"
 scalaVersion := "2.12.6"
 
 laikaInputs := InputTree[IO]
-  .addFile(baseDirectory.value / "src/docs/hello.md", Root / "doc-1.md")
-  .addFile(baseDirectory.value / "src/docs/default.template.html", Root / "default.template.html")
+  .addFile(
+    FilePath.fromJavaFile(baseDirectory.value / "src/docs/hello.md"),
+    Root / "doc-1.md"
+  )
+  .addFile(
+    FilePath.fromJavaFile(baseDirectory.value / "src/docs/default.template.html"),
+    Root / "default.template.html"
+  )
   .addString(
     """# Title
       |


### PR DESCRIPTION
First PR for the 1.0 milestone series - there is a branch for 0.19 maintenance now.

I think we can release the first milestone just with this cleanup and the switch to ci-releases, so we have some early confirmation it's all working before the main work commences.