### PR TITLE
remove unused parameters

### DIFF
--- a/core/jvm/src/test/scala/laika/rst/ReStructuredTextToHTMLSpec.scala
+++ b/core/jvm/src/test/scala/laika/rst/ReStructuredTextToHTMLSpec.scala
@@ -154,9 +154,9 @@ class ReStructuredTextToHTMLSpec extends FunSuite {
           fmt.childPerLine(
             Seq(it, Header(level, rest, opt))
           ) // move target out of the header content
-        case (fmt, Header(level, content, opt))                                        =>
+        case (fmt, Header(level, content, _))                                          =>
           fmt.element("h" + (level - 1), NoOpt, content) // rst special treatment of first header
-        case (fmt, Title(content, opt)) => fmt.element("h1", NoOpt, content, "class" -> "title")
+        case (fmt, Title(content, _)) => fmt.element("h1", NoOpt, content, "class" -> "title")
         case (fmt, TitledBlock(title, content, opt)) =>
           fmt.indentedElement("div", opt, Paragraph(title, Styles("admonition-title")) +: content)
         case (fmt, QuotedBlock(content, attr, opt))  =>

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -473,7 +473,7 @@ object DocumentCursor {
     apply(
       document,
       parent,
-      ReferenceResolver.forDocument(document, parent, config, position),
+      ReferenceResolver.forDocument(document, parent, config),
       config,
       None,
       position

--- a/core/shared/src/main/scala/laika/directive/api.scala
+++ b/core/shared/src/main/scala/laika/directive/api.scala
@@ -17,14 +17,15 @@
 package laika.directive
 
 import cats.{ Functor, Semigroupal }
-import laika.ast.{ TemplateSpan, _ }
-import laika.collection.TransitionalCollectionOps._
+import laika.ast.{ TemplateSpan, * }
+import laika.collection.TransitionalCollectionOps.*
 import laika.config.Origin.DirectiveScope
-import laika.config._
+import laika.config.*
 import laika.parse.SourceFragment
 import laika.parse.directive.DirectiveParsers.ParsedDirective
 import laika.parse.hocon.ConfigResolver
 import laika.parse.markup.{ RecursiveParsers, RecursiveSpanParsers }
+import org.typelevel.scalaccompat.annotation.unused
 
 import scala.reflect.ClassTag
 
@@ -259,7 +260,7 @@ trait BuilderContext[E <: Element] {
         .asInstanceOf[E]
     }
 
-    def runsIn(phase: RewritePhase): Boolean = directive.fold(true)(_.runsIn(phase))
+    def runsIn(@unused phase: RewritePhase): Boolean = directive.fold(true)(_.runsIn(phase))
   }
 
   private[laika] trait SeparatorInstanceBase extends DirectiveProcessor {
@@ -280,7 +281,7 @@ trait BuilderContext[E <: Element] {
 
     }
 
-    def runsIn(phase: RewritePhase): Boolean = true
+    def runsIn(@unused phase: RewritePhase): Boolean = true
   }
 
   /** Provides combinators to describe the expected structure of a specific directive.

--- a/core/shared/src/main/scala/laika/parse/code/common/CharLiteral.scala
+++ b/core/shared/src/main/scala/laika/parse/code/common/CharLiteral.scala
@@ -45,17 +45,17 @@ object CharLiteral {
 
     lazy val underlying: PrefixedParser[Seq[CodeSpan]] = {
 
-      def plainChar(char: String) = oneNot('\'', '\n').asCode(categories)
-      val delimParser             = oneOf(delim).asCode(categories)
+      val plainChar   = oneNot('\'', '\n').asCode(categories)
+      val delimParser = oneOf(delim).asCode(categories)
 
       (delim.toString ~> lookAhead(oneChar)).flatMap { char =>
-        (PrefixedParser.mapAndMerge(embedded.flatMap(_.parsers)).getOrElse(
-          char.head,
-          plainChar(char)
-        ) ~ delimParser).mapN { (span, delimSpan) =>
-          val codeSpans = delimSpan +: CodeSpans.extract(categories)(span) :+ delimSpan
-          CodeSpans.merge(codeSpans)
-        }
+        (PrefixedParser
+          .mapAndMerge(embedded.flatMap(_.parsers))
+          .getOrElse(char.head, plainChar) ~ delimParser)
+          .mapN { (span, delimSpan) =>
+            val codeSpans = delimSpan +: CodeSpans.extract(categories)(span) :+ delimSpan
+            CodeSpans.merge(codeSpans)
+          }
       }
 
     }

--- a/core/shared/src/main/scala/laika/parse/directive/TemplateParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/directive/TemplateParsers.scala
@@ -51,7 +51,7 @@ class TemplateParsers(directives: Map[String, Templates.Directive])
     val separators = directives.values.flatMap(_.separators).toSet
 
     PrefixedParser('@') {
-      directiveParser(body, this).withCursor.map { case (res, source) =>
+      directiveParser(body).withCursor.map { case (res, source) =>
         if (separators.contains(res.name)) Templates.SeparatorInstance(res, source)
         else Templates.DirectiveInstance(directives.get(res.name), res, this, source)
       }

--- a/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
@@ -138,7 +138,7 @@ object ConfigResolver {
         else {
           resolvedParent(key).flatMap { case (obj, fieldPath) =>
             obj.values.find(_.validKey == fieldPath).map(_.value).foreach(
-              resolveField(fieldPath, _, obj)
+              resolveField(fieldPath, _)
             )
             resolvedValue(key).orElse(fallback.get[ConfigValue](key).toOption)
           }
@@ -180,8 +180,7 @@ object ConfigResolver {
 
       def resolveField(
           key: Key,
-          value: ConfigBuilderValue,
-          parent: ObjectBuilderValue
+          value: ConfigBuilderValue
       ): Option[ConfigValue] = {
         resolvedValue(key).orElse {
           activeFields += key
@@ -198,7 +197,7 @@ object ConfigResolver {
         startedObjects += ((key, obj))
 
         def resolve(field: BuilderField): Option[Field] =
-          resolveField(field.validKey, field.value, obj).map(
+          resolveField(field.validKey, field.value).map(
             Field(field.validKey.local.toString, _, origin)
           )
 

--- a/core/shared/src/main/scala/laika/parse/text/Characters.scala
+++ b/core/shared/src/main/scala/laika/parse/text/Characters.scala
@@ -117,7 +117,7 @@ object Characters {
   def include(chars: Seq[Char]): Characters[String] = {
     val p: Char => Boolean = chars.length match {
       case 0 =>
-        c => false
+        _ => false
       case 1 =>
         val c = chars(0)
         _ == c

--- a/core/shared/src/main/scala/laika/render/BaseFormatter.scala
+++ b/core/shared/src/main/scala/laika/render/BaseFormatter.scala
@@ -22,8 +22,6 @@ import laika.ast._
   *
   *  @param renderChild the function to use for rendering child elements
   *  @param currentElement the active element currently being rendered
-  *  @param parents the stack of parent elements of this formatter in recursive rendering,
-  *                 with the root element being the last in the list
   *  @param indentation the indentation mechanism for this formatter
   *  @param messageFilter the filter to apply before rendering runtime messages
   *
@@ -32,7 +30,6 @@ import laika.ast._
 abstract class BaseFormatter[Rep <: BaseFormatter[Rep]](
     renderChild: (Rep, Element) => String,
     currentElement: Element,
-    parents: List[Element],
     indentation: Indentation,
     messageFilter: MessageFilter
 ) { this: Rep =>

--- a/core/shared/src/main/scala/laika/render/FOFormatter.scala
+++ b/core/shared/src/main/scala/laika/render/FOFormatter.scala
@@ -47,8 +47,6 @@ case class FOFormatter(
 ) extends TagFormatter[FOFormatter](
       renderChild,
       currentElement,
-      parents,
-      pathTranslator,
       indentation,
       messageFilter
     ) with FOProperties {

--- a/core/shared/src/main/scala/laika/render/FORenderer.scala
+++ b/core/shared/src/main/scala/laika/render/FORenderer.scala
@@ -209,7 +209,7 @@ object FORenderer extends ((FOFormatter, Element) => String) {
       case unknown                => fmt.text(unknown, unknown.content)
     }
 
-    def renderChoices(name: String, choices: Seq[Choice], options: Options): String = {
+    def renderChoices(choices: Seq[Choice], options: Options): String = {
       val content = choices.flatMap { choice =>
         Paragraph(Strong(Text(choice.label))) +: choice.content
       }
@@ -217,19 +217,19 @@ object FORenderer extends ((FOFormatter, Element) => String) {
     }
 
     def renderSimpleBlock(block: Block): String = block match {
-      case e: ContentWrapper             => renderContentWrapper(e)
-      case e: Preamble                   => renderPreamble(e)
-      case e @ ListItemLabel(content, _) => fmt.listItemLabel(e, content)
-      case e: Rule                       =>
+      case e: ContentWrapper                                      => renderContentWrapper(e)
+      case e: Preamble                                            => renderPreamble(e)
+      case e @ ListItemLabel(content, _)                          => fmt.listItemLabel(e, content)
+      case e: Rule                                                =>
         fmt.rawElement(
           "fo:block",
           BlockSequence.empty.withOptions(e.options + Styles("rule-block")),
           fmt.textElement("fo:leader", e, "", "leader-pattern" -> "rule")
         )
-      case Selection(name, choices, opt) => renderChoices(name, choices, opt)
-      case e: InternalLinkTarget         => fmt.internalLinkTarget(e)
-      case e: PageBreak                  => fmt.block(e)
-      case e @ LineBlock(content, _)     => fmt.blockContainer(e, content)
+      case Selection(_, choices, opt)                             => renderChoices(choices, opt)
+      case e: InternalLinkTarget                                  => fmt.internalLinkTarget(e)
+      case e: PageBreak                                           => fmt.block(e)
+      case e @ LineBlock(content, _)                              => fmt.blockContainer(e, content)
       case TargetFormat(f, e, _) if f.intersect(formats).nonEmpty => fmt.child(e)
 
       case WithFallback(fallback) => fmt.child(fallback)

--- a/core/shared/src/main/scala/laika/render/HTMLFormatter.scala
+++ b/core/shared/src/main/scala/laika/render/HTMLFormatter.scala
@@ -45,8 +45,6 @@ case class HTMLFormatter(
 ) extends TagFormatter[HTMLFormatter](
       renderChild,
       currentElement,
-      parents,
-      pathTranslator,
       indentation,
       messageFilter
     ) {

--- a/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
@@ -22,7 +22,7 @@ import laika.ast._
   *
   * @author Jens Halm
   */
-class HTMLRenderer(fileSuffix: String, format: String)
+class HTMLRenderer(format: String)
     extends ((HTMLFormatter, Element) => String) {
 
   def apply(fmt: HTMLFormatter, element: Element): String = {
@@ -248,7 +248,7 @@ class HTMLRenderer(fileSuffix: String, format: String)
       case unknown                => fmt.textElement("span", unknown.options, unknown.content)
     }
 
-    def renderChoices(name: String, choices: Seq[Choice], options: Options): String = {
+    def renderChoices(choices: Seq[Choice], options: Options): String = {
       val content = choices.flatMap { choice =>
         Paragraph(Strong(Text(choice.label))) +: choice.content
       }
@@ -258,7 +258,7 @@ class HTMLRenderer(fileSuffix: String, format: String)
     def renderSimpleBlock(block: Block): String = block match {
       case Rule(opt)                                   => fmt.emptyElement("hr", opt)
       case InternalLinkTarget(opt)                     => fmt.textElement("a", opt, "")
-      case Selection(name, choices, opt)               => renderChoices(name, choices, opt)
+      case Selection(_, choices, opt)                  => renderChoices(choices, opt)
       case TargetFormat(f, e, _) if f.contains(format) => fmt.child(e)
 
       case WithFallback(fallback) => fmt.child(fallback)
@@ -385,4 +385,4 @@ class HTMLRenderer(fileSuffix: String, format: String)
 
 }
 
-object HTMLRenderer extends HTMLRenderer(fileSuffix = "html", format = "html")
+object HTMLRenderer extends HTMLRenderer(format = "html")

--- a/core/shared/src/main/scala/laika/render/TagFormatter.scala
+++ b/core/shared/src/main/scala/laika/render/TagFormatter.scala
@@ -17,7 +17,6 @@
 package laika.render
 
 import laika.ast._
-import laika.rewrite.nav.PathTranslator
 
 import scala.collection.mutable
 
@@ -28,9 +27,6 @@ import scala.collection.mutable
   *
   *  @param renderChild   the function to use for rendering child elements
   *  @param currentElement the active element currently being rendered
-  *  @param parents the stack of parent elements of this formatter in recursive rendering,
-  *                 with the root element being the last in the list
-  *  @param pathTranslator translates paths of input documents to the corresponding output path
   *  @param indentation   the indentation mechanism for this formatter
   *  @param messageFilter the filter to apply before rendering runtime messages
   *
@@ -39,11 +35,9 @@ import scala.collection.mutable
 abstract class TagFormatter[Rep <: BaseFormatter[Rep]](
     renderChild: (Rep, Element) => String,
     currentElement: Element,
-    parents: List[Element],
-    pathTranslator: PathTranslator,
     indentation: Indentation,
     messageFilter: MessageFilter
-) extends BaseFormatter[Rep](renderChild, currentElement, parents, indentation, messageFilter) {
+) extends BaseFormatter[Rep](renderChild, currentElement, indentation, messageFilter) {
   this: Rep =>
 
   type StyleHint

--- a/core/shared/src/main/scala/laika/render/TextFormatter.scala
+++ b/core/shared/src/main/scala/laika/render/TextFormatter.scala
@@ -37,7 +37,6 @@ case class TextFormatter(
 ) extends BaseFormatter[TextFormatter](
       renderChild,
       currentElement,
-      parents,
       indentation,
       MessageFilter.Debug
     ) {

--- a/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
@@ -27,7 +27,7 @@ import laika.config.{
   ObjectValue,
   StringValue
 }
-import laika.ast.{ Document, DocumentTree, Path, RawLink, SpanSequence, TreeCursor, TreePosition }
+import laika.ast.{ Document, DocumentTree, Path, RawLink, SpanSequence, TreeCursor }
 
 /** A resolver for context references in templates or markup documents.
   *
@@ -73,8 +73,7 @@ object ReferenceResolver {
   def forDocument(
       document: Document,
       parent: TreeCursor,
-      config: Config,
-      position: TreePosition
+      config: Config
   ): ReferenceResolver = {
 
     val rootKey = Key("cursor")

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -118,8 +118,7 @@ private[laika] trait TemplateRewriter {
         resolver = ReferenceResolver.forDocument(
           cursor.target,
           cursor.parent,
-          mergedConfig,
-          cursor.position
+          mergedConfig
         ),
         templatePath = Some(template.path)
       )

--- a/core/shared/src/main/scala/laika/rewrite/link/DocumentTargets.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/DocumentTargets.scala
@@ -188,14 +188,13 @@ case class DocumentTargets(document: Document, slugBuilder: String => String) {
     @tailrec
     def resolve(
         alias: LinkAliasResolver,
-        targetSelector: TargetIdSelector,
         visited: Set[TargetIdSelector]
     ): TargetResolver = {
       if (visited.contains(alias.targetSelector)) alias.circularReference
       else
         groupedTargets.get(alias.targetSelector) match {
           case Some(alias2: LinkAliasResolver) =>
-            resolve(alias, alias2.targetSelector, visited + alias2.sourceSelector)
+            resolve(alias, visited + alias2.sourceSelector)
           case Some(resolved)                  => alias.resolveWith(resolved.resolveReference)
           case None                            => alias
         }
@@ -207,7 +206,7 @@ case class DocumentTargets(document: Document, slugBuilder: String => String) {
     }
 
     val resolvedTargets = groupedTargets.toSeq.map {
-      case (_, alias: LinkAliasResolver) => resolve(alias, alias.targetSelector, Set())
+      case (_, alias: LinkAliasResolver) => resolve(alias, Set())
       case (_, resolved)                 => resolved
     }
 

--- a/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
@@ -23,11 +23,11 @@ import laika.config.{ Config, ConfigBuilder, LaikaKeys, Origin, TreeConfigErrors
 object SampleTrees {
 
   def twoDocuments: SampleTwoDocuments = new SampleTwoDocuments(
-    SampleRoot(0, 2, 0, SampleContent.text)
+    SampleRoot(0, 2, 0)
   )
 
   def sixDocuments: SampleSixDocuments = new SampleSixDocuments(
-    SampleRoot(2, 6, 2, SampleContent.text)
+    SampleRoot(2, 6, 2)
   )
 
 }
@@ -304,8 +304,7 @@ private[sample] object SampleRoot {
   def apply(
       numTrees: Int,
       numDocs: Int,
-      numStatic: Int,
-      defaultContent: BuilderKey => Seq[Block]
+      numStatic: Int
   ): SampleRoot =
     new SampleRoot(
       (0 to numTrees).map(num =>

--- a/core/shared/src/test/scala/laika/parse/ParserSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/ParserSpec.scala
@@ -78,7 +78,7 @@ class ParserSpec extends FunSuite {
   }
 
   test("fail if the specified Either function produces a Left") {
-    expectFailure(parser1.evalMap { res => Left("wrong") }, "abc")
+    expectFailure(parser1.evalMap { _ => Left("wrong") }, "abc")
   }
 
   test("handle errors from a failed parser") {

--- a/core/shared/src/test/scala/laika/rewrite/LinkValidatorSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/LinkValidatorSpec.scala
@@ -17,7 +17,7 @@
 package laika.rewrite
 
 import laika.ast.Path.Root
-import laika.ast.sample.{ BuilderKey, SampleTrees }
+import laika.ast.sample.SampleTrees
 import laika.ast._
 import laika.rewrite.link.{ InvalidTarget, RecoveredTarget, ValidTarget }
 import laika.rewrite.nav.TargetFormats
@@ -30,7 +30,7 @@ class LinkValidatorSpec extends FunSuite {
   private val testCursor: DocumentCursor = {
     import laika.ast.sample.SampleConfig._
 
-    def doc2(key: BuilderKey): Seq[Block] = Seq(
+    val doc2: Seq[Block] = Seq(
       Header(1, "Title").withOptions(Id("ref")),
       Paragraph("text")
     )
@@ -41,7 +41,7 @@ class LinkValidatorSpec extends FunSuite {
       .static2.config(targetFormats("html"))
       .staticDoc(Root / "static-1" / "doc-7.txt")
       .staticDoc(Root / "static-2" / "doc-8.txt", "html")
-      .docContent(doc2 _)
+      .docContent(doc2)
       .suffix("md")
       .buildCursor // TODO - buildCursor should be available on doc6
       .toOption

--- a/core/shared/src/test/scala/laika/rewrite/PathTranslatorSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/PathTranslatorSpec.scala
@@ -19,7 +19,7 @@ package laika.rewrite
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
 import laika.ast._
-import laika.ast.sample.{ BuilderKey, SampleConfig, SampleTrees }
+import laika.ast.sample.{ SampleConfig, SampleTrees }
 import laika.config.LaikaKeys
 import laika.format.HTML
 import laika.rewrite.nav.{
@@ -36,7 +36,7 @@ class PathTranslatorSpec extends FunSuite {
 
     val versions = Versions(Version("0.42.x", "0.42"), Nil)
 
-    def doc2(key: BuilderKey): Seq[Block] = Seq(
+    val doc2: Seq[Block] = Seq(
       Header(1, "Title").withOptions(Id("ref")),
       Paragraph("text")
     )
@@ -49,7 +49,7 @@ class PathTranslatorSpec extends FunSuite {
       .static1.config(SampleConfig.versioned(false))
       .staticDoc(Root / "static-1" / "doc-7.txt")
       .staticDoc(Root / "static-2" / "doc-8.txt")
-      .docContent(doc2 _)
+      .docContent(doc2)
       .suffix("md")
       .buildCursor
       .getOrElse(fail("unable to create cursor"))

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -708,11 +708,10 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   test(
     "duplicate ids - replace ambiguous references for a link alias pointing to duplicate ids with invalid spans"
   ) {
-    val target        = InternalLinkTarget(Id("ref"))
-    val targetMsg     = "Ambiguous reference: more than one link target with id 'ref' in path /doc"
-    val invalidTarget = invalidBlock(targetMsg, InternalLinkTarget())
-    val rootElem      = RootElement(p(pathRef()), LinkAlias("name", "ref"), target, target)
-    val expected      = RootElement(
+    val target    = InternalLinkTarget(Id("ref"))
+    val targetMsg = "Ambiguous reference: more than one link target with id 'ref' in path /doc"
+    val rootElem  = RootElement(p(pathRef()), LinkAlias("name", "ref"), target, target)
+    val expected  = RootElement(
       p(invalidSpan(targetMsg, "[<name>]")),
       InternalLinkTarget(Id("ref-1")),
       InternalLinkTarget(Id("ref-2"))

--- a/io/src/main/scala/laika/render/epub/HtmlNavRenderer.scala
+++ b/io/src/main/scala/laika/render/epub/HtmlNavRenderer.scala
@@ -33,9 +33,7 @@ class HtmlNavRenderer {
   def fileContent(
       title: String,
       styles: String,
-      navItems: String,
-      coverDoc: Option[String] = None,
-      titleDoc: Option[String] = None
+      navItems: String
   ): String =
     s"""<?xml version="1.0" encoding="UTF-8"?>
        |<!DOCTYPE html>
@@ -110,12 +108,7 @@ class HtmlNavRenderer {
       s"""<link rel="stylesheet" type="text/css" href="content${path.toString}" />"""
     }.mkString("\n    ")
     val renderedNavPoints = navItems(bookNav)
-    val coverDoc          =
-      result.coverDocument.map(doc => NavigationBuilder.fullPath(doc.path, forceXhtml = true))
-    val titleDoc          =
-      result.titleDocument.map(doc => NavigationBuilder.fullPath(doc.path, forceXhtml = true))
-
-    fileContent(title, styles, renderedNavPoints, coverDoc, titleDoc)
+    fileContent(title, styles, renderedNavPoints)
   }
 
 }

--- a/io/src/main/scala/laika/render/epub/XHTMLRenderer.scala
+++ b/io/src/main/scala/laika/render/epub/XHTMLRenderer.scala
@@ -23,11 +23,10 @@ import laika.render.{ HTMLFormatter, HTMLRenderer }
   *
   *  @author Jens Halm
   */
-object XHTMLRenderer extends HTMLRenderer(fileSuffix = "epub.xhtml", format = "epub") {
+object XHTMLRenderer extends HTMLRenderer(format = "epub") {
 
   def renderChoices(
       fmt: HTMLFormatter,
-      name: String,
       choices: Seq[Choice],
       options: Options
   ): String = {
@@ -63,8 +62,8 @@ object XHTMLRenderer extends HTMLRenderer(fileSuffix = "epub.xhtml", format = "e
     case Footnote(_, content, opt) =>
       fmt.indentedElement("aside", opt + Style.footnote, content, "epub:type" -> "footnote")
 
-    case Selection(name, choices, opt) =>
-      renderChoices(fmt, name, choices, opt)
+    case Selection(_, choices, opt) =>
+      renderChoices(fmt, choices, opt)
 
     case _ =>
       super.apply(fmt, element)

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -330,7 +330,6 @@ class TreeRendererSpec extends CatsEffectSuite
 
   test("tree with a single document to HTML using the default template") {
     val html     = RenderResult.html.withDefaultTemplate(
-      "Title",
       """<h1 id="title" class="title">Title</h1>
         |<p>bbb</p>""".stripMargin
     )
@@ -548,7 +547,6 @@ class TreeRendererSpec extends CatsEffectSuite
       coverDocument = Some(Document(Root / "cover", HTMLRenderer.defaultContent))
     )
     val expected = RenderResult.html.withDefaultTemplate(
-      "Title",
       """<h1 id="title" class="title">Title</h1>
         |<p>bbb</p>""".stripMargin
     )
@@ -596,12 +594,10 @@ class TreeRendererSpec extends CatsEffectSuite
     )
     val treeRoot                     = DocumentTreeRoot(input)
     val expectedDefault              = RenderResult.html.withDefaultTemplate(
-      "Title",
       """<h1 id="title" class="title">Title</h1>
         |<p>bbb</p>""".stripMargin
     )
     val expectedContentWithLink      = RenderResult.html.withDefaultTemplate(
-      "Title",
       """<h1 id="title" class="title">Title</h1>
         |<p><a href="../doc-2/">Link Text</a></p>""".stripMargin
     )
@@ -631,7 +627,6 @@ class TreeRendererSpec extends CatsEffectSuite
 
   test("tree with a single document to EPUB.XHTML using the default template") {
     val html = RenderResult.epub.withDefaultTemplate(
-      "Title",
       """<h1 id="title" class="title">Title</h1>
         |<p>bbb</p>""".stripMargin
     )

--- a/io/src/test/scala/laika/io/helper/RenderResult.scala
+++ b/io/src/test/scala/laika/io/helper/RenderResult.scala
@@ -31,14 +31,14 @@ object RenderResult {
 
   object html {
 
-    def withDefaultTemplate(title: String, content: String): String =
+    def withDefaultTemplate(content: String): String =
       buildResult(TestTheme.htmlTemplate, Seq(content))
 
   }
 
   object epub {
 
-    def withDefaultTemplate(title: String, content: String): String =
+    def withDefaultTemplate(content: String): String =
       buildResult(TestTheme.htmlTemplate, Seq(content))
 
   }

--- a/io/src/test/scala/laika/render/epub/HTMLNavRendererSpec.scala
+++ b/io/src/test/scala/laika/render/epub/HTMLNavRendererSpec.scala
@@ -88,7 +88,7 @@ class HTMLNavRendererSpec extends FunSuite {
         |      </ol>""".stripMargin
     val title    = "From TitleDoc"
     val expected =
-      renderer.fileContent(title, "", html, titleDoc = Some("content/title.epub.xhtml"))
+      renderer.fileContent(title, "", html)
     val actual   = renderer.render(DocumentPlusTitle.input, "From TitleDoc", Some(1))
     assertEquals(actual, expected)
   }
@@ -104,7 +104,7 @@ class HTMLNavRendererSpec extends FunSuite {
         |        </li>
         |      </ol>""".stripMargin
     val expected =
-      renderer.fileContent(title, "", html, coverDoc = Some("content/cover.epub.xhtml"))
+      renderer.fileContent(title, "", html)
     assertEquals(render(DocumentPlusCover.input), expected)
   }
 

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -87,7 +87,7 @@ class ServerBuilder[F[_]: Async](
     }
     val routeLogger                                             =
       if (config.isVerbose) logger.getOrElse((s: String) => Async[F].delay(println(s)))
-      else (s: String) => Async[F].unit
+      else (_: String) => Async[F].unit
     Router("/" -> renderStacktrace(new RouteBuilder[F](cache, topic, routeLogger).build)).orNotFound
   }
 


### PR DESCRIPTION
This removes all unused parameters (or replaces them with `_` in pattern matches).

Some signatures are public API, so these are breaking changes. But many of those APIs won't be public anymore anyway in M2, so it's a very minor point.

In two cases where removal is not possible I added a `@nowarn` annotation to the parameter.

Some of these improvements could be backported to 0.19, but I'd prefer to keep it simple here and aim for getting fatal warnings on for the main branch only.

There are 10 warnings left, which cannot be as easily grouped, so I might lump them together into a final PR and then try to switch on fatal warnings as a last step before a release.

Btw. I did not run a full code analysis on why the unused parameters existed in the first place and rely on the very large test suites instead. In most cases it will be historic leftovers that were not removed in a refactoring given that this is an 11-year-old code base.