### PR TITLE
fix broken boundary check in Parsers.lookAhead

### DIFF
--- a/core/shared/src/main/scala/laika/parse/combinator/Parsers.scala
+++ b/core/shared/src/main/scala/laika/parse/combinator/Parsers.scala
@@ -84,11 +84,12 @@ trait Parsers {
       s"Unable to look ahead with offset $o"
     }
     Parser { in =>
-      if (in.offset - offset < 0) Failure(errMsg(offset), in)
-      p.parse(in.consume(offset)) match {
-        case Success(s1, _) => Success(s1, in)
-        case e              => e
-      }
+      if (offset > in.remaining) Failure(errMsg(offset), in)
+      else
+        p.parse(in.consume(offset)) match {
+          case Success(s1, _) => Success(s1, in)
+          case e              => e
+        }
     }
   }
 

--- a/core/shared/src/test/scala/laika/parse/ParserSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/ParserSpec.scala
@@ -275,6 +275,10 @@ class ParserSpec extends FunSuite {
     expectFailure(TextParsers.lookAhead(2, "a"), "abcd")
   }
 
+  test("lookAhead - fails when the specified offset is too big") {
+    expectFailure(TextParsers.lookAhead(7, "a"), "abcd")
+  }
+
   object LookBehind {
     val input: SourceCursor = SourceCursor("abcd").consume(2)
   }


### PR DESCRIPTION
In one case the expanded set of compiler warnings caused a bug in the parser combinators to surface that existed since version 0.8 in 2018... 🙂 

Therefore pulling this over to 0.19.x now.