### PR TITLE
ensure pattern matches are exhaustive

### DIFF
--- a/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
+++ b/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
@@ -302,9 +302,9 @@ object OperationConfig {
 
     @tailrec
     def processBundles(
-        past: Seq[ExtensionBundle],
-        pending: Seq[ExtensionBundle]
-    ): Seq[ExtensionBundle] = pending match {
+        past: List[ExtensionBundle],
+        pending: List[ExtensionBundle]
+    ): List[ExtensionBundle] = pending match {
       case Nil          => past
       case next :: rest =>
         val newPast    = past.map(ex => next.processExtension.lift(ex).getOrElse(ex)) :+ next
@@ -312,9 +312,10 @@ object OperationConfig {
         processBundles(newPast, newPending)
     }
 
-    processBundles(Nil, sortBundles(bundles)).reverse.reduceLeftOption(_ withBase _).getOrElse(
-      ExtensionBundle.Empty
-    )
+    processBundles(Nil, sortBundles(bundles).toList)
+      .reverse
+      .reduceLeftOption(_ withBase _)
+      .getOrElse(ExtensionBundle.Empty)
   }
 
   /** A configuration instance with all the libraries default extension bundles.

--- a/core/shared/src/main/scala/laika/ast/TreePosition.scala
+++ b/core/shared/src/main/scala/laika/ast/TreePosition.scala
@@ -68,6 +68,7 @@ class TreePosition private (private val positions: Option[Seq[Int]]) extends Ord
 
   override def equals(obj: Any): Boolean = obj match {
     case tp: TreePosition => tp.positions == positions
+    case _                => false
   }
 
 }

--- a/core/shared/src/main/scala/laika/ast/paths.scala
+++ b/core/shared/src/main/scala/laika/ast/paths.scala
@@ -136,14 +136,16 @@ object SegmentedVirtualPath {
     ) { lastSegment =>
       def splitAtLast(in: String, char: Char): (String, Option[String]) =
         in.split(char).toSeq match {
-          case Seq(single)  => (single, None)
-          case init :+ last => (init.mkString(char.toString), Some(last))
+          case Seq()       => ("", None)
+          case Seq(single) => (single, None)
+          case multiple    => (multiple.init.mkString(char.toString), Some(multiple.last))
         }
 
       def splitAtFirst(in: String, char: Char): (String, Option[String]) =
         in.split(char).toSeq match {
-          case Seq(single)   => (single, None)
-          case first +: rest => (first, Some(rest.mkString(char.toString)))
+          case Seq()       => ("", None)
+          case Seq(single) => (single, None)
+          case multiple    => (multiple.head, Some(multiple.tail.mkString(char.toString)))
         }
 
       val (name, fragment)   = splitAtLast(lastSegment, '#')

--- a/core/shared/src/main/scala/laika/config/ConfigBuilder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigBuilder.scala
@@ -83,7 +83,7 @@ class ConfigBuilder(fields: Seq[Field], origin: Origin, fallback: Config = Empty
   private[laika] def asObjectValue: ObjectValue = mergeObjects(ObjectValue(fields))
 
   private def expandPath(key: Key, value: ConfigValue): Field = {
-    key.segments match {
+    key.segments.toList match {
       case name :: Nil  => Field(name, value, origin)
       case name :: rest => Field(name, ObjectValue(Seq(expandPath(Key(rest), value))), origin)
       case Nil          => Field("", value, origin)

--- a/core/shared/src/main/scala/laika/directive/std/LinkDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/LinkDirectives.scala
@@ -71,6 +71,7 @@ object LinkDirectives {
             in.split(char).toSeq match {
               case Seq(single)  => (single, None)
               case init :+ last => (init.mkString(char.toString), Some(last))
+              case _            => ("", None)
             }
 
           val (fqName, method)         = splitAtLast(linkId, '#')

--- a/core/shared/src/main/scala/laika/rst/TableParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/TableParsers.scala
@@ -209,6 +209,7 @@ object TableParsers {
   private def flattenElements(result: Any): List[TableElement] = result match {
     case x: TableElement => List(x)
     case x ~ y           => flattenElements(x) ::: flattenElements(y)
+    case _               => Nil
   }
 
   /** Parses a grid table.

--- a/core/shared/src/main/scala/laika/rst/std/StandardBlockDirectives.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardBlockDirectives.scala
@@ -307,11 +307,7 @@ class StandardBlockDirectives {
         if (hAlign.contains(style)) (pOpt + Styles(style), imgOpt)
         else (pOpt, imgOpt + Styles(style))
     }
-    val content        = img match {
-      case img: ImageResolver  => img.withOptions(imgOpt)
-      case el: SpanLink        => el.withOptions(imgOpt)
-      case lr: LinkIdReference => lr.withOptions(imgOpt)
-    }
+    val content        = img.withOptions(imgOpt)
     Paragraph(List(content), pOpt)
   }
 

--- a/core/shared/src/main/scala/laika/rst/std/StandardDirectiveParts.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardDirectiveParts.scala
@@ -82,12 +82,16 @@ object StandardDirectiveParts {
       val img      = Image(Target.parse(uri), width = actualWidth, height = actualHeight, alt = alt)
       val resolver = ImageResolver(img, GeneratedSource)
 
-      (target map {
-        case ref: SpanLink        =>
-          ref.copy(content = List(resolver.withOptions(opt)), options = alignOpt)
-        case ref: LinkIdReference =>
-          ref.copy(content = List(resolver.withOptions(opt)), options = alignOpt)
-      }).getOrElse(resolver.withOptions(alignOpt + opt))
+      target
+        .flatMap {
+          case sc: SpanContainer =>
+            // type inference not working properly here, but the cast is safe
+            Some(
+              sc.withContent(List(resolver.withOptions(opt))).withOptions(opt).asInstanceOf[Span]
+            )
+          case _                 => None
+        }
+        .getOrElse(resolver.withOptions(alignOpt + opt))
     }
   }
 

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -266,7 +266,7 @@ class ParserHookSpec extends FunSuite with ParserSetup {
   }
 
   def appendString(root: RootElement, append: String): RootElement =
-    root.copy(content = root.content.map { case Paragraph(Seq(Text(text, _)), _) =>
+    root.copy(content = root.content.collect { case Paragraph(Seq(Text(text, _)), _) =>
       Paragraph(text + append)
     })
 
@@ -277,7 +277,7 @@ class ParserHookSpec extends FunSuite with ParserSetup {
   }
 
   def processBlocks(append: String): Seq[Block] => Seq[Block] = { blocks =>
-    blocks map { case Paragraph(Seq(Text(text, _)), _) =>
+    blocks.collect { case Paragraph(Seq(Text(text, _)), _) =>
       Paragraph(text + append)
     }
   }

--- a/io/src/main/scala/laika/helium/builder/HeliumRenderOverrides.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumRenderOverrides.scala
@@ -43,12 +43,12 @@ private[helium] object HeliumRenderOverrides {
   def renderChoices(
       fmt: HTMLFormatter,
       name: String,
-      choices: Seq[Choice],
+      choices: List[Choice],
       options: Options
   ): String = {
     choices match {
       case Nil           => ""
-      case first +: rest =>
+      case first :: rest =>
         val tabs    = Tabs(
           Tab(first.name, first.label, Style.active) +: rest.map(c => Tab(c.name, c.label))
         )
@@ -113,7 +113,7 @@ private[helium] object HeliumRenderOverrides {
       renderCallout(fmt, htmlCalloutOptions(b), b.content)
     case (fmt, b: BlockSequence) if b.hasStyle("menu-content") =>
       fmt.indentedElement("nav", b.options, b.content)
-    case (fmt, Selection(name, choices, opt)) => renderChoices(fmt, name, choices, opt)
+    case (fmt, Selection(name, choices, opt)) => renderChoices(fmt, name, choices.toList, opt)
 
     case (fmt, tabs: Tabs)      => fmt.indentedElement("ul", Styles("tab-group"), tabs.tabs)
     case (fmt, tab: TabContent) =>

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -405,6 +405,7 @@ class TreeParserSpec
       val Stylesheet = """.+\.([a,b]+).css$""".r
       path.name match {
         case Stylesheet(kind) => StyleSheet(kind)
+        case _                => Ignored
       }
     }
 


### PR DESCRIPTION
These were almost exclusively detected by the 2.13 compiler, not the one for 2.12 which apparently was very lenient when List-style patterns were used for Seq types.

The issues are addressed in different ways, in some cases we simply become explicit about using List, in others we add a fallback case, use `collect` instead of `map` or avoid the match altogether by using more generic types.