### PR TITLE
avoid compiler warnings for inferring Any

### DIFF
--- a/core/shared/src/main/scala/laika/parse/css/CSSParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/css/CSSParsers.scala
@@ -125,15 +125,16 @@ object CSSParsers {
     */
   val comment: Parser[Unit] = ("/*" ~ delimitedBy("*/") ~ wsOrNl).void
 
-  /** Parses a sequence of style declarations, ignoring
-    *  any comments.
+  /** Parses a sequence of style declarations, ignoring any comments.
     */
-  val styleDeclarations: Parser[Seq[StyleDeclaration]] =
-    ((selectorGroup <~ wsOrNl ~ "{" ~ wsOrNl) ~ (comment | style).rep <~ (wsOrNl ~ "}"))
+  val styleDeclarations: Parser[Seq[StyleDeclaration]] = {
+    val styleBody: Parser[Any] = comment | style
+    ((selectorGroup <~ wsOrNl ~ "{" ~ wsOrNl) ~ styleBody.rep <~ (wsOrNl ~ "}"))
       .mapN { (selectors, stylesAndComments) =>
         val styles = stylesAndComments collect { case st: Style => (st.name, st.value) } toMap;
         selectors map (StyleDeclaration(_, styles))
       }
+  }
 
   /** Parses an entire set of style declarations.
     *  This is the top level parser of this trait.

--- a/core/shared/src/main/scala/laika/parse/hocon/HoconParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/HoconParsers.scala
@@ -26,6 +26,7 @@ import laika.parse.builders._
 import laika.parse.implicits._
 import laika.parse.{ Failure, Message, Parser, SourceCursor, Success }
 
+import scala.annotation.nowarn
 import scala.util.Try
 
 /** The parser implementation for the HOCON format.
@@ -299,6 +300,7 @@ object HoconParsers {
   /** Parses the rest of the current line if it contains either just whitespace or a comment. */
   val wsOrComment: Parser[Any] = wsOrNl ~ (comment | wsOrNl.min(1)).rep
 
+  @nowarn
   private val separator: Parser[Unit] = ((oneOf(',') | eol | comment) ~ wsOrComment).void
 
   private val trailingComma: Parser[Any] = opt("," ~ wsOrComment)

--- a/core/shared/src/main/scala/laika/render/ASTRenderer.scala
+++ b/core/shared/src/main/scala/laika/render/ASTRenderer.scala
@@ -112,7 +112,7 @@ object ASTRenderer extends ((TextFormatter, Element) => String) {
       case DefinitionListItem(term, defn, _) =>
         lists("Item", (term, "Term - Spans: "), (defn, "Definition - Blocks: "))
       case SectionNumber(pos, opt)           =>
-        "SectionNumber" + attributes(Seq(pos.mkString("."), opt).iterator)
+        "SectionNumber" + attributes(Seq[Object](pos.mkString("."), opt).iterator)
       case bc: BlockContainer                => elementContainerDesc(bc, "Blocks")
       case sc: SpanContainer                 => elementContainerDesc(sc, "Spans")
       case tsc: TemplateSpanContainer        => elementContainerDesc(tsc, "TemplateSpans")

--- a/core/shared/src/main/scala/laika/rst/ExplicitBlockParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/ExplicitBlockParsers.scala
@@ -141,7 +141,7 @@ object ExplicitBlockParsers {
   }
 
   private[rst] lazy val linkDefinitionBody: Parser[String] = {
-    val notEmpty = not(blankLine) | lookAhead(restOfLine ~ ws.min(1) ~ not(blankLine))
+    val notEmpty = not(blankLine) | lookAhead(restOfLine ~ ws.min(1) ~ not(blankLine)).void
 
     (notEmpty ~> indentedBlock()).map {
       _.lines.iterator.map(_.input.trim).mkString

--- a/core/shared/src/main/scala/laika/rst/TableParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/TableParsers.scala
@@ -354,12 +354,12 @@ object TableParsers {
 
         val tableBuilder = new TableBuilder(cols map { col => col._1 + col._2 }, recParsers)
 
-        def addBlankLines(acc: ListBuffer[List[TableElement]], parentSource: SourceCursor) =
+        def addBlankLines(acc: ListBuffer[List[TableElement]], parentSource: SourceCursor): Unit =
           acc += cols.flatMap { case (cell, sep) =>
             List(CellElement(LineSource(" " * cell, parentSource)), CellSeparator(" " * sep))
           }
 
-        def addRowSeparators(acc: ListBuffer[List[TableElement]]) =
+        def addRowSeparators(acc: ListBuffer[List[TableElement]]): Unit =
           acc += (cols flatMap { _ => List(RowSeparator, Intersection) })
 
         /* in contrast to the grid table, some rows need to be processed in context,

--- a/core/shared/src/test/scala/laika/rst/std/StandardBlockDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/std/StandardBlockDirectivesSpec.scala
@@ -653,21 +653,25 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
   }
 
   test("meta - creates config entries in the document instance") {
-    val input    = """.. meta::
+    val input = """.. meta::
                   | :key1: val1
                   | :key2: val2""".stripMargin
+
     val expected =
       ObjectValue(Seq(Field("key1", StringValue("val1")), Field("key2", StringValue("val2"))))
-    val res      = docParser.parse(input).flatMap(_.config.get[ConfigValue]("meta"))
+
+    val res: Either[Any, ConfigValue] =
+      docParser.parse(input).flatMap(_.config.get[ConfigValue]("meta"))
     assertEquals(res, Right(expected))
   }
 
   test("sectnum - creates config entries in the document instance") {
-    val input    = """.. sectnum::
+    val input = """.. sectnum::
                   | :depth: 3
                   | :start: 1
                   | :prefix: (
                   | :suffix: )""".stripMargin
+
     val expected = ObjectValue(
       Seq(
         Field("depth", StringValue("3")),
@@ -676,7 +680,9 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
         Field("suffix", StringValue(")"))
       )
     )
-    val res = docParser.parse(input).flatMap(_.config.get[ConfigValue](LaikaKeys.autonumbering))
+
+    val res: Either[Any, ConfigValue] =
+      docParser.parse(input).flatMap(_.config.get[ConfigValue](LaikaKeys.autonumbering))
     assertEquals(res, Right(expected))
   }
 


### PR DESCRIPTION
For the use of Laika's parser combinators this is quite common, as parsers are often combined in a way where only the final top-level parser invokes `.void` to ignore the result.

This PR introduces explicit type annotations for `Any` or `Object` in those cases where we genuinely want the type.

For one case I chose to use `@nowarn` on a single line to keep it simple and concise.

No complaints from mima, therefore adding this to 0.19.