### PR TITLE
use explicit parentheses for passing tuples as sole argument

### DIFF
--- a/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
@@ -291,10 +291,12 @@ class HTMLRenderer(fileSuffix: String, format: String)
 
       case Image(target, width, height, alt, title, opt) =>
         def sizeAttr(size: Option[Length], styleName: String): (Option[String], Option[String]) =
-          size map {
-            case Length(amount, LengthUnit.px) => (Some(amount.toInt.toString), None)
-            case s: Length                     => (None, Some(s"$styleName:${s.displayValue}"))
-          } getOrElse (None, None)
+          size
+            .map {
+              case Length(amount, LengthUnit.px) => (Some(amount.toInt.toString), None)
+              case s: Length                     => (None, Some(s"$styleName:${s.displayValue}"))
+            }
+            .getOrElse((None, None))
         val (widthAttr, wStyle)  = sizeAttr(width, "width")
         val (heightAttr, hStyle) = sizeAttr(height, "height")
         val styleAttr            = (wStyle ++ hStyle).reduceLeftOption((a, b) => s"$a;$b")

--- a/core/shared/src/main/scala/laika/rst/std/StandardBlockDirectives.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardBlockDirectives.scala
@@ -205,7 +205,7 @@ class StandardBlockDirectives {
     DocumentFragment("footer", BlockSequence(blocks))
   }
 
-  private def tuple(name: String) = optField(name, Right(name, _))
+  private def tuple(name: String) = optField(name, s => Right((name, s)))
 
   lazy val sectnum: DirectivePartBuilder[Block] =
     (tuple("depth") ~ tuple("start") ~ tuple("prefix") ~ tuple("suffix")).map {

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -268,7 +268,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
         |@:@
         |
         |Some *markup* here.""".stripMargin
-    val inputsWithExtraDoc = inputs :+ (Root / "landing-page.md", content)
+    val inputsWithExtraDoc = inputs :+ ((Root / "landing-page.md", content))
     transformAndExtract(
       inputsWithExtraDoc,
       helium,


### PR DESCRIPTION
Trivial PR addressing compiler warnings. The final one that is binary-compatible and can go to 0.19