### PR TITLE
remove some constraints on F[_]

### DIFF
--- a/io/src/main/scala/laika/factory/BinaryPostProcessor.scala
+++ b/io/src/main/scala/laika/factory/BinaryPostProcessor.scala
@@ -28,7 +28,7 @@ import laika.theme.Theme
   *
   *  @author Jens Halm
   */
-abstract class BinaryPostProcessor[F[_]: Async] {
+abstract class BinaryPostProcessor[F[_]] {
 
   /** Processes the interim render result and writes it to the specified final output.
     *

--- a/io/src/main/scala/laika/io/api/BinaryTreeRenderer.scala
+++ b/io/src/main/scala/laika/io/api/BinaryTreeRenderer.scala
@@ -66,7 +66,7 @@ object BinaryTreeRenderer {
     *                      result, the implementing type may vary from format to format
     * @param description short string describing the output format for tooling and logging
     */
-  case class BinaryRenderer[F[_]: Async](
+  case class BinaryRenderer[F[_]](
       interimRenderer: Renderer,
       prepareTree: DocumentTreeRoot => Either[Throwable, DocumentTreeRoot],
       postProcessor: BinaryPostProcessor[F],

--- a/io/src/main/scala/laika/io/model/BinaryInput.scala
+++ b/io/src/main/scala/laika/io/model/BinaryInput.scala
@@ -36,7 +36,7 @@ import scala.reflect.ClassTag
   *                   if necessary (e.g. to only include it in HTML output, but omit it from PDF or EPUB)
   * @param sourceFile The source file from the file system, empty if this does not represent a file system resource
   */
-case class BinaryInput[F[_]: Sync](
+case class BinaryInput[F[_]](
     input: fs2.Stream[F, Byte],
     path: Path,
     formats: TargetFormats = TargetFormats.All,
@@ -45,7 +45,7 @@ case class BinaryInput[F[_]: Sync](
 
 object BinaryInput {
 
-  def fromString[F[_]: Sync](
+  def fromString[F[_]](
       input: String,
       mountPoint: Path = Root / "doc",
       targetFormats: TargetFormats = TargetFormats.All

--- a/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
+++ b/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
@@ -283,7 +283,7 @@ class InputTreeBuilder[F[_]](
     */
   def addString(input: String, mountPoint: Path): InputTreeBuilder[F] =
     addStep(mountPoint) {
-      case DocumentType.Static(formats) => _ + BinaryInput.fromString(input, mountPoint, formats)
+      case DocumentType.Static(formats) => _ + BinaryInput.fromString[F](input, mountPoint, formats)
       case docType: TextDocumentType    => _ + TextInput.fromString[F](input, mountPoint, docType)
     }
 

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -306,7 +306,7 @@ object RendererRuntime {
     } yield res
   }
 
-  private def getDefaultTemplate[F[_]: Sync](
+  private def getDefaultTemplate[F[_]](
       themeInputs: InputTree[F],
       suffix: String
   ): TemplateRoot =

--- a/io/src/main/scala/laika/io/runtime/TransformerRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/TransformerRuntime.scala
@@ -16,7 +16,6 @@
 
 package laika.io.runtime
 
-import cats.Monad
 import cats.effect.Async
 import cats.implicits._
 import laika.bundle.ExtensionBundle
@@ -47,7 +46,7 @@ import laika.theme.Theme.TreeProcessor
   */
 object TransformerRuntime {
 
-  private def themeWithoutInputs[F[_]: Monad](theme: Theme[F]): Theme[F] = new Theme[F] {
+  private def themeWithoutInputs[F[_]](theme: Theme[F]): Theme[F] = new Theme[F] {
     def descriptor: ThemeDescriptor               = theme.descriptor
     def inputs: InputTree[F]                      = InputTree.empty
     def extensions: Seq[ExtensionBundle]          = theme.extensions

--- a/io/src/main/scala/laika/render/epub/ContainerWriter.scala
+++ b/io/src/main/scala/laika/render/epub/ContainerWriter.scala
@@ -48,7 +48,7 @@ class ContainerWriter {
     *  @param result the result of the render operation as a tree
     *  @return a list of all documents that need to be written to the EPUB container.
     */
-  def collectInputs[F[_]: Sync](
+  def collectInputs[F[_]](
       result: RenderedTreeRoot[F],
       config: EPUB.BookConfig
   ): Seq[BinaryInput[F]] = {

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -35,6 +35,7 @@ import laika.rewrite.nav.{ Selections, TargetFormats }
 import laika.theme.Theme
 
 import java.io.ByteArrayOutputStream
+import scala.annotation.nowarn
 
 private[preview] class SiteTransformer[F[_]: Async](
     val parser: TreeParser[F],
@@ -180,7 +181,7 @@ private[preview] object SiteTransformer {
 
 }
 
-class SiteResults[F[_]: Async](map: Map[Path, SiteResult[F]]) {
+class SiteResults[F[_]](map: Map[Path, SiteResult[F]]) {
 
   def get(path: Path): Option[SiteResult[F]] = map.get(path)
 
@@ -188,6 +189,8 @@ class SiteResults[F[_]: Async](map: Map[Path, SiteResult[F]]) {
 
 }
 
-sealed abstract class SiteResult[F[_]: Async]                      extends Product with Serializable
+@nowarn
+sealed abstract class SiteResult[F[_]: Async] extends Product with Serializable
+
 case class RenderedResult[F[_]: Async](content: String)            extends SiteResult[F]
 case class StaticResult[F[_]: Async](content: fs2.Stream[F, Byte]) extends SiteResult[F]


### PR DESCRIPTION
These were also only detected by the 2.13 compiler.

There is one case which I was unable to solve: https://github.com/typelevel/Laika/compare/fix/remove-constraints?expand=1#diff-71877c3c6b9e7a1eac86020ffa30be30c87c88caa6ad040c17b04b2a27c14ccfR192
2.13 complains about an unused constraint, but removing it causes 3.3 to complain about two Fs not matching higher up. Adding a `@nowarn` for now until a better solution surfaces.