### PR TITLE
seal several traits in AST + parsers for exhaustive pattern matches

### DIFF
--- a/core/shared/src/main/scala/laika/ast/Table.scala
+++ b/core/shared/src/main/scala/laika/ast/Table.scala
@@ -49,11 +49,11 @@ object Table {
 
 /** A table element, like a row, cell or column.
   */
-trait TableElement extends Element { type Self <: TableElement }
+sealed trait TableElement extends Element { type Self <: TableElement }
 
 /** A container of table elements.
   */
-trait TableContainer extends TableElement with ElementContainer[TableElement] {
+sealed trait TableContainer extends TableElement with ElementContainer[TableElement] {
   type Self <: TableContainer
 }
 

--- a/core/shared/src/main/scala/laika/ast/Target.scala
+++ b/core/shared/src/main/scala/laika/ast/Target.scala
@@ -62,7 +62,7 @@ case class ExternalTarget(url: String) extends Target {
 
 /** Represents a target within the virtual tree that can be referred to by links.
   */
-trait InternalTarget extends Target {
+sealed trait InternalTarget extends Target {
   def relativeTo(refPath: Path): ResolvedInternalTarget
 
   /** The underlying path reference, which is either a relative or absolute path,

--- a/core/shared/src/main/scala/laika/ast/base.scala
+++ b/core/shared/src/main/scala/laika/ast/base.scala
@@ -167,7 +167,7 @@ trait Definition extends Block { type Self <: Definition }
   * In contrast to the reference type, it is only mixed in by elements representing resolved links
   * that can be dealt with by renderers.
   */
-trait Link extends Span { type Self <: Link }
+sealed trait Link extends Span { type Self <: Link }
 
 /** A local link that always points to a target within the same document.
   */

--- a/core/shared/src/main/scala/laika/ast/links.scala
+++ b/core/shared/src/main/scala/laika/ast/links.scala
@@ -85,7 +85,7 @@ case class Footnote(label: String, content: Seq[Block], options: Options = NoOpt
 
 /** Base type for all types of footnote labels.
   */
-abstract class FootnoteLabel
+sealed trait FootnoteLabel
 
 /** Label with automatic numbering.
   */

--- a/core/shared/src/main/scala/laika/parse/markup/BlockParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/BlockParsers.scala
@@ -121,10 +121,11 @@ trait BlockParsers {
 
     import scala.math._
 
-    abstract class Line                                                      extends Product {
+    sealed trait Line extends Product {
       def curIndent: Int
       def source: LineSource
     }
+
     case class BlankLine(curIndent: Int, source: LineSource)                 extends Line
     case class IndentedLine(curIndent: Int, indent: Int, source: LineSource) extends Line
     case class FirstLine(source: LineSource) extends Line { val curIndent: Int = Int.MaxValue }

--- a/core/shared/src/main/scala/laika/parse/text/DelimitedText.scala
+++ b/core/shared/src/main/scala/laika/parse/text/DelimitedText.scala
@@ -201,7 +201,7 @@ private[laika] object TextDelimiter {
   *
   * @tparam T the type of result produced by this delimiter
   */
-private[laika] trait DelimiterResult[+T]
+private[laika] sealed trait DelimiterResult[+T]
 
 private[laika] object DelimiterResult {
 


### PR DESCRIPTION
The root traits for the AST (e.g. `Span` and `Block`) are left unsealed on purpose so that the model can be extended with custom user types. But there are a few more concrete types which should better become sealed to enable better compiler checks.

Affected public API where traits in `laika.ast` are now sealed: `TableElement`, `TableContainer`, `InternalTarget`, `Link`, `FootnoteLabel`.