### PR TITLE
Fix remaining warnings and enable fatal warnings on CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,11 @@ def disableMissingInterpolatorWarning(options: Seq[String]): Seq[String] =
     if (opt.startsWith("-Xlint")) opt + ",-missing-interpolator" else opt
   }
 
+def disableUnusedWarningsForMdoc(options: Seq[String]): Seq[String] =
+  options.map { opt =>
+    if (opt.startsWith("-Ywarn-unused")) opt + ",-locals,-explicits" else opt
+  }
+
 val munit = "org.scalameta" %% "munit" % versions.munit % "test"
 val jTidy = "net.sf.jtidy"   % "jtidy" % versions.jTidy % "test"
 
@@ -92,7 +97,8 @@ lazy val docs = project.in(file("docs"))
     mdocVariables             := Map(
       "LAIKA_VERSION" -> "0.19.2"
     ),
-    mdocExtraArguments        := Seq("--no-link-hygiene")
+    mdocExtraArguments        := Seq("--no-link-hygiene"),
+    scalacOptions ~= disableUnusedWarningsForMdoc
   )
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ inThisBuild(
     crossScalaVersions := Seq(versions.scala2_12, versions.scala2_13, versions.scala3),
     scalaVersion       := versions.scala2_12,
     developers      := List(Developer("jenshalm", "Jens Halm", "", new URL("http://planet42.org"))),
-    tlFatalWarnings := false,
     tlCiHeaderCheck := false,
     tlCiDependencyGraphJob := false,
     githubWorkflowJavaVersions += JavaSpec.temurin("17"),

--- a/core/shared/src/main/scala/laika/ast/base.scala
+++ b/core/shared/src/main/scala/laika/ast/base.scala
@@ -201,3 +201,7 @@ trait GlobalLink extends Link {
   *  of `LinkTarget` implementations.
   */
 trait LinkTarget extends Block { type Self <: LinkTarget }
+
+/** A wrapper for two result values.
+  */
+case class ~[+A, +B](_1: A, _2: B)

--- a/core/shared/src/main/scala/laika/ast/package.scala
+++ b/core/shared/src/main/scala/laika/ast/package.scala
@@ -38,8 +38,4 @@ package object ast {
     */
   type RenderFunction = PartialFunction[Element, Unit]
 
-  /** A wrapper for two result values.
-    */
-  case class ~[+A, +B](_1: A, _2: B)
-
 }

--- a/core/shared/src/main/scala/laika/factory/RenderFormat.scala
+++ b/core/shared/src/main/scala/laika/factory/RenderFormat.scala
@@ -82,7 +82,8 @@ trait RenderFormat[FMT] extends Format {
     */
   def formatterFactory: RenderContext[FMT] => FMT
 
-  type CustomRenderFunction[FMT] = PartialFunction[(FMT, Element), String] // TODO - move/promote
+  type CustomRenderFunction[FORMAT] =
+    PartialFunction[(FORMAT, Element), String] // TODO - move/promote
 
   case class Overrides(value: CustomRenderFunction[FMT] = PartialFunction.empty)
       extends RenderOverrides {

--- a/core/shared/src/main/scala/laika/markdown/BlockParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/BlockParsers.scala
@@ -110,9 +110,9 @@ object BlockParsers {
 
     def decoratedHeaderLevel(decoration: String) = if (decoration.head == '=') 1 else 2
 
-    /**  Merges the specified list of lines into a single string,
-      *  while looking for lines ending with double spaces which (sadly) stand for a hard line break in Markdown.
-      */
+    /*  Merges the specified list of lines into a single string,
+     *  while looking for lines ending with double spaces which (sadly) stand for a hard line break in Markdown.
+     */
     def processLineBreaks(line: LineSource): LineSource =
       /* add a special sequence for hard line breaks so that the
        * inline parser does not have to stop at each space character */

--- a/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
+++ b/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
@@ -28,9 +28,9 @@ import laika.rewrite.nav.PathTranslator
   */
 object BundleProvider {
 
-  class TestExtensionBundle(override val origin: BundleOrigin = BundleOrigin.User)
-      extends ExtensionBundle {
-    val description: String = "Extensions under test"
+  class TestExtensionBundle(originP: BundleOrigin = BundleOrigin.User) extends ExtensionBundle {
+    override def origin: BundleOrigin = originP
+    val description: String           = "Extensions under test"
   }
 
   def forMarkupParser(

--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -306,7 +306,7 @@ val (transformer: TreeTransformer[IO], releaseF: IO[Unit]) = alloc.unsafeRunSync
 You would usually run the above when initializing your web application. 
 The obtained transformer can then be used in your controllers and each transformation would produce a new `Future`:
 
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 val futureResult: Future[RenderedTreeRoot[IO]] = transformer
   .fromDirectory("docs")
   .toDirectory("target")
@@ -334,8 +334,8 @@ The effectful transformer is the most powerful variant and also the one that is 
 It expands the functionality beyond just processing markup input to also parsing templates and configuration files
 as well as copying static files over to the target directory.
 
-```scala mdoc:nest:silent
-val transformer = Transformer
+```scala mdoc:silent
+val transformerIO = Transformer
   .from(Markdown)
   .to(HTML)
   .using(GitHubFlavor)
@@ -346,7 +346,7 @@ val transformer = Transformer
 The above transformer can then be used to process a directory of markup, template and configuration files:
 
 ```scala mdoc:silent
-val res: IO[RenderedTreeRoot[IO]] = transformer.use {
+val res: IO[RenderedTreeRoot[IO]] = transformerIO.use {
   _.fromDirectory("src")
    .toDirectory("target")
    .transform
@@ -389,7 +389,7 @@ val directories = Seq(
   FilePath.parse("markup"),
   FilePath.parse("theme")
 )
-val mergedRes: IO[RenderedTreeRoot[IO]] = transformer.use {
+val mergedRes: IO[RenderedTreeRoot[IO]] = transformerIO.use {
   _.fromDirectories(directories)
    .toDirectory("target")
    .transform
@@ -454,7 +454,7 @@ For the complete API see @:api(laika.io.model.InputTreeBuilder).
 The customized input tree can then be passed to the transformer:
 
 ```scala mdoc:compile-only
-val composedRes: IO[RenderedTreeRoot[IO]] = transformer.use {
+val composedRes: IO[RenderedTreeRoot[IO]] = transformerIO.use {
   _.fromInput(inputs)
    .toDirectory("target")
    .transform
@@ -660,7 +660,7 @@ This includes auto-refreshing whenever changes to any input document are detecte
 It is the basis of the `laikaPreview` task of the sbt plugin, 
 but can alternatively be launched via the library API:
 
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 import laika.preview.ServerBuilder
 
 val parser = MarkupParser
@@ -682,6 +682,7 @@ Open `localhost:4242` for the landing page of your site.
 You can override the defaults by passing a `ServerConfig` instance explicitly:
 
 ```scala mdoc:silent
+import laika.preview.ServerBuilder
 import laika.preview.ServerConfig
 import com.comcast.ip4s._
 import scala.concurrent.duration.DurationInt

--- a/docs/src/03-preparing-content/01-directory-structure.md
+++ b/docs/src/03-preparing-content/01-directory-structure.md
@@ -41,8 +41,6 @@ Apart from standard markup syntax, markup files in Laika can also contain the fo
 
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 
 ### Title Documents

--- a/docs/src/03-preparing-content/02-navigation.md
+++ b/docs/src/03-preparing-content/02-navigation.md
@@ -4,8 +4,6 @@ Navigation
 
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 
 Laika's functionality for navigation can roughly be divided into four categories:
@@ -72,7 +70,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:silent
+```scala mdoc:compile-only
 import laika.api._
 import laika.ast.Path.Root
 import laika.format._
@@ -143,7 +141,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest:silent
+```scala mdoc:silent
 import laika.api._
 import laika.ast.ExternalTarget
 import laika.format._
@@ -262,7 +260,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -296,7 +294,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -343,7 +341,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -384,7 +382,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -607,7 +605,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -657,7 +655,7 @@ laikaExtensions += PrettyURLs
 ```
 
 @:choice(library)
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 import laika.api._
 import laika.format._
 import laika.rewrite.nav.PrettyURLs

--- a/docs/src/03-preparing-content/05-syntax-highlighting.md
+++ b/docs/src/03-preparing-content/05-syntax-highlighting.md
@@ -15,8 +15,6 @@ All code samples shown are highlighted by Laika's own syntax support.
 
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
   
 Configuration
@@ -151,9 +149,6 @@ as a starting point.
 Once you have implemented and tested your highlighter you can add it to the built-in ones like this:
 
 ```scala mdoc:compile-only
-import laika.api._
-import laika.format._
-import laika.markdown.github.GitHubFlavor
 import laika.parse.code.{SyntaxHighlighting, CodeSpanParser }
 import laika.bundle.SyntaxHighlighter
 import cats.data.NonEmptyList

--- a/docs/src/04-customizing-laika/05-ast-rewriting.md
+++ b/docs/src/04-customizing-laika/05-ast-rewriting.md
@@ -54,8 +54,6 @@ into a `Strong` node while processing everything else with default rules:
 
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 
 ```scala mdoc:compile-only
@@ -104,7 +102,7 @@ Once again we are turning all `Emphasized` nodes in the text to `Strong` nodes f
 ```scala mdoc:compile-only
 import laika.ast._
 
-val doc: Document = ??? // obtained through the Parser API
+def doc: Document = ??? // obtained through the Parser API
 
 val newDoc = doc.rewrite(RewriteRules.forSpans {
   case Emphasized(content, opts) => Replace(Strong(content, opts))
@@ -117,7 +115,7 @@ To accomplish this you need to nest a rewrite operation inside another one:
 ```scala mdoc:compile-only
 import laika.ast._
 
-val doc: Document = ??? // obtained through the Parser API
+def doc: Document = ??? // obtained through the Parser API
 
 val newDoc = doc.rewrite(RewriteRules.forBlocks {
   case h: Header => Replace(h.rewriteSpans {

--- a/docs/src/04-customizing-laika/06-overriding-renderers.md
+++ b/docs/src/04-customizing-laika/06-overriding-renderers.md
@@ -81,8 +81,6 @@ In case you want to combine it with other extensions, a render override can also
 
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 
 ```scala mdoc:compile-only
@@ -115,7 +113,7 @@ val transformer = Transformer
 **Using the Renderer API**
 
 ```scala mdoc:compile-only
-val doc: Document = ???
+def doc: Document = ???
 
 val renderer = Renderer
   .of(HTML)

--- a/docs/src/05-extending-laika/01-overview.md
+++ b/docs/src/05-extending-laika/01-overview.md
@@ -53,7 +53,6 @@ so that you only need to override the ones you intend to use.
 
 ```scala mdoc
 import laika.bundle.ExtensionBundle
-import laika.ast.{ DocumentType, Path }
 
 object MyExtensions extends ExtensionBundle {
 
@@ -70,8 +69,6 @@ Such a bundle can then be passed to the transformer:
 @:choice(sbt)
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 
 ```scala mdoc:compile-only

--- a/docs/src/05-extending-laika/02-creating-themes.md
+++ b/docs/src/05-extending-laika/02-creating-themes.md
@@ -282,7 +282,7 @@ import cats.effect.IO
 import laika.ast.Path.Root
 import laika.io.model.InputTreeBuilder
 
-val builder: InputTreeBuilder[IO] = ???
+def builder: InputTreeBuilder[IO] = ???
 val resourcePath = "my-theme/css/theme.css"
 val vars: String = "<... generated-CSS ...>"
 builder
@@ -314,7 +314,7 @@ import laika.config.ConfigBuilder
 import laika.theme.ThemeBuilder
 import laika.theme.config.FontDefinition
 
-val fonts: Seq[FontDefinition] = ???
+def fonts: Seq[FontDefinition] = ???
 val baseConfig = ConfigBuilder.empty
   .withValue("laika.epub.fonts", fonts)
   .withValue("laika.pdf.fonts", fonts)

--- a/docs/src/05-extending-laika/03-implementing-directives.md
+++ b/docs/src/05-extending-laika/03-implementing-directives.md
@@ -217,8 +217,6 @@ Finally we need to register our registry together with any built-in extensions y
 @:choice(sbt)
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 
 ```scala mdoc:compile-only

--- a/docs/src/05-extending-laika/04-writing-parser-extensions.md
+++ b/docs/src/05-extending-laika/04-writing-parser-extensions.md
@@ -132,8 +132,6 @@ Finally you can register your extension together with any built-in extensions yo
 @:choice(sbt)
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 
 ```scala mdoc:compile-only
@@ -500,7 +498,7 @@ Precedence
 Both, block and span parsers can specify a precedence:
 
 ```scala mdoc:silent
-BlockParser.recursive { implicit recParsers =>
+BlockParser.recursive { recParsers =>
   ??? // parser impl here
 }.withLowPrecedence
 ```

--- a/docs/src/05-extending-laika/06-adding-syntax-highlighters.md
+++ b/docs/src/05-extending-laika/06-adding-syntax-highlighters.md
@@ -257,7 +257,6 @@ which is quite straightforward, but not included in the reusable builders since 
 
 ```scala mdoc:compile-only
 import laika.parse.builders._
-import laika.parse.implicits._
 import laika.parse.code.CodeCategory
 
 val backtickId: CodeSpanParser = CodeSpanParser(CodeCategory.Identifier) {
@@ -397,8 +396,6 @@ Finally, you can register your extension together with any built-in extensions y
 @:choice(sbt)
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 
 ```scala mdoc:compile-only

--- a/docs/src/06-sub-modules/02-laikas-parser-combinators.md
+++ b/docs/src/06-sub-modules/02-laikas-parser-combinators.md
@@ -171,7 +171,7 @@ In many cases we are only interested in one of the results of a concatenation,
 when some of the results are known for example.
 The `~>` combinator ignores the left result, `<~` ignores the right one: 
 
-```scala mdoc:nest:silent
+```scala mdoc:compile-only
 val p = "<" ~> someOf(range('a', 'z')) <~ ">"
 ```
 
@@ -382,7 +382,7 @@ import laika.ast.Span
 import laika.parse.markup.InlineParsers
 import laika.parse.text.PrefixedParser
 
-val nestedSpanParsers: Seq[PrefixedParser[Span]] = ???
+def nestedSpanParsers: Seq[PrefixedParser[Span]] = ???
 val linkSpanParser = delimitedBy("]").failOn('\n')
 
 "[" ~> InlineParsers.spans(linkSpanParser).embedAll(nestedSpanParsers)

--- a/docs/src/06-sub-modules/03-laikas-hocon-api.md
+++ b/docs/src/06-sub-modules/03-laikas-hocon-api.md
@@ -103,7 +103,7 @@ You have to provide the key you want to read and the type you expect:
 ```scala mdoc:compile-only
 import laika.config.Config
 
-val config: Config = ???
+def config: Config = ???
 
 val version = config.get[String]("project.version")
 ```
@@ -266,7 +266,7 @@ You can alternatively create your own encoder as shown above.
 If you have a fallback instance, you can pass it to the constructor:
 
 ```scala mdoc:compile-only
-val parentConfig: Config = ???
+def parentConfig: Config = ???
 
 val config = ConfigBuilder.withFallback(parentConfig)
   .withValue("laika.epub.coverImage", "/images/epub-cover.jpg")
@@ -282,7 +282,7 @@ where you build an entire tree programmatically, you also have to provide a corr
 ```scala mdoc:compile-only
 import laika.ast.Document
 
-val doc: Document = ???
+def doc: Document = ???
 val docOrigin: Origin = Origin(Origin.DocumentScope, doc.path) 
 
 val config = ConfigBuilder.withOrigin(docOrigin)
@@ -301,7 +301,7 @@ This is essential for resolving relative paths defined in that configuration cor
 The `ConfigParser` has a very simple API:
 
 ```scala mdoc:compile-only
-val hoconInput: String = ???
+def hoconInput: String = ???
 
 val result: Either[ConfigError, Config] = ConfigParser
   .parse(hoconInput)
@@ -316,8 +316,8 @@ The `resolve` step then finally creates a `Config` instance, resolving and valid
 If you have a fallback instance, you can pass it via `resolve`:
 
 ```scala mdoc:compile-only
-val hoconInput: String = ???
-val parentConfig: Config = ???
+def hoconInput: String = ???
+def parentConfig: Config = ???
 
 val result: Either[ConfigError, Config] = ConfigParser
   .parse(hoconInput)
@@ -332,8 +332,8 @@ where you build an entire tree programmatically, you also have to provide a corr
 ```scala mdoc:compile-only
 import laika.ast.Document
 
-val hoconInput: String = ???
-val doc: Document = ???
+def hoconInput: String = ???
+def doc: Document = ???
 val docOrigin: Origin = Origin(Origin.DocumentScope, doc.path) 
 
 val result: Either[ConfigError, Document] = ConfigParser

--- a/docs/src/07-reference/01-standard-directives.md
+++ b/docs/src/07-reference/01-standard-directives.md
@@ -214,8 +214,6 @@ The available icon set can be registered as part of the transformer setup:
 @:choice(sbt)
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 ```scala mdoc:compile-only
 import laika.ast._
@@ -383,7 +381,6 @@ laikaConfig := LaikaConfig.defaults
 @:choice(library)
 
 ```scala mdoc:compile-only
-import laika.ast._
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor

--- a/docs/src/07-reference/02-substitution-variables.md
+++ b/docs/src/07-reference/02-substitution-variables.md
@@ -130,8 +130,6 @@ You can add arbitrary configuration values when building a `Parser`, `Renderer` 
 @:choice(sbt)
 ```scala mdoc:invisible
 import laika.sbt.LaikaPlugin.autoImport._
-import sbt.Keys._
-import sbt._
 ```
 ```scala mdoc:compile-only
 laikaConfig := LaikaConfig.defaults
@@ -206,7 +204,7 @@ all have a `config` property that exposes those values:
 import laika.ast.Document
 import laika.config.ConfigError
 
-val doc: Document = ???
+def doc: Document = ???
 val version: Either[ConfigError, String] = 
   doc.config.get[String]("project.version")
 ```

--- a/docs/src/07-reference/07-migration-guide.md
+++ b/docs/src/07-reference/07-migration-guide.md
@@ -90,7 +90,7 @@ import cats.effect.{ IO, Resource }
 import laika.io.api.TreeTransformer
 
 // build your transformer like before
-val transformer: Resource[IO, TreeTransformer[IO]] = ???
+def transformer: Resource[IO, TreeTransformer[IO]] = ???
 
 transformer.use {
   _.fromDirectory("docs")

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -224,9 +224,9 @@ object BalancedGroups {
     val loSize   = items.size / size
     val hiSize   = loSize + 1
     val (hi, lo) = items.splitAt(mod * hiSize)
-    val hiBatch  = if (mod > 0) hi.grouped(hiSize) else Vector()
-    val loBatch  = if (loSize > 0) lo.grouped(loSize) else Vector()
-    hiBatch.toVector ++ loBatch.toVector
+    val hiBatch  = if (mod > 0) hi.grouped(hiSize).toVector else Vector()
+    val loBatch  = if (loSize > 0) lo.grouped(loSize).toVector else Vector()
+    hiBatch ++ loBatch
   }
 
 }

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -504,7 +504,7 @@ class TreeTransformerSpec extends CatsEffectSuite
       Root / "foo" / "bar.md" -> refSrc(sectionSlug)
     )
 
-    def assertTree(f: IO[RenderedTreeRoot[IO]], titleSlug: String, sectionSlug: String): Unit =
+    def assertTree(f: IO[RenderedTreeRoot[IO]], titleSlug: String, sectionSlug: String): IO[Unit] =
       f.assertEquals(
         renderedRoot(
           docs((Root / "baz.txt", targetRes(titleSlug, sectionSlug))).map(

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -18,10 +18,11 @@ package laika.preview
 
 import java.io.{ PrintWriter, StringWriter }
 import cats.data.{ Kleisli, OptionT }
-import cats.effect._
-import cats.syntax.all._
-import com.comcast.ip4s._
+import cats.effect.*
+import cats.syntax.all.*
+import com.comcast.ip4s.*
 import fs2.concurrent.Topic
+import fs2.io.net.Network
 import laika.ast
 import laika.ast.DocumentType
 import laika.format.{ EPUB, PDF }
@@ -30,11 +31,11 @@ import laika.io.model.{ FilePath, InputTreeBuilder }
 import laika.preview.ServerBuilder.Logger
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{ HttpApp, HttpRoutes, Request }
-import org.http4s.implicits._
+import org.http4s.implicits.*
 import org.http4s.server.{ Router, Server }
 import org.http4s.ember.server.EmberServerBuilder
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /** Configures and instantiates a resource for a preview server.
   *
@@ -92,7 +93,7 @@ class ServerBuilder[F[_]: Async](
   }
 
   private def createServer(httpApp: HttpApp[F]): Resource[F, Server] =
-    EmberServerBuilder.default[F]
+    EmberServerBuilder.default(Async[F], Network.forAsync(Async[F]))
       .withShutdownTimeout(2.seconds)
       .withPort(config.port)
       .withHost(config.host)


### PR DESCRIPTION
This is a grab bag of changes since the remaining issues cannot be easily grouped and I want to avoid having a series of very tiny PRs.

* Moves the case class `~` from the `ast` package object to a top level declaration within the `ast` package
* Uses the `toVector` method on a collection type where it is not deprecated in Scala 3
* Addresses the deprecation warning for `EmberServerBuilder.default[F]`
* Changes for avoiding `mdoc` warnings:
    * disable warnings for unused locals and parameters as this happens a lot for incomplete code snippets
    * change all occurrences of `val foo = ???` to `def foo = ???` to avoid dead code warnings
    * removes unused imports from sample code
    * switches flags from `:nest:silent` to `:compile-only` where `:nest` triggered inexplicable warnings for the generated code

This is the final PR for the M1 release which will happen shortly after this is merged.