### PR TITLE
shrink public API surface - core APIs

### DIFF
--- a/core/shared/src/main/scala/laika/api/MarkupParser.scala
+++ b/core/shared/src/main/scala/laika/api/MarkupParser.scala
@@ -51,7 +51,7 @@ import laika.parse.markup.DocumentParser.{ DocumentInput, InvalidDocument, Parse
   *
   * @author Jens Halm
   */
-class MarkupParser(val format: MarkupFormat, val config: OperationConfig) {
+class MarkupParser private[laika] (val format: MarkupFormat, val config: OperationConfig) {
 
   /** The file suffixes this parser will recognize
     * as a supported format.
@@ -78,7 +78,7 @@ class MarkupParser(val format: MarkupFormat, val config: OperationConfig) {
 
   /** Parses the specified markup input into a document AST structure.
     */
-  def parse(input: DocumentInput): Either[ParserError, Document] = {
+  private def parse(input: DocumentInput): Either[ParserError, Document] = {
 
     def resolveDocument(unresolved: UnresolvedDocument, docConfig: Config): Document = {
       val embeddedConfig = unresolved.document.content.collect { case c: EmbeddedConfigValue =>
@@ -131,9 +131,10 @@ class MarkupParser(val format: MarkupFormat, val config: OperationConfig) {
     *
     * This low-level hook is rarely used by application code.
     */
-  def parseUnresolved(input: DocumentInput): Either[ParserError, UnresolvedDocument] = docParser(
-    input
-  )
+  private[laika] def parseUnresolved(
+      input: DocumentInput
+  ): Either[ParserError, UnresolvedDocument] =
+    docParser(input)
 
 }
 

--- a/core/shared/src/main/scala/laika/api/Renderer.scala
+++ b/core/shared/src/main/scala/laika/api/Renderer.scala
@@ -51,7 +51,8 @@ import laika.rewrite.nav.{ NoOpPathTranslator, PathTranslator }
   *
   * @author Jens Halm
   */
-abstract class Renderer(val config: OperationConfig, skipRewrite: Boolean = false) { self =>
+abstract class Renderer private[laika] (val config: OperationConfig, skipRewrite: Boolean = false) {
+  self =>
 
   type Formatter
 

--- a/core/shared/src/main/scala/laika/api/Renderer.scala
+++ b/core/shared/src/main/scala/laika/api/Renderer.scala
@@ -137,7 +137,14 @@ abstract class Renderer private[laika] (val config: OperationConfig, skipRewrite
 
     (if (skipRewrite) Right(targetElement) else rewrite).map { elementToRender =>
       val renderContext =
-        RenderContext(renderFunction, elementToRender, styles, doc.path, pathTranslator, config)
+        new RenderContext[Formatter](
+          renderFunction,
+          elementToRender,
+          styles,
+          doc.path,
+          pathTranslator,
+          config
+        )
 
       val formatter = format.formatterFactory(renderContext)
 

--- a/core/shared/src/main/scala/laika/api/Transformer.scala
+++ b/core/shared/src/main/scala/laika/api/Transformer.scala
@@ -43,7 +43,7 @@ import laika.parse.markup.DocumentParser.TransformationError
   *
   * @author Jens Halm
   */
-class Transformer(val parser: MarkupParser, val renderer: Renderer) {
+class Transformer private[laika] (val parser: MarkupParser, val renderer: Renderer) {
 
   def transform(input: String): Either[TransformationError, String] = transform(input, Root)
 

--- a/core/shared/src/main/scala/laika/api/builder/CommonBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/CommonBuilderOps.scala
@@ -23,7 +23,7 @@ import laika.bundle.ExtensionBundle
   *
   * @author Jens Halm
   */
-trait CommonBuilderOps {
+private[api] trait CommonBuilderOps {
 
   /** The type of the operation being configured by this instance.
     */

--- a/core/shared/src/main/scala/laika/api/builder/ParserBuilder.scala
+++ b/core/shared/src/main/scala/laika/api/builder/ParserBuilder.scala
@@ -17,8 +17,6 @@
 package laika.api.builder
 
 import laika.api.MarkupParser
-import laika.ast.DocumentType.Markup
-import laika.ast.TextDocumentType
 import laika.factory.MarkupFormat
 
 /** Builder API for Parser instances.
@@ -27,9 +25,8 @@ import laika.factory.MarkupFormat
   *
   * @author Jens Halm
   */
-class ParserBuilder(format: MarkupFormat, val config: OperationConfig) extends ParserBuilderOps {
-
-  val docType: TextDocumentType = Markup
+class ParserBuilder private[laika] (format: MarkupFormat, val config: OperationConfig)
+    extends ParserBuilderOps {
 
   type ThisType = ParserBuilder
 

--- a/core/shared/src/main/scala/laika/api/builder/ParserBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/ParserBuilderOps.scala
@@ -24,7 +24,7 @@ import laika.config.{ ConfigEncoder, DefaultKey, Key }
   *
   * @author Jens Halm
   */
-trait ParserBuilderOps extends CommonBuilderOps {
+private[api] trait ParserBuilderOps extends CommonBuilderOps {
 
   /**  Turns strict mode on for the target parser, switching off any
     *  features not part of the original markup syntax.
@@ -46,7 +46,7 @@ trait ParserBuilderOps extends CommonBuilderOps {
     * The default is to fail transformations on messages of level `Error` or higher.
     */
   def failOnMessages(filter: MessageFilter): ThisType = withConfig(
-    config.copy(failOnMessages = filter)
+    config.withMessageFilters(failOn = filter)
   )
 
   /** Returns a new instance with the specified configuration value added.

--- a/core/shared/src/main/scala/laika/api/builder/RendererBuilder.scala
+++ b/core/shared/src/main/scala/laika/api/builder/RendererBuilder.scala
@@ -28,7 +28,7 @@ import laika.factory.RenderFormat
   *
   * @author Jens Halm
   */
-class RendererBuilder[FMT](
+class RendererBuilder[FMT] private[laika] (
     val renderFormat: RenderFormat[FMT],
     val config: OperationConfig,
     skipRewritePhase: Boolean = false

--- a/core/shared/src/main/scala/laika/api/builder/RendererBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/RendererBuilderOps.scala
@@ -25,7 +25,7 @@ import laika.factory.RenderFormat
   *
   * @author Jens Halm
   */
-trait RendererBuilderOps[FMT] extends CommonBuilderOps {
+private[api] trait RendererBuilderOps[FMT] extends CommonBuilderOps {
 
   protected def renderFormat: RenderFormat[FMT]
 
@@ -54,12 +54,12 @@ trait RendererBuilderOps[FMT] extends CommonBuilderOps {
   /**  Specifies the minimum required level for a runtime message to get included into the output by this renderer.
     */
   def renderMessages(filter: MessageFilter): ThisType = withConfig(
-    config.copy(renderMessages = filter)
+    config.withMessageFilters(render = filter)
   )
 
   /**  Renders without any formatting (line breaks or indentation).
     *  Useful when storing the output in a database for example.
     */
-  def unformatted: ThisType = withConfig(config.copy(renderFormatted = false))
+  def unformatted: ThisType = withConfig(config.renderUnformatted)
 
 }

--- a/core/shared/src/main/scala/laika/api/builder/TransformerBuilder.scala
+++ b/core/shared/src/main/scala/laika/api/builder/TransformerBuilder.scala
@@ -17,8 +17,6 @@
 package laika.api.builder
 
 import laika.api.{ MarkupParser, Transformer }
-import laika.ast.DocumentType.Markup
-import laika.ast._
 import laika.factory.{ MarkupFormat, RenderFormat }
 
 /** Builder API for Transformer instances.
@@ -30,15 +28,13 @@ import laika.factory.{ MarkupFormat, RenderFormat }
   *
   * @author Jens Halm
   */
-class TransformerBuilder[FMT](
+class TransformerBuilder[FMT] private[laika] (
     markupFormat: MarkupFormat,
     protected val renderFormat: RenderFormat[FMT],
     protected val config: OperationConfig
 ) extends TransformerBuilderOps[FMT] {
 
   type ThisType = TransformerBuilder[FMT]
-
-  val docType: TextDocumentType = Markup
 
   def withConfig(newConfig: OperationConfig): ThisType =
     new TransformerBuilder(markupFormat, renderFormat, newConfig)

--- a/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
@@ -25,7 +25,8 @@ import laika.bundle.ExtensionBundle
   *
   * @author Jens Halm
   */
-trait TransformerBuilderOps[FMT] extends ParserBuilderOps with RendererBuilderOps[FMT] {
+private[api] trait TransformerBuilderOps[FMT] extends ParserBuilderOps
+    with RendererBuilderOps[FMT] {
 
   type ThisType <: TransformerBuilderOps[FMT]
 

--- a/core/shared/src/main/scala/laika/api/builder/TwoPhaseRendererBuilder.scala
+++ b/core/shared/src/main/scala/laika/api/builder/TwoPhaseRendererBuilder.scala
@@ -28,7 +28,7 @@ import laika.factory.TwoPhaseRenderFormat
   *
   * @author Jens Halm
   */
-class TwoPhaseRendererBuilder[FMT, PP](
+class TwoPhaseRendererBuilder[FMT, PP] private[laika] (
     val twoPhaseFormat: TwoPhaseRenderFormat[FMT, PP],
     val config: OperationConfig
 ) extends RendererBuilderOps[FMT] {

--- a/core/shared/src/main/scala/laika/api/builder/TwoPhaseTransformerBuilder.scala
+++ b/core/shared/src/main/scala/laika/api/builder/TwoPhaseTransformerBuilder.scala
@@ -28,7 +28,7 @@ import laika.factory.{ MarkupFormat, RenderFormat, TwoPhaseRenderFormat }
   *
   * @author Jens Halm
   */
-class TwoPhaseTransformerBuilder[FMT, PP](
+class TwoPhaseTransformerBuilder[FMT, PP] private[api] (
     val markupFormat: MarkupFormat,
     val twoPhaseRenderFormat: TwoPhaseRenderFormat[FMT, PP],
     val config: OperationConfig

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -155,6 +155,8 @@ class RootCursor private (
 
 object RootCursor {
 
+  /** Creates a new cursor for the specified document tree.
+    */
   def apply(
       target: DocumentTreeRoot,
       outputContext: Option[OutputContext] = None
@@ -287,9 +289,11 @@ case class TreeCursor(
 
 object TreeCursor {
 
-  def apply(root: RootCursor): TreeCursor =
+  private[ast] def apply(root: RootCursor): TreeCursor =
     apply(root.target.tree, None, root, root.config, TreePosition.root)
 
+  /** Creates a new cursor for the specified document tree.
+    */
   def apply(
       root: DocumentTree,
       outputContext: Option[OutputContext] = None
@@ -464,7 +468,7 @@ object DocumentCursor {
   /** Creates a cursor for a document and full context information:
     * its parent, configuration and position within the document tree.
     */
-  def apply(
+  private[ast] def apply(
       document: Document,
       parent: TreeCursor,
       config: Config,

--- a/core/shared/src/main/scala/laika/ast/RewriteRules.scala
+++ b/core/shared/src/main/scala/laika/ast/RewriteRules.scala
@@ -41,14 +41,16 @@ case class RewriteRules(
     templateRules: Seq[RewriteRule[TemplateSpan]] = Nil
 ) {
 
-  private lazy val chainedSpanRules: Span => RewriteAction[Span] = ChainedRewriteRules(spanRules)
+  private lazy val chainedSpanRules: Span => RewriteAction[Span] = new ChainedRewriteRules(
+    spanRules
+  )
 
-  private lazy val chainedBlockRules: Block => RewriteAction[Block] = ChainedRewriteRules(
+  private lazy val chainedBlockRules: Block => RewriteAction[Block] = new ChainedRewriteRules(
     blockRules
   )
 
   private lazy val chainedTemplateRules: TemplateSpan => RewriteAction[TemplateSpan] =
-    ChainedRewriteRules(templateRules)
+    new ChainedRewriteRules(templateRules)
 
   /** Combines the rules defined in this instance with the rules defined
     * in the specified other instance. If a rule in this instance matches the same
@@ -235,7 +237,7 @@ object RewriteRules {
   /** Chains the specified rewrite rules so that they get applied to matching elements
     * in the order specified in the given sequence.
     */
-  case class ChainedRewriteRules[T](rules: Seq[RewriteRule[T]]) extends (T => RewriteAction[T]) {
+  private class ChainedRewriteRules[T](rules: Seq[RewriteRule[T]]) extends (T => RewriteAction[T]) {
 
     def apply(element: T): RewriteAction[T] = {
 

--- a/core/shared/src/main/scala/laika/collection/Stack.scala
+++ b/core/shared/src/main/scala/laika/collection/Stack.scala
@@ -21,7 +21,7 @@ package laika.collection
   *
   * @author Jens Halm
   */
-class Stack[T] {
+private[laika] class Stack[T] {
 
   private var underlying: List[T] = Nil
 

--- a/core/shared/src/main/scala/laika/collection/TransitionalCollectionOps.scala
+++ b/core/shared/src/main/scala/laika/collection/TransitionalCollectionOps.scala
@@ -22,7 +22,7 @@ import scala.collection.{ AbstractIterator, Iterator }
   *
   * @author Jens Halm
   */
-object TransitionalCollectionOps {
+private[laika] object TransitionalCollectionOps {
 
   implicit class TransitionalMapOps[K, V](val map: Map[K, V]) extends AnyVal {
 

--- a/core/shared/src/main/scala/laika/factory/RenderFormat.scala
+++ b/core/shared/src/main/scala/laika/factory/RenderFormat.scala
@@ -31,13 +31,13 @@ import laika.rewrite.nav.PathTranslator
   * @param pathTranslator translates paths of input documents to the corresponding output path
   * @param config additional configuration for the renderer
   */
-case class RenderContext[FMT](
-    renderChild: (FMT, Element) => String,
-    root: Element,
-    styles: StyleDeclarationSet,
-    path: Path,
-    pathTranslator: PathTranslator,
-    config: RenderConfig
+class RenderContext[FMT] private[laika] (
+    val renderChild: (FMT, Element) => String,
+    val root: Element,
+    val styles: StyleDeclarationSet,
+    val path: Path,
+    val pathTranslator: PathTranslator,
+    val config: RenderConfig
 ) {
 
   /** The indentation mechanism to use for rendering.
@@ -82,10 +82,7 @@ trait RenderFormat[FMT] extends Format {
     */
   def formatterFactory: RenderContext[FMT] => FMT
 
-  type CustomRenderFunction[FORMAT] =
-    PartialFunction[(FORMAT, Element), String] // TODO - move/promote
-
-  case class Overrides(value: CustomRenderFunction[FMT] = PartialFunction.empty)
+  case class Overrides(value: PartialFunction[(FMT, Element), String] = PartialFunction.empty)
       extends RenderOverrides {
 
     type Formatter = FMT

--- a/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
@@ -58,8 +58,8 @@ class OperationConfigSpec extends FunSuite {
 
     val bundles1 = Seq(UserBundle1, LaikaDefaults, ThemeBundle, GitHubFlavor, UserBundle2)
     val bundles2 = Seq(VerbatimHTML, UserBundle1, ExtensionBundle.Empty)
-    val config1  = OperationConfig(bundles1)
-    val config2  = OperationConfig(bundles2)
+    val config1  = new OperationConfig(bundles1)
+    val config2  = new OperationConfig(bundles2)
     assertEquals(
       config1.merge(config2).bundles,
       Seq(

--- a/core/shared/src/test/scala/laika/markdown/BlockParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/BlockParsersSpec.scala
@@ -27,7 +27,10 @@ import munit.FunSuite
 class BlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
 
   val rootParser =
-    new RootParser(Markdown, OperationConfig(Markdown.extensions).forStrictMode.markupExtensions)
+    new RootParser(
+      Markdown,
+      new OperationConfig(Markdown.extensions).forStrictMode.markupExtensions
+    )
 
   val defaultParser: Parser[RootElement] = rootParser.rootElement
 

--- a/core/shared/src/test/scala/laika/markdown/GitHubFlavorSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/GitHubFlavorSpec.scala
@@ -29,7 +29,7 @@ class GitHubFlavorSpec extends FunSuite with ParagraphCompanionShortcuts {
 
   val rootParser = new RootParser(
     Markdown,
-    OperationConfig(Markdown.extensions)
+    new OperationConfig(Markdown.extensions)
       .withBundles(Seq(GitHubFlavor)).markupExtensions
   )
 

--- a/core/shared/src/test/scala/laika/markdown/HTMLBlockParserSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/HTMLBlockParserSpec.scala
@@ -30,7 +30,10 @@ class HTMLBlockParserSpec extends FunSuite
     with HTMLModelBuilder {
 
   val rootParser =
-    new RootParser(Markdown, OperationConfig(Markdown.extensions).forRawContent.markupExtensions)
+    new RootParser(
+      Markdown,
+      new OperationConfig(Markdown.extensions).forRawContent.markupExtensions
+    )
 
   val defaultParser: Parser[RootElement] = rootParser.rootElement
 

--- a/core/shared/src/test/scala/laika/markdown/HTMLParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/HTMLParsersSpec.scala
@@ -28,7 +28,7 @@ class HTMLParsersSpec extends FunSuite with HTMLModelBuilder {
 
   val rootParser = new RootParserWrapper(
     Markdown,
-    OperationConfig(Markdown.extensions).forRawContent.markupExtensions
+    new OperationConfig(Markdown.extensions).forRawContent.markupExtensions
   )
 
   val defaultParser: Parser[List[Span]] = rootParser.standaloneSpanParser

--- a/core/shared/src/test/scala/laika/markdown/InlineParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/InlineParsersSpec.scala
@@ -27,7 +27,7 @@ import munit.FunSuite
 class InlineParsersSpec extends FunSuite with TestSourceBuilders {
 
   val rootParser =
-    new RootParserWrapper(Markdown, OperationConfig(Markdown.extensions).markupExtensions)
+    new RootParserWrapper(Markdown, new OperationConfig(Markdown.extensions).markupExtensions)
 
   val defaultParser: Parser[List[Span]] = rootParser.standaloneSpanParser
 

--- a/core/shared/src/test/scala/laika/rst/BlockParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/BlockParsersSpec.scala
@@ -39,7 +39,7 @@ class BlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
   val rootParser = new RootParser(
     ReStructuredText,
-    OperationConfig(ReStructuredText.extensions :+ interruptions).markupExtensions
+    new OperationConfig(ReStructuredText.extensions :+ interruptions).markupExtensions
   )
 
   val defaultParser: Parser[RootElement] = rootParser.rootElement

--- a/core/shared/src/test/scala/laika/rst/ExplicitBlockParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/ExplicitBlockParsersSpec.scala
@@ -30,7 +30,7 @@ class ExplicitBlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts
   private val defaultParser: Parser[RootElement] =
     new RootParser(
       ReStructuredText,
-      OperationConfig(ReStructuredText.extensions).markupExtensions
+      new OperationConfig(ReStructuredText.extensions).markupExtensions
     ).rootElement
 
   def run(input: String, blocks: Block*)(implicit loc: munit.Location): Unit =

--- a/io/src/main/scala/laika/factory/BinaryPostProcessor.scala
+++ b/io/src/main/scala/laika/factory/BinaryPostProcessor.scala
@@ -28,7 +28,7 @@ import laika.theme.Theme
   *
   *  @author Jens Halm
   */
-abstract class BinaryPostProcessor[F[_]] {
+trait BinaryPostProcessor[F[_]] {
 
   /** Processes the interim render result and writes it to the specified final output.
     *

--- a/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
+++ b/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
@@ -57,10 +57,11 @@ class FOConcatenationSpec extends FunSuite with TestSourceBuilders {
   }
 
   test("succeed when there are errors in the template result, but the filter is None") {
-    val config   = OperationConfig.default.copy(
-      renderMessages = MessageFilter.Warning,
-      failOnMessages = MessageFilter.None
-    )
+    val config   = OperationConfig.default
+      .withMessageFilters(
+        render = MessageFilter.Warning,
+        failOn = MessageFilter.None
+      )
     val expected =
       """<fo:inline background-color="#ffe9e3" border="1pt solid #d83030" color="#d83030" padding="1pt 2pt">WRONG</fo:inline> <fo:inline font-family="monospaced" font-size="0.9em">faulty input</fo:inline>"""
     assertEquals(FOConcatenation(result, PDF.BookConfig(), config), Right(expected))

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -144,13 +144,11 @@ private[preview] object SiteTransformer {
       artifactBasename: String
   ): Resource[F, SiteTransformer[F]] = {
 
-    def adjustConfig(p: TreeParser[F]): TreeParser[F] = p.modifyConfig(oc =>
-      oc.copy(
-        failOnMessages = MessageFilter.None,
-        configBuilder = oc.configBuilder
-          .withValue(LaikaKeys.preview.enabled, true)
-      )
-    )
+    def adjustConfig(p: TreeParser[F]): TreeParser[F] = p.modifyConfig {
+      _
+        .withMessageFilters(failOn = MessageFilter.None)
+        .withConfigValue(LaikaKeys.preview.enabled, true)
+    }
 
     def asInputTree(map: ResultMap[F]): InputTree[F] = {
       val inputs = map.collect { case (path, static: StaticResult[F]) =>

--- a/sbt/src/main/scala/laika/sbt/Settings.scala
+++ b/sbt/src/main/scala/laika/sbt/Settings.scala
@@ -59,11 +59,12 @@ object Settings {
     val userConfig = laikaConfig.value
 
     def mergedConfig(config: OperationConfig): OperationConfig = {
-      config.copy(
-        bundleFilter = userConfig.bundleFilter,
-        renderMessages = userConfig.renderMessages,
-        failOnMessages = userConfig.failOnMessages
-      )
+      config
+        .withMessageFilters(
+          render = userConfig.renderMessages,
+          failOn = userConfig.failOnMessages
+        )
+        .withBundleFilter(userConfig.bundleFilter)
     }
 
     def createParser(format: MarkupFormat): ParserBuilder = {
@@ -122,12 +123,13 @@ object Settings {
     val userConfig                                        = laikaConfig.value
     def createParser(format: MarkupFormat): ParserBuilder = {
       val parser       = MarkupParser.of(format)
-      val mergedConfig = parser.config.copy(
+      val mergedConfig = new OperationConfig(
         bundles = parser.config.bundles :+ configFallbacks,
         bundleFilter = userConfig.bundleFilter,
         failOnMessages = userConfig.failOnMessages,
         renderMessages = userConfig.renderMessages,
-        configBuilder = userConfig.configBuilder
+        configBuilder = userConfig.configBuilder,
+        renderFormatted = parser.config.renderFormatted
       )
       parser.withConfig(mergedConfig).using(laikaExtensions.value: _*)
     }


### PR DESCRIPTION
This is the first PR for #452.

Naturally, since this covers the main entry point for user-facing APIs, this area does not shrink too much.

The PR covers the packages `laika.api`, `laika.ast`, `laika.format`, `laika.factory`, `laika.time`, `laika.collection` and prepares them for long-term binary compatibility.

Some APIs use package-private traits mixed into public classes for the sole purpose of code sharing - `mima` seems happy with it (e.g. adding abstract methods to those traits) and `unidoc` output does show the hidden types in signatures, but they are not linked, so it should not be too confusing for users.

Some other details:

* Types which are used as part of a fluent builder API now have private constructors, as these types are never serving as API entry point.
* `OperationConfig` is no longer a case class - the likeliness we need to add properties during 1.x maintenance is quite high.
* Some method overloads have been made package-private to clean up those APIs.
* The package `laika.collection` disappears from the public API entirely - those are really just internal utilities.