### PR TITLE
shrink public API surface - core extension points

### DIFF
--- a/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
+++ b/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
@@ -143,7 +143,7 @@ class OperationConfig private[laika] (
   /** Provides all extensions for the text markup parser extracted from
     * all defined bundles.
     */
-  lazy val markupExtensions: MarkupExtensions = mergedBundle.parsers.markupExtensions
+  private[laika] lazy val markupExtensions: MarkupExtensions = mergedBundle.parsers.markupExtensions
 
   /** Provides the parser for configuration documents and configuration headers in text markup
     * and template documents.

--- a/core/shared/src/main/scala/laika/bundle/DocumentTypeMatcher.scala
+++ b/core/shared/src/main/scala/laika/bundle/DocumentTypeMatcher.scala
@@ -20,7 +20,7 @@ import laika.ast.{ DocumentType, Path }
 import laika.rewrite.nav.TargetFormats
 
 /** The default implementations for determining the document type
-  *  of the input based on its path.
+  * of the input based on its path.
   *
   *  @author Jens Halm
   */
@@ -39,7 +39,7 @@ object DocumentTypeMatcher {
     """.+\.fo.css$""".r // stylesheets for HTML are treated as static documents
   private val ConfigName = "directory.conf"
 
-  def staticTargetFormats(path: Path): TargetFormats = path.suffix match {
+  private def staticTargetFormats(path: Path): TargetFormats = path.suffix match {
     case Some("shared.css") | Some("shared.js") =>
       TargetFormats.Selected("html", "epub", "epub.xhtml")
     case Some("epub.css") | Some("epub.js")     => TargetFormats.Selected("epub", "epub.xhtml")

--- a/core/shared/src/main/scala/laika/bundle/ExtensionBundle.scala
+++ b/core/shared/src/main/scala/laika/bundle/ExtensionBundle.scala
@@ -100,7 +100,7 @@ trait ExtensionBundle { self =>
   /** Specifies extensions and/or replacements for parsers that deal with
     * text markup, templates, CSS or configuration headers.
     */
-  def parsers: ParserBundle = ParserBundle()
+  def parsers: ParserBundle = new ParserBundle()
 
   /** Specifies rewrite rules to be applied to the document tree model between the
     * parse and render operations.
@@ -282,7 +282,7 @@ object ExtensionBundle {
     override val baseConfig: Config =
       ConfigBuilder.empty.withValue("laika.version", "0.19.3-SNAPSHOT").build
 
-    override val parsers: ParserBundle = ParserBundle(
+    override val parsers: ParserBundle = new ParserBundle(
       styleSheetParser = Some(CSSParsers.styleDeclarationSet)
     )
 

--- a/core/shared/src/main/scala/laika/bundle/ParserBundle.scala
+++ b/core/shared/src/main/scala/laika/bundle/ParserBundle.scala
@@ -37,14 +37,14 @@ import laika.parse.markup.DocumentParser.DocumentInput
   * @param templateParser parser for template documents
   * @param styleSheetParser parser for CSS documents
   */
-case class ParserBundle(
-    blockParsers: Seq[BlockParserBuilder] = Nil,
-    spanParsers: Seq[SpanParserBuilder] = Nil,
-    syntaxHighlighters: Seq[SyntaxHighlighter] = Nil,
-    markupParserHooks: Option[ParserHooks] = None,
-    configProvider: Option[ConfigProvider] = None,
-    templateParser: Option[Parser[TemplateRoot]] = None,
-    styleSheetParser: Option[Parser[Set[StyleDeclaration]]] = None
+class ParserBundle(
+    val blockParsers: Seq[BlockParserBuilder] = Nil,
+    val spanParsers: Seq[SpanParserBuilder] = Nil,
+    val syntaxHighlighters: Seq[SyntaxHighlighter] = Nil,
+    val markupParserHooks: Option[ParserHooks] = None,
+    val configProvider: Option[ConfigProvider] = None,
+    val templateParser: Option[Parser[TemplateRoot]] = None,
+    val styleSheetParser: Option[Parser[Set[StyleDeclaration]]] = None
 ) {
 
   /** Merges this instance with the specified base.
@@ -53,7 +53,7 @@ case class ParserBundle(
     * in the base (if defined), with the base only serving as a fallback.
     */
   def withBase(base: ParserBundle): ParserBundle =
-    ParserBundle(
+    new ParserBundle(
       blockParsers ++ base.blockParsers,
       spanParsers ++ base.spanParsers,
       syntaxHighlighters ++ base.syntaxHighlighters,
@@ -67,12 +67,12 @@ case class ParserBundle(
     * Fallback instances will be added where appropriate for parsers or hooks not defined
     * in this bundle.
     */
-  def markupExtensions: MarkupExtensions =
-    MarkupExtensions(
+  private[laika] def markupExtensions: MarkupExtensions =
+    new MarkupExtensions(
       blockParsers,
       spanParsers,
       syntaxHighlighters,
-      markupParserHooks.getOrElse(ParserHooks())
+      markupParserHooks.getOrElse(new ParserHooks())
     )
 
 }
@@ -84,17 +84,17 @@ case class ParserBundle(
   * @param postProcessDocument function invoked after parsing but before rewriting, allowing to modify the document
   * @param preProcessInput function invoked before parsing, allowing to pre-process the input
   */
-case class ParserHooks(
-    postProcessBlocks: Seq[Block] => Seq[Block] = identity,
-    postProcessDocument: UnresolvedDocument => UnresolvedDocument = identity,
-    preProcessInput: DocumentInput => DocumentInput = identity
+class ParserHooks(
+    val postProcessBlocks: Seq[Block] => Seq[Block] = identity,
+    val postProcessDocument: UnresolvedDocument => UnresolvedDocument = identity,
+    val preProcessInput: DocumentInput => DocumentInput = identity
 ) {
 
   /** Merges this instance with the specified base.
     * The functions specified in the base are always invoked before
     * the functions in this instance.
     */
-  def withBase(base: ParserHooks): ParserHooks = ParserHooks(
+  def withBase(base: ParserHooks): ParserHooks = new ParserHooks(
     base.postProcessBlocks andThen postProcessBlocks,
     base.postProcessDocument andThen postProcessDocument,
     base.preProcessInput andThen preProcessInput
@@ -113,9 +113,9 @@ case class ParserHooks(
   * @param syntaxHighlighters parsers for syntax highlighting of code blocks
   * @param parserHooks hooks for markup parsers to control aspects beyond the individual span and block parsers
   */
-case class MarkupExtensions(
-    blockParsers: Seq[BlockParserBuilder],
-    spanParsers: Seq[SpanParserBuilder],
-    syntaxHighlighters: Seq[SyntaxHighlighter],
-    parserHooks: ParserHooks
+private[laika] class MarkupExtensions(
+    val blockParsers: Seq[BlockParserBuilder],
+    val spanParsers: Seq[SpanParserBuilder],
+    val syntaxHighlighters: Seq[SyntaxHighlighter],
+    val parserHooks: ParserHooks
 )

--- a/core/shared/src/main/scala/laika/bundle/ParserDefinition.scala
+++ b/core/shared/src/main/scala/laika/bundle/ParserDefinition.scala
@@ -56,13 +56,13 @@ sealed trait ParserDefinition[E <: Element] {
   * @param paragraphLineCheck a test for the start of each line in plain paragraphs that indicates whether the line might
   *                           be the start of a block identified by this parser
   */
-case class BlockParserDefinition(
-    startChars: Set[Char],
-    parser: Parser[Block],
-    isRecursive: Boolean,
-    position: BlockPosition,
-    precedence: Precedence,
-    paragraphLineCheck: Option[PrefixedParser[Any]] = None
+class BlockParserDefinition(
+    val startChars: Set[Char],
+    val parser: Parser[Block],
+    val isRecursive: Boolean,
+    val position: BlockPosition,
+    val precedence: Precedence,
+    val paragraphLineCheck: Option[PrefixedParser[Any]] = None
 ) extends ParserDefinition[Block]
 
 /** Defines a parser for a single kind of span element,
@@ -74,11 +74,11 @@ case class BlockParserDefinition(
   * @param precedence indicates whether the parser should be applied before the base parsers of
   * the host language (high precedence) or after them
   */
-case class SpanParserDefinition(
-    startChars: NonEmptySet[Char],
-    parser: Parser[Span],
-    isRecursive: Boolean,
-    precedence: Precedence
+class SpanParserDefinition(
+    val startChars: NonEmptySet[Char],
+    val parser: Parser[Span],
+    val isRecursive: Boolean,
+    val precedence: Precedence
 ) extends ParserDefinition[Span]
 
 /** Indicates whether a parser should be applied before the base parsers of

--- a/core/shared/src/main/scala/laika/bundle/SyntaxHighlighter.scala
+++ b/core/shared/src/main/scala/laika/bundle/SyntaxHighlighter.scala
@@ -23,6 +23,9 @@ import laika.parse.code.CodeSpanParser
 import laika.parse.code.common.EmbeddedCodeSpans
 import laika.parse.text.DelimitedText
 
+/** Captures the parser implementation and aliases of the syntax highlighter for
+  * a particular language.
+  */
 trait SyntaxHighlighter {
 
   /** The names of the language (and its optional aliases) as used in text markup */

--- a/core/shared/src/main/scala/laika/directive/DirectiveRegistry.scala
+++ b/core/shared/src/main/scala/laika/directive/DirectiveRegistry.scala
@@ -73,7 +73,7 @@ trait DirectiveRegistry extends ExtensionBundle { self =>
     *  `@:ticket(2356)` and turns it into an external link node for the
     *  URL `http://tickets.service.com/2356`.
     *
-    *  For more details on implementing Laika directives see [[laika.directive.BuilderContext.dsl]].
+    *  For more details on implementing Laika span directives see [[laika.directive.Spans.dsl]].
     */
   def spanDirectives: Seq[Spans.Directive]
 
@@ -98,7 +98,7 @@ trait DirectiveRegistry extends ExtensionBundle { self =>
     *  val transformer = Transformer.from(Markdown).to(HTML).using(MyDirectives).build
     *  }}}
     *
-    *  For more details on implementing Laika directives see [[laika.directive.BuilderContext.dsl]].
+    *  For more details on implementing Laika block directives see [[laika.directive.Blocks.dsl]].
     */
   def blockDirectives: Seq[Blocks.Directive]
 
@@ -130,7 +130,7 @@ trait DirectiveRegistry extends ExtensionBundle { self =>
     *  `@:ticket(2356)` and turns it into an external link node for the
     *  URL `http://tickets.service.com/2356`.
     *
-    *  For more details on implementing Laika directives see [[laika.directive.BuilderContext.dsl]].
+    *  For more details on implementing Laika template directives see [[laika.directive.Templates.dsl]].
     */
   def templateDirectives: Seq[Templates.Directive]
 
@@ -161,7 +161,7 @@ trait DirectiveRegistry extends ExtensionBundle { self =>
     *  `@:rfc(2356)` and turns it into an external link node for the
     *  URL `http://tools.ietf.org/html/rfc2356`.
     *
-    *  For more details on implementing Laika directives see [[laika.directive.BuilderContext.dsl]].
+    *  For more details on implementing Laika directives see [[laika.directive.Links]].
     */
   def linkDirectives: Seq[Links.Directive]
 

--- a/core/shared/src/main/scala/laika/directive/DirectiveSupport.scala
+++ b/core/shared/src/main/scala/laika/directive/DirectiveSupport.scala
@@ -51,7 +51,7 @@ import laika.parse.text.TextParsers
   *
   * @author Jens Halm
   */
-class DirectiveSupport(
+private[laika] class DirectiveSupport(
     blockDirectives: Seq[Blocks.Directive],
     spanDirectives: Seq[Spans.Directive],
     templateDirectives: Seq[Templates.Directive],
@@ -155,4 +155,5 @@ class DirectiveSupport(
 
 /** Empty default instance without any directives installed.
   */
-object DirectiveSupport extends DirectiveSupport(Nil, Nil, Nil, Nil, strictMode = false)
+private[laika] object DirectiveSupport
+    extends DirectiveSupport(Nil, Nil, Nil, Nil, strictMode = false)

--- a/core/shared/src/main/scala/laika/directive/DirectiveSupport.scala
+++ b/core/shared/src/main/scala/laika/directive/DirectiveSupport.scala
@@ -73,7 +73,7 @@ class DirectiveSupport(
     def configDocument(input: String): ConfigParser = ConfigParser.parse(input)
   }
 
-  override lazy val parsers: ParserBundle = ParserBundle(
+  override lazy val parsers: ParserBundle = new ParserBundle(
     blockParsers =
       if (strictMode) Nil
       else Seq(BlockDirectiveParsers.blockDirective(Blocks.toMap(blockDirectives))),

--- a/core/shared/src/main/scala/laika/directive/std/BreadcrumbDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/BreadcrumbDirectives.scala
@@ -33,7 +33,7 @@ import scala.annotation.tailrec
   *
   * @author Jens Halm
   */
-object BreadcrumbDirectives {
+private[laika] object BreadcrumbDirectives {
 
   /** A block resolver that replaces itself with a navigation list from the root node of the input tree to the current document
     * during AST transformations.

--- a/core/shared/src/main/scala/laika/directive/std/ControlFlowDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/ControlFlowDirectives.scala
@@ -47,7 +47,7 @@ import scala.annotation.tailrec
   *
   * @author Jens Halm
   */
-object ControlFlowDirectives {
+private[laika] object ControlFlowDirectives {
 
   /** Implementation of the `for` directive for templates.
     */

--- a/core/shared/src/main/scala/laika/directive/std/HTMLHeadDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/HTMLHeadDirectives.scala
@@ -35,7 +35,7 @@ import laika.directive.Templates
   *
   * @author Jens Halm
   */
-object HTMLHeadDirectives {
+private[laika] object HTMLHeadDirectives {
 
   private[std] case class SearchPaths(globalPaths: Seq[Path], localPaths: Seq[Path])
 

--- a/core/shared/src/main/scala/laika/directive/std/ImageDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/ImageDirectives.scala
@@ -38,7 +38,7 @@ import laika.directive.{ Blocks, Spans }
   *
   * @author Jens Halm
   */
-object ImageDirectives {
+private[laika] object ImageDirectives {
 
   /** Markup directive for inserting an image as a block level element.
     *

--- a/core/shared/src/main/scala/laika/directive/std/IncludeDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/IncludeDirectives.scala
@@ -43,7 +43,7 @@ import laika.parse.SourceFragment
   *
   * @author Jens Halm
   */
-object IncludeDirectives {
+private[laika] object IncludeDirectives {
 
   private def config(attributes: Config, body: Option[Element], path: Path): ObjectValue = {
     val attributeValues = attributes match {

--- a/core/shared/src/main/scala/laika/directive/std/LinkDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/LinkDirectives.scala
@@ -34,7 +34,7 @@ import laika.rewrite.link.LinkConfig
   *
   * @author Jens Halm
   */
-object LinkDirectives {
+private[laika] object LinkDirectives {
 
   private def linkConfig[T](
       cursor: DocumentCursor,

--- a/core/shared/src/main/scala/laika/directive/std/NavigationTreeDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/NavigationTreeDirectives.scala
@@ -52,7 +52,7 @@ import laika.parse.{ GeneratedSource, SourceFragment }
   *
   * @author Jens Halm
   */
-object NavigationTreeDirectives {
+private[laika] object NavigationTreeDirectives {
 
   /** A block resolver that replaces itself with a navigation list according to this instances configuration.
     * The resulting navigation tree can either be automatically generated from specified root nodes

--- a/core/shared/src/main/scala/laika/directive/std/SelectDirective.scala
+++ b/core/shared/src/main/scala/laika/directive/std/SelectDirective.scala
@@ -35,7 +35,7 @@ import laika.rewrite.nav.Selections
   *
   * @author Jens Halm
   */
-object SelectDirective {
+private[laika] object SelectDirective {
 
   /** Implementation of the `select` directive for block elements in markup documents.
     */

--- a/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
@@ -94,7 +94,7 @@ import scala.collection.immutable.TreeSet
   *
   *  @author Jens Halm
   */
-object StandardDirectives extends DirectiveRegistry {
+private[laika] object StandardDirectives extends DirectiveRegistry {
 
   override val description: String = "Laika's built-in directives"
 

--- a/core/shared/src/main/scala/laika/format/ReStructuredText.scala
+++ b/core/shared/src/main/scala/laika/format/ReStructuredText.scala
@@ -97,9 +97,9 @@ case object ReStructuredText extends MarkupFormat { self =>
 
     override val origin: BundleOrigin = BundleOrigin.Parser
 
-    override val parsers: ParserBundle = ParserBundle(
+    override val parsers: ParserBundle = new ParserBundle(
       markupParserHooks = Some(
-        ParserHooks(
+        new ParserHooks(
           preProcessInput = WhitespacePreprocessor.forInput,
           postProcessDocument = DocInfoExtractor,
           postProcessBlocks = LinkTargetProcessor

--- a/core/shared/src/main/scala/laika/markdown/HTMLParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/HTMLParsers.scala
@@ -18,7 +18,7 @@ package laika.markdown
 
 import cats.data.NonEmptySet
 import laika.ast._
-import laika.bundle.{ BlockParser, BlockParserBuilder, SpanParser, SpanParserBuilder }
+import laika.bundle.{ BlockParserBuilder, SpanParserBuilder }
 import laika.markdown.ast._
 import laika.parse.Parser
 import laika.parse.markup.InlineParsers.spans
@@ -156,7 +156,7 @@ object HTMLParsers {
 
   /** Parses any of the HTML span elements supported by this trait, plus standard markdown inside HTML elements.
     */
-  val htmlSpan: SpanParserBuilder = SpanParser.recursive { recParsers =>
+  val htmlSpan: SpanParserBuilder = SpanParserBuilder.recursive { recParsers =>
     "<" ~> (htmlComment | htmlEmptyElement | htmlElementWithNestedMarkdown(
       recParsers
     ) | htmlEndTag | htmlStartTag)
@@ -164,7 +164,7 @@ object HTMLParsers {
 
   /** Parses a numeric or named character reference.
     */
-  val htmlCharRef: SpanParserBuilder = SpanParser.standalone(htmlCharReference)
+  val htmlCharRef: SpanParserBuilder = SpanParserBuilder.standalone(htmlCharReference)
 
   /** Parses any of the HTML span elements supported by this trait, but no standard markdown inside HTML elements.
     */
@@ -249,6 +249,6 @@ object HTMLParsers {
     "<" ~> (htmlComment | htmlEmptyElement | htmlStartTag) <~ wsEol ~ blankLine
 
   lazy val htmlBlockFragment: BlockParserBuilder =
-    BlockParser.standalone(htmlBlock | htmlBlockElement).rootOnly // TODO - keep separate
+    BlockParserBuilder.standalone(htmlBlock | htmlBlockElement).rootOnly // TODO - keep separate
 
 }

--- a/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
@@ -17,7 +17,7 @@
 package laika.markdown
 
 import laika.ast._
-import laika.bundle.{ SpanParser, SpanParserBuilder }
+import laika.bundle.SpanParserBuilder
 import laika.parse.{ LineSource, Parser, SourceFragment }
 import laika.parse.markup.InlineParsers.text
 import laika.parse.markup.RecursiveSpanParsers
@@ -51,7 +51,7 @@ object InlineParsers {
 
   /** Parses an explicit hard line break.
     */
-  val lineBreak: SpanParserBuilder = SpanParser.standalone(literal("\\\r").as(LineBreak()))
+  val lineBreak: SpanParserBuilder = SpanParserBuilder.standalone(literal("\\\r").as(LineBreak()))
 
   /** Parses a span of strong text enclosed by two consecutive occurrences of the specified character.
     */
@@ -75,13 +75,13 @@ object InlineParsers {
 
   /** Parses either strong spans enclosed in double asterisks or emphasized spans enclosed in single asterisks.
     */
-  val enclosedByAsterisk: SpanParserBuilder = SpanParser.recursive { implicit recParsers =>
+  val enclosedByAsterisk: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     strong('*') | em('*')
   }
 
   /** Parses either strong spans enclosed in double underscores or emphasized spans enclosed in single underscores.
     */
-  val enclosedByUnderscore: SpanParserBuilder = SpanParser.recursive { implicit recParsers =>
+  val enclosedByUnderscore: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     strong('_') | em('_')
   }
 
@@ -110,7 +110,7 @@ object InlineParsers {
   /** Parses a literal span enclosed by one or more backticks.
     *  Does neither parse nested spans nor Markdown escapes.
     */
-  val literalSpan: SpanParserBuilder = SpanParser.standalone {
+  val literalSpan: SpanParserBuilder = SpanParserBuilder.standalone {
     someOf('`').count >> { cnt =>
       delimitedBy("`" * cnt).trim.map(Literal(_))
     }
@@ -123,7 +123,7 @@ object InlineParsers {
   /** Parses a link, including nested spans in the link text.
     *  Recognizes both, an inline link `[text](url)` and a link reference `[text][id]`.
     */
-  lazy val link: SpanParserBuilder = SpanParser.recursive { recParsers =>
+  lazy val link: SpanParserBuilder = SpanParserBuilder.recursive { recParsers =>
     def unwrap(ref: LinkIdReference, suffix: String) = {
       if (ref.select(_.isInstanceOf[LinkIdReference]).tail.nonEmpty)
         SpanSequence(Text("[") :: ref.content.toList ::: Text(suffix) :: Nil)
@@ -157,7 +157,7 @@ object InlineParsers {
   /** Parses an inline image.
     *  Recognizes both, an inline image `![text](url)` and an image reference `![text][id]`.
     */
-  val image: SpanParserBuilder = SpanParser.recursive { recParsers =>
+  val image: SpanParserBuilder = SpanParserBuilder.recursive { recParsers =>
     def escape(text: LineSource, input: SourceFragment, f: String => Span): Span =
       recParsers.escapedText(DelimitedText.Undelimited).parse(text).toEither.fold(
         InvalidSpan(_, input),
@@ -221,7 +221,7 @@ object InlineParsers {
 
   /** Parses a simple inline link in the form of &lt;http://someURL/&gt;
     */
-  val simpleLink: SpanParserBuilder = SpanParser.standalone {
+  val simpleLink: SpanParserBuilder = SpanParserBuilder.standalone {
 
     def isAcceptedScheme(s: String) = s == "http" || s == "https" || s == "ftp" || s == "mailto"
 

--- a/core/shared/src/main/scala/laika/markdown/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/ListParsers.scala
@@ -17,7 +17,7 @@
 package laika.markdown
 
 import laika.ast._
-import laika.bundle.{ BlockParser, BlockParserBuilderOps }
+import laika.bundle.BlockParserBuilder
 import laika.parse.Parser
 import laika.parse.combinator.Parsers.opt
 import laika.parse.markup.RecursiveParsers
@@ -103,8 +103,8 @@ object ListParsers {
 
   /** Parses a bullet list, called "unordered list" in the Markdown syntax description.
     */
-  val bulletLists: BlockParserBuilderOps =
-    BlockParser.recursive { implicit recParsers =>
+  val bulletLists: BlockParserBuilder =
+    BlockParserBuilder.recursive { implicit recParsers =>
       PrefixedParser('+', '*', '-') {
         lookAhead(oneChar) >> { char =>
           val bullet = StringBullet(char)
@@ -120,8 +120,8 @@ object ListParsers {
 
   /** Parses an enumerated list, called "ordered list" in the Markdown syntax description.
     */
-  val enumLists: BlockParserBuilderOps =
-    BlockParser.recursive { implicit recParsers =>
+  val enumLists: BlockParserBuilder =
+    BlockParserBuilder.recursive { implicit recParsers =>
       PrefixedParser(CharGroup.digit) {
         list(
           enumChar,

--- a/core/shared/src/main/scala/laika/markdown/bundle/VerbatimHTML.scala
+++ b/core/shared/src/main/scala/laika/markdown/bundle/VerbatimHTML.scala
@@ -43,7 +43,7 @@ object VerbatimHTML extends ExtensionBundle {
 
   override def rawContentDisabled: Option[ExtensionBundle] = None
 
-  override def parsers: ParserBundle = ParserBundle(
+  override def parsers: ParserBundle = new ParserBundle(
     blockParsers = Seq(HTMLParsers.htmlBlockFragment),
     spanParsers = Seq(HTMLParsers.htmlSpan, HTMLParsers.htmlCharRef)
   )

--- a/core/shared/src/main/scala/laika/markdown/github/FencedCodeBlocks.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/FencedCodeBlocks.scala
@@ -18,7 +18,7 @@ package laika.markdown.github
 
 import cats.data.NonEmptyChain
 import laika.ast.{ CodeBlock, LiteralBlock, Span, Text }
-import laika.bundle.{ BlockParser, BlockParserBuilder }
+import laika.bundle.BlockParserBuilder
 import laika.parse.builders._
 import laika.parse.implicits._
 import laika.parse.{ BlockSource, Failure, Parser, Success }
@@ -40,7 +40,7 @@ object FencedCodeBlocks {
 
   /** Creates a parser for a fenced code block with the specified fence character.
     */
-  def codeBlock(fenceChar: Char): BlockParserBuilder = BlockParser.recursive { recParsers =>
+  def codeBlock(fenceChar: Char): BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val infoString                       = restOfLine.map(
       Some(_)
         .filter(_.nonEmpty)

--- a/core/shared/src/main/scala/laika/markdown/github/GitHubFlavor.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/GitHubFlavor.scala
@@ -45,7 +45,7 @@ object GitHubFlavor extends ExtensionBundle {
 
   override val origin: BundleOrigin = BundleOrigin.Parser
 
-  override def parsers: ParserBundle = ParserBundle(
+  override def parsers: ParserBundle = new ParserBundle(
     blockParsers = Seq(
       Tables.parser
     ) ++ FencedCodeBlocks.parsers,

--- a/core/shared/src/main/scala/laika/markdown/github/Strikethrough.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/Strikethrough.scala
@@ -17,7 +17,7 @@
 package laika.markdown.github
 
 import laika.ast.Deleted
-import laika.bundle.{ SpanParser, SpanParserBuilder }
+import laika.bundle.SpanParserBuilder
 import laika.markdown.InlineParsers.enclosedByDoubleChar
 
 /** Parser for spans with strike-through markup.
@@ -28,7 +28,7 @@ import laika.markdown.InlineParsers.enclosedByDoubleChar
   */
 object Strikethrough {
 
-  val parser: SpanParserBuilder = SpanParser.recursive { implicit recParsers =>
+  val parser: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     enclosedByDoubleChar('~').map { Deleted(_) }
   }
 

--- a/core/shared/src/main/scala/laika/markdown/github/Tables.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/Tables.scala
@@ -17,7 +17,7 @@
 package laika.markdown.github
 
 import laika.ast._
-import laika.bundle.{ BlockParser, BlockParserBuilder }
+import laika.bundle.BlockParserBuilder
 import laika.markdown.BlockParsers._
 import laika.parse.{ LineSource, Parser }
 import laika.parse.text.PrefixedParser
@@ -32,7 +32,7 @@ import laika.parse.implicits._
   */
 object Tables {
 
-  val parser: BlockParserBuilder = BlockParser.withSpans { spanParsers =>
+  val parser: BlockParserBuilder = BlockParserBuilder.withSpans { spanParsers =>
     def cell(textParser: Parser[LineSource], cellType: CellType): Parser[Cell] =
       spanParsers.recursiveSpans(textParser).map { spans =>
         Cell(cellType, Seq(Paragraph(spans)))

--- a/core/shared/src/main/scala/laika/parse/code/SyntaxHighlighting.scala
+++ b/core/shared/src/main/scala/laika/parse/code/SyntaxHighlighting.scala
@@ -41,7 +41,7 @@ case object SyntaxHighlighting extends ExtensionBundle { self =>
 
   val description: String = "Default Syntax Highlighters for Code"
 
-  override def parsers: ParserBundle = ParserBundle(
+  override def parsers: ParserBundle = new ParserBundle(
     syntaxHighlighters = Seq(
       ScalaSyntax,
       DottySyntax,
@@ -82,7 +82,7 @@ case object SyntaxHighlighting extends ExtensionBundle { self =>
 
     val description: String = "Customized collection of Syntax Highlighters for Code"
 
-    override def parsers: ParserBundle = ParserBundle(
+    override def parsers: ParserBundle = new ParserBundle(
       syntaxHighlighters = self.parsers.syntaxHighlighters ++ syntax
     )
 

--- a/core/shared/src/main/scala/laika/parse/directive/ConfigHeaderParser.scala
+++ b/core/shared/src/main/scala/laika/parse/directive/ConfigHeaderParser.scala
@@ -16,7 +16,7 @@
 
 package laika.parse.directive
 
-import laika.config.{ Config, ConfigBuilder, ConfigParser, ConfigValue }
+import laika.config.ConfigParser
 import laika.parse.Parser
 import laika.parse.builders._
 
@@ -51,12 +51,5 @@ object ConfigHeaderParser {
     * tried instead.
     */
   def forTextParser(parser: Parser[String]): Parser[ConfigParser] = parser.map(ConfigParser.parse)
-
-  // val fallback: Path => Parser[Either[InvalidElement, Config]] = { _ => Parsers.success(Right(Config.empty)) }
-
-  def merge(config: Config, values: Seq[(String, ConfigValue)]): Config =
-    values.foldLeft(ConfigBuilder.withFallback(config)) { case (builder, (key, value)) =>
-      builder.withValue(key, value)
-    }.build
 
 }

--- a/core/shared/src/main/scala/laika/parse/directive/DirectiveParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/directive/DirectiveParsers.scala
@@ -18,7 +18,7 @@ package laika.parse.directive
 
 import cats.data.{ NonEmptyChain, NonEmptySet }
 import laika.ast.*
-import laika.bundle.{ BlockParser, BlockParserBuilder, SpanParser, SpanParserBuilder }
+import laika.bundle.{ BlockParserBuilder, SpanParserBuilder }
 import laika.config.Key
 import laika.directive.*
 import laika.parse.builders.*
@@ -166,10 +166,10 @@ object SpanDirectiveParsers {
   import laika.directive.Spans
 
   val contextRef: SpanParserBuilder =
-    SpanParser.standalone(hoconReference(MarkupContextReference(_, _, _), identity))
+    SpanParserBuilder.standalone(hoconReference(MarkupContextReference(_, _, _), identity))
 
   def spanDirective(directives: Map[String, Spans.Directive]): SpanParserBuilder =
-    SpanParser.recursive(rec => spanDirectiveParser(directives)(rec))
+    SpanParserBuilder.recursive(rec => spanDirectiveParser(directives)(rec))
 
   def spanDirectiveParser(
       directives: Map[String, Spans.Directive]
@@ -203,7 +203,7 @@ object BlockDirectiveParsers {
   import laika.directive.Blocks
 
   def blockDirective(directives: Map[String, Blocks.Directive]): BlockParserBuilder =
-    BlockParser.recursive(blockDirectiveParser(directives))
+    BlockParserBuilder.recursive(blockDirectiveParser(directives))
 
   def blockDirectiveParser(
       directives: Map[String, Blocks.Directive]

--- a/core/shared/src/main/scala/laika/parse/directive/DirectiveParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/directive/DirectiveParsers.scala
@@ -41,7 +41,7 @@ import laika.parse.{
   *
   *  @author Jens Halm
   */
-object DirectiveParsers {
+private[laika] object DirectiveParsers {
 
   case class DirectiveSpec(name: String, fence: String)
 
@@ -160,7 +160,7 @@ object DirectiveParsers {
 
 /** Provides the parser definitions for span directives in markup documents.
   */
-object SpanDirectiveParsers {
+private[laika] object SpanDirectiveParsers {
 
   import DirectiveParsers._
   import laika.directive.Spans
@@ -197,7 +197,7 @@ object SpanDirectiveParsers {
 
 /** Provides the parser definitions for block directives in markup documents.
   */
-object BlockDirectiveParsers {
+private[laika] object BlockDirectiveParsers {
 
   import DirectiveParsers._
   import laika.directive.Blocks

--- a/core/shared/src/main/scala/laika/parse/directive/TemplateParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/directive/TemplateParsers.scala
@@ -28,7 +28,7 @@ import laika.parse.implicits._
   *
   * @author Jens Halm
   */
-class TemplateParsers(directives: Map[String, Templates.Directive])
+private[laika] class TemplateParsers(directives: Map[String, Templates.Directive])
     extends DefaultRecursiveSpanParsers {
 
   import DirectiveParsers._

--- a/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
@@ -177,7 +177,7 @@ object DocumentParser {
   /** Combines the specified markup parsers and extensions and the parser for (optional) configuration
     * headers to create a parser function for an entire text markup document.
     */
-  def forMarkup(
+  private[laika] def forMarkup(
       markupParser: MarkupFormat,
       markupExtensions: MarkupExtensions,
       configProvider: ConfigProvider
@@ -194,7 +194,7 @@ object DocumentParser {
   /** Combines the specified parsers for the root element and for (optional) configuration
     * headers to create a parser function for an entire text markup document.
     */
-  def forMarkup(
+  private[laika] def forMarkup(
       rootParser: Parser[RootElement],
       configProvider: ConfigProvider
   ): DocumentInput => Either[ParserError, UnresolvedDocument] =
@@ -206,7 +206,7 @@ object DocumentParser {
   /** Combines the specified parsers for the root element and for (optional) configuration
     * headers to create a parser function for an entire template document.
     */
-  def forTemplate(
+  private[laika] def forTemplate(
       rootParser: Parser[TemplateRoot],
       configProvider: ConfigProvider
   ): DocumentInput => Either[ParserError, TemplateDocument] =
@@ -216,7 +216,7 @@ object DocumentParser {
 
   /** Builds a document parser for CSS documents based on the specified parser for style declarations.
     */
-  def forStyleSheets(
+  private[laika] def forStyleSheets(
       parser: Parser[Set[StyleDeclaration]]
   ): DocumentInput => Either[ParserError, StyleDeclarationSet] =
     forParser { path => parser.map(res => StyleDeclarationSet.forPath(path, res)) }
@@ -227,12 +227,13 @@ object DocumentParser {
     * The specified function is invoked for each parsed document, so that a parser
     * dependent on the input path can be created.
     */
-  def forParser[T](p: Path => Parser[T]): DocumentInput => Either[ParserError, T] = { in =>
-    Parsers
-      .consumeAll(p(in.path))
-      .parse(in.source)
-      .toEither
-      .left.map(ParserError(_, in.path))
+  private[laika] def forParser[T](p: Path => Parser[T]): DocumentInput => Either[ParserError, T] = {
+    in =>
+      Parsers
+        .consumeAll(p(in.path))
+        .parse(in.source)
+        .toEither
+        .left.map(ParserError(_, in.path))
   }
 
 }

--- a/core/shared/src/main/scala/laika/parse/markup/RootParser.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/RootParser.scala
@@ -31,7 +31,7 @@ import scala.collection.immutable.TreeSet
   *
   * @author Jens Halm
   */
-class RootParser(markupParser: MarkupFormat, markupExtensions: MarkupExtensions)
+private[laika] class RootParser(markupParser: MarkupFormat, markupExtensions: MarkupExtensions)
     extends DefaultRecursiveParsers {
 
   private lazy val highlighterMap: Map[String, Parser[Seq[Span]]] =
@@ -76,7 +76,7 @@ class RootParser(markupParser: MarkupFormat, markupExtensions: MarkupExtensions)
   private lazy val allInterruptions: Parser[Block] = mergeInterruptions(sortedBlockParsers)
 
   protected lazy val spanParsers: Seq[PrefixedParser[Span]] = {
-    val escapedText = SpanParser.standalone(escapeSequence.map(Text(_))).withLowPrecedence
+    val escapedText = SpanParserBuilder.standalone(escapeSequence.map(Text(_))).withLowPrecedence
     val mainParsers = markupParser.spanParsers :+ escapedText
 
     createAndSortParsers(mainParsers, markupExtensions.spanParsers).map { parserDef =>

--- a/core/shared/src/main/scala/laika/parse/uri/AutoLinkParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/uri/AutoLinkParsers.scala
@@ -17,7 +17,7 @@
 package laika.parse.uri
 
 import laika.ast.{ Reverse, Span, SpanLink, Text, ~ }
-import laika.bundle.{ SpanParser, SpanParserBuilder }
+import laika.bundle.SpanParserBuilder
 import laika.parse.text.PrefixedParser
 import laika.parse.{ Failure, Parser, Success }
 import laika.parse.builders._
@@ -81,13 +81,13 @@ class AutoLinkParsers(
 
   /** Parses a standalone HTTP or HTTPS hyperlink (with no surrounding markup).
     */
-  lazy val http: SpanParserBuilder = SpanParser.standalone {
+  lazy val http: SpanParserBuilder = SpanParserBuilder.standalone {
     uri("ptth" | "sptth", ":" ~> URIParsers.httpUriNoScheme, ":")
   }.withLowPrecedence
 
   /** Parses a standalone www hyperlink (with no surrounding markup).
     */
-  lazy val www: SpanParserBuilder = SpanParser.standalone {
+  lazy val www: SpanParserBuilder = SpanParserBuilder.standalone {
     uri(
       literal("www"),
       "." ~> (regName ~ path ~ opt("?" ~ query) ~ opt("#" ~ fragment)).source,
@@ -97,7 +97,7 @@ class AutoLinkParsers(
 
   /** Parses a standalone email address (with no surrounding markup).
     */
-  lazy val email: SpanParserBuilder = SpanParser.standalone {
+  lazy val email: SpanParserBuilder = SpanParserBuilder.standalone {
     PrefixedParser('@') {
       val rev    = reverse(0, URIParsers.localPart <~ reverseMarkupStart)
       val fwd    = "@" ~> URIParsers.domain <~ lookAhead(eol | afterEndMarkup)

--- a/core/shared/src/main/scala/laika/rst/BlockParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/BlockParsers.scala
@@ -18,7 +18,7 @@ package laika.rst
 
 import cats.data.NonEmptyChain
 import laika.ast._
-import laika.bundle.{ BlockParser, BlockParserBuilder }
+import laika.bundle.BlockParserBuilder
 import laika.parse.builders._
 import laika.parse.implicits._
 import laika.parse.text.Characters
@@ -58,14 +58,14 @@ object BlockParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#transitions]].
     */
-  val transition: BlockParserBuilder = BlockParser.standalone {
+  val transition: BlockParserBuilder = BlockParserBuilder.standalone {
     (punctuationChar.min(4) ~ wsEol ~ lookAhead(blankLine)).as(Rule())
   }
 
   /** Parses a single paragraph. Everything between two blank lines that is not
     * recognized as a special reStructuredText block type will be parsed as a regular paragraph.
     */
-  lazy val paragraph: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  lazy val paragraph: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val interruptions = recParsers.paragraphInterruptions()
     val lines         = textLine.line.repUntil(interruptions)
 
@@ -87,7 +87,7 @@ object BlockParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections]].
     */
-  lazy val headerWithOverline: BlockParserBuilder = BlockParser.withSpans { spanParsers =>
+  lazy val headerWithOverline: BlockParserBuilder = BlockParserBuilder.withSpans { spanParsers =>
     val spanParser = punctuationChar.take(1) >> { start =>
       val char = start.charAt(0)
       anyOf(char) >> { deco =>
@@ -109,7 +109,7 @@ object BlockParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections]].
     */
-  lazy val headerWithUnderline: BlockParserBuilder = BlockParser.withSpans { spanParsers =>
+  lazy val headerWithUnderline: BlockParserBuilder = BlockParserBuilder.withSpans { spanParsers =>
     val spanParser = nextNot(' ') ~ not(eof) ~> restOfLine.trim.line >> { title =>
       punctuationChar.take(1) >> { start =>
         val char = start.charAt(0)
@@ -135,7 +135,7 @@ object BlockParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#doctest-blocks]]
     */
-  val doctest: BlockParserBuilder = BlockParser.standalone {
+  val doctest: BlockParserBuilder = BlockParserBuilder.standalone {
     val lineParser = restOfLine.rep(not(blankLine)).min(1)
     ">>> " ~> lineParser.mkLines.map(DoctestBlock(_))
   }
@@ -144,7 +144,7 @@ object BlockParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#block-quotes]]
     */
-  lazy val blockQuote: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  lazy val blockQuote: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val attributionStart = "---" | "--" | "\u2014" // em dash
 
     def attribution(indent: Int) = ws.take(indent) ~ attributionStart ~ ws.max(1) ~>

--- a/core/shared/src/main/scala/laika/rst/ExplicitBlockParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/ExplicitBlockParsers.scala
@@ -17,7 +17,7 @@
 package laika.rst
 
 import laika.ast._
-import laika.bundle.{ BlockParser, BlockParserBuilder }
+import laika.bundle.BlockParserBuilder
 import laika.parse.markup.RecursiveParsers
 import laika.parse.builders._
 import laika.parse.implicits._
@@ -136,7 +136,7 @@ object ExplicitBlockParsers {
   /** The parser builder for all explicit block items that start with `..` except
     * for directives which are provided by an extension.
     */
-  val allBlocks: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  val allBlocks: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     new ExplicitBlockParsers(recParsers).explicitBlockItem
   }
 
@@ -153,7 +153,7 @@ object ExplicitBlockParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks]].
     */
-  lazy val shortAnonymousLinkTarget: BlockParserBuilder = BlockParser.standalone {
+  lazy val shortAnonymousLinkTarget: BlockParserBuilder = BlockParserBuilder.standalone {
     "__ " ~> linkDefinitionBody.map(LinkDefinition.create("", _))
   }
 

--- a/core/shared/src/main/scala/laika/rst/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/ListParsers.scala
@@ -17,7 +17,7 @@
 package laika.rst
 
 import laika.ast._
-import laika.bundle.{ BlockParser, BlockParserBuilder }
+import laika.bundle.BlockParserBuilder
 import laika.collection.Stack
 import laika.parse.Parser
 import laika.parse.markup.RecursiveParsers
@@ -96,7 +96,7 @@ object ListParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#bullet-lists]].
     */
-  lazy val bulletList: BlockParserBuilder = BlockParser.recursive { implicit recParsers =>
+  lazy val bulletList: BlockParserBuilder = BlockParserBuilder.recursive { implicit recParsers =>
     lookAhead(bulletListStart <~ ws.min(1)) >> { symbol =>
       val bullet = StringBullet(symbol)
       listItem(literal(symbol), BulletListItem(_, bullet)).rep.min(1).map { items =>
@@ -143,7 +143,7 @@ object ListParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#enumerated-lists]].
     */
-  lazy val enumList: BlockParserBuilder = BlockParser.recursive { implicit recParsers =>
+  lazy val enumList: BlockParserBuilder = BlockParserBuilder.recursive { implicit recParsers =>
     import EnumType._
 
     val lowerRoman = someOf('i', 'v', 'x', 'l', 'c', 'd', 'm')
@@ -186,7 +186,7 @@ object ListParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#definition-lists]].
     */
-  lazy val definitionList: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  lazy val definitionList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val tableStart    = anyOf(' ', '=') ~ eol
     val explicitStart = ".. " | "__ "
     val listStart     = (bulletListStart | enumListStart) ~ ws.min(1)
@@ -214,7 +214,7 @@ object ListParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists]].
     */
-  lazy val fieldList: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  lazy val fieldList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val nameParser = ":" ~> recParsers.escapedUntil(':').line <~ (lookAhead(eol).as("") | " ")
 
     val name    = recParsers.recursiveSpans(nameParser)
@@ -229,7 +229,7 @@ object ListParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#option-lists]].
     */
-  lazy val optionList: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  lazy val optionList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val optionString = someOf(CharGroup.alphaNum.add('_').add('-'))
     val optionArg    = optionString | ("<" ~> delimitedBy('>')).map { "<" + _ + ">" }
 
@@ -261,7 +261,7 @@ object ListParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#line-blocks]].
     */
-  lazy val lineBlock: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  lazy val lineBlock: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val itemStart = oneOf('|')
 
     val line: Parser[Int ~ Line] =

--- a/core/shared/src/main/scala/laika/rst/TableParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/TableParsers.scala
@@ -18,7 +18,7 @@ package laika.rst
 
 import cats.data.NonEmptyChain
 import laika.ast._
-import laika.bundle.{ BlockParser, BlockParserBuilder }
+import laika.bundle.BlockParserBuilder
 import laika.collection.Stack
 import laika.collection.TransitionalCollectionOps.Zip3Iterator
 import laika.parse.builders._
@@ -216,7 +216,7 @@ object TableParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables]].
     */
-  lazy val gridTable: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  lazy val gridTable: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val intersectChar = '+'
     val intersect     = oneOf(intersectChar).as(Intersection)
 
@@ -311,7 +311,7 @@ object TableParsers {
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables]].
     */
-  lazy val simpleTable: BlockParserBuilder = BlockParser.recursive { recParsers =>
+  lazy val simpleTable: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val intersect   = someOf(' ').count
     val tableBorder = someOf('=').count
     val columnSpec  = tableBorder ~ opt(intersect) ^^ {

--- a/core/shared/src/main/scala/laika/rst/bundle/RstExtensionSupport.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/RstExtensionSupport.scala
@@ -47,7 +47,7 @@ class RstExtensionSupport(
     Seq(new RewriteRules(textRoles))
   }
 
-  override lazy val parsers: ParserBundle = ParserBundle(
+  override lazy val parsers: ParserBundle = new ParserBundle(
     blockParsers = Seq(
       ExtensionParsers.allBlocks(blockDirectives, spanDirectives, textRoles, defaultTextRole)
     ),

--- a/core/shared/src/main/scala/laika/rst/ext/ExtensionParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/ext/ExtensionParsers.scala
@@ -17,7 +17,7 @@
 package laika.rst.ext
 
 import laika.ast._
-import laika.bundle.{ BlockParser, BlockParserBuilder }
+import laika.bundle.BlockParserBuilder
 import laika.parse.markup.RecursiveParsers
 import laika.parse.text.{ DelimitedText, PrefixedParser }
 import laika.parse.builders._
@@ -322,7 +322,7 @@ object ExtensionParsers {
       spanDirectives: Seq[Directive[Span]],
       textRoles: Seq[TextRole],
       defaultTextRole: String
-  ): BlockParserBuilder = BlockParser.recursive { recParsers =>
+  ): BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     new ExtensionParsers(
       recParsers,
       RstExtension.createAsMap(blockDirectives, recParsers),

--- a/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
+++ b/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
@@ -39,7 +39,7 @@ object BundleProvider {
       origin: BundleOrigin = BundleOrigin.User
   ): ExtensionBundle = new TestExtensionBundle(origin) {
 
-    override def parsers: ParserBundle = ParserBundle(
+    override def parsers: ParserBundle = new ParserBundle(
       blockParsers = blockParsers,
       spanParsers = spanParsers
     )
@@ -53,9 +53,9 @@ object BundleProvider {
       origin: BundleOrigin = BundleOrigin.User
   ): ExtensionBundle = new TestExtensionBundle(origin) {
 
-    override def parsers: ParserBundle = ParserBundle(
+    override def parsers: ParserBundle = new ParserBundle(
       markupParserHooks = Some(
-        ParserHooks(
+        new ParserHooks(
           postProcessBlocks = postProcessBlocks,
           postProcessDocument = postProcessDocument,
           preProcessInput = preProcessInput
@@ -70,7 +70,7 @@ object BundleProvider {
       origin: BundleOrigin = BundleOrigin.User
   ): TestExtensionBundle = new TestExtensionBundle(origin) {
 
-    override def parsers: ParserBundle = ParserBundle(
+    override def parsers: ParserBundle = new ParserBundle(
       configProvider = Some(provider)
     )
 
@@ -142,7 +142,7 @@ object BundleProvider {
       origin: BundleOrigin = BundleOrigin.User
   ): ExtensionBundle = new TestExtensionBundle(origin) {
 
-    override def parsers: ParserBundle = ParserBundle(
+    override def parsers: ParserBundle = new ParserBundle(
       templateParser = Some(parser)
     )
 
@@ -167,7 +167,7 @@ object BundleProvider {
       origin: BundleOrigin = BundleOrigin.User
   ): ExtensionBundle = new TestExtensionBundle(origin) {
 
-    override def parsers: ParserBundle = ParserBundle(
+    override def parsers: ParserBundle = new ParserBundle(
       styleSheetParser = Some(parser)
     )
 

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -91,7 +91,7 @@ class BlockParserConfigSpec extends FunSuite with ParserSetup {
   def blockFor(deco: Char): BlockParserBuilder = blockFor(deco, deco)
 
   def blockFor(deco: Char, overrideDeco: Char): BlockParserBuilder =
-    BlockParser.withSpans { spanParsers =>
+    BlockParserBuilder.withSpans { spanParsers =>
       builders.oneOf(deco) ~> spanParsers.recursiveSpans(defaultTextBlockParser).map(
         DecoratedBlock(overrideDeco, _)
       )
@@ -145,7 +145,7 @@ class BlockParserConfigSpec extends FunSuite with ParserSetup {
 
     val bundle = BundleProvider.forMarkupParser(blockParsers =
       Seq(
-        BlockParser.standalone(literal("+").map(_ => Rule())).withLowPrecedence
+        BlockParserBuilder.standalone(literal("+").map(_ => Rule())).withLowPrecedence
       )
     )
 
@@ -163,7 +163,7 @@ class SpanParserConfigSpec extends FunSuite with ParserSetup {
 
   val input = ">aaa +bbb"
 
-  val blockParsers: Seq[BlockParserBuilder] = Seq(BlockParser.withSpans { spanParsers =>
+  val blockParsers: Seq[BlockParserBuilder] = Seq(BlockParserBuilder.withSpans { spanParsers =>
     spanParsers.recursiveSpans(defaultTextBlockParser).map(Paragraph(_))
   })
 
@@ -176,7 +176,7 @@ class SpanParserConfigSpec extends FunSuite with ParserSetup {
   def spanFor(deco: Char): SpanParserBuilder = spanFor(deco, deco)
 
   def spanFor(deco: Char, overrideDeco: Char): SpanParserBuilder =
-    SpanParser.standalone {
+    SpanParserBuilder.standalone {
       (deco.toString ~> anyNot(' ') <~ opt(" ")).map(DecoratedSpan(overrideDeco, _))
     }
 
@@ -237,7 +237,7 @@ class SpanParserConfigSpec extends FunSuite with ParserSetup {
 
     val bundle = BundleProvider.forMarkupParser(spanParsers =
       Seq(
-        SpanParser.standalone(literal("+").map(Text(_))).withLowPrecedence
+        SpanParserBuilder.standalone(literal("+").map(Text(_))).withLowPrecedence
       )
     )
 
@@ -253,7 +253,7 @@ class ParserHookSpec extends FunSuite with ParserSetup {
 
   def parserBuilder(bundles: ExtensionBundle*): laika.api.builder.ParserBuilder = MarkupParser.of(
     createParser(
-      blocks = Seq(BlockParser.standalone {
+      blocks = Seq(BlockParserBuilder.standalone {
         TextParsers.textLine.map(Paragraph(_))
       }),
       bundles = bundles

--- a/core/shared/src/test/scala/laika/directive/BlockDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/BlockDirectiveAPISpec.scala
@@ -21,7 +21,7 @@ import laika.api.RenderPhaseRewrite
 import laika.ast.Path.Root
 import laika.ast._
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
-import laika.bundle.{ BlockParser, BlockParserBuilder, ParserBundle }
+import laika.bundle.{ BlockParserBuilder, ParserBundle }
 import laika.config.ConfigBuilder
 import laika.directive.std.StandardDirectives
 import laika.format.HTML
@@ -183,7 +183,7 @@ class BlockDirectiveAPISpec extends FunSuite
       Nil
     ).parsers
 
-    lazy val paragraphParser: BlockParserBuilder = BlockParser.recursive { recParser =>
+    lazy val paragraphParser: BlockParserBuilder = BlockParserBuilder.recursive { recParser =>
       recParser.recursiveSpans((Parsers.not(blankLine) ~> restOfLine).rep.min(1).mkLines.line) ^^ {
         Paragraph(_)
       }

--- a/core/shared/src/test/scala/laika/parse/markup/RootParserProvider.scala
+++ b/core/shared/src/test/scala/laika/parse/markup/RootParserProvider.scala
@@ -26,7 +26,7 @@ object RootParserProvider {
   def forParsers(
       blockParsers: Seq[BlockParserBuilder] = Nil,
       spanParsers: Seq[SpanParserBuilder] = Nil,
-      markupExtensions: MarkupExtensions = ParserBundle().markupExtensions
+      markupExtensions: MarkupExtensions = new ParserBundle().markupExtensions
   ): RootParserWrapper = {
 
     val bp = blockParsers

--- a/core/shared/src/test/scala/laika/rst/BlockParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/BlockParsersSpec.scala
@@ -19,7 +19,7 @@ package laika.rst
 import laika.api.builder.OperationConfig
 import laika.ast._
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
-import laika.bundle.{ BlockParser, BundleProvider }
+import laika.bundle.{ BlockParserBuilder, BundleProvider }
 import laika.format.ReStructuredText
 import laika.parse.Parser
 import laika.parse.markup.RootParser
@@ -31,7 +31,7 @@ class BlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
   private val interruptions = BundleProvider.forMarkupParser(
     blockParsers = Seq(
-      BlockParser
+      BlockParserBuilder
         .standalone(TextParsers.literal("£££").as(PageBreak()))
         .interruptsParagraphWith(TextParsers.literal("£££"))
     )

--- a/core/shared/src/test/scala/laika/rst/TableParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/TableParsersSpec.scala
@@ -26,7 +26,7 @@ import munit.FunSuite
 
 class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
 
-  val rootParser = new RootParser(ReStructuredText, ParserBundle().markupExtensions)
+  val rootParser = new RootParser(ReStructuredText, new ParserBundle().markupExtensions)
   val defaultParser: Parser[RootElement] = rootParser.rootElement
 
   def textRow(cells: String*): Row = Row(cells.map(BodyCell(_)))

--- a/core/shared/src/test/scala/laika/rst/ext/ExtensionProvider.scala
+++ b/core/shared/src/test/scala/laika/rst/ext/ExtensionProvider.scala
@@ -51,11 +51,11 @@ object RootParserProvider {
 
   def forBundle(bundle: ExtensionBundle): RootParserWrapper = {
     val finalBundle      = bundle.processExtension(RstExtensionSupport)
-    val markupExtensions = MarkupExtensions(
+    val markupExtensions = new MarkupExtensions(
       blockParsers = finalBundle.parsers.blockParsers,
       spanParsers = finalBundle.parsers.spanParsers,
       syntaxHighlighters = Nil,
-      parserHooks = ParserHooks(postProcessBlocks = LinkTargetProcessor)
+      parserHooks = new ParserHooks(postProcessBlocks = LinkTargetProcessor)
     )
     new RootParserWrapper(ReStructuredText, markupExtensions)
   }

--- a/docs/src/05-extending-laika/06-adding-syntax-highlighters.md
+++ b/docs/src/05-extending-laika/06-adding-syntax-highlighters.md
@@ -379,7 +379,7 @@ case object MyExtensions extends ExtensionBundle {
   
   val description: String = "Foo Syntax Highlighter"
   
-  override def parsers: ParserBundle = ParserBundle(
+  override def parsers: ParserBundle = new ParserBundle(
     syntaxHighlighters = Seq(
       FooHighlighter
     )

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -562,7 +562,7 @@ class TreeParserSpec
     def spanFor(deco: Char): SpanParserBuilder = spanFor(deco, deco)
 
     def spanFor(deco: Char, overrideDeco: Char): SpanParserBuilder =
-      SpanParser.standalone {
+      SpanParserBuilder.standalone {
         (deco.toString ~> anyNot(' ')).map(DecoratedSpan(overrideDeco, _))
       }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.2")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.1")
 
-addSbtPlugin("org.planet42" % "laika-sbt" % "0.19.2")
+addSbtPlugin("org.planet42" % "laika-sbt" % "0.19.3")
 
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.5.0-RC4")


### PR DESCRIPTION
This is the second PR for #452.

The PR covers the packages `laika.bundle`, `laika.directive`, `laika.parse.directive`  and prepares them for long-term binary compatibility.

**`laika.bundle`**

These are the types referenced by `laika.bundle.ExtensionBundle` which means most types remain public. Like with other builder APIs, constructors have been made private when they don't serve as an entry point. 

There is also some cleanup around a confusing split of related types. Previously there was `SpanParser`, `SpanParserBuilderOps` and `SpanParserBuilder` which have all been collapsed into the latter. The same applies to `BlockParserBuilder`.

Finally, some case classes have been converted to regular classes.

**`laika.directive`**

These are the APIs for defining new directives. Here the public combinator APIs and the private processing is a bit intertwined, so that the types had to be kept together with internal types receiving package-private modifiers.

**`laika.parse.directive`**

The entire package is now treated as an implementation detail and no longer public. Only exception is the object `ConfigHeaderParser` which will move to `laika.bundle` in a later milestone to avoid a package with a single public type.
