### PR TITLE
shrink public API surface - config API & Hocon parser

### DIFF
--- a/core/shared/src/main/scala/laika/config/Config.scala
+++ b/core/shared/src/main/scala/laika/config/Config.scala
@@ -168,10 +168,10 @@ trait Config {
 
 /** The default implementation of the Config API.
   */
-class ObjectConfig(
-    private[laika] val root: ObjectValue,
+private[laika] class ObjectConfig(
+    val root: ObjectValue,
     val origin: Origin,
-    private[laika] val fallback: Config = EmptyConfig
+    val fallback: Config = EmptyConfig
 ) extends Config {
 
   private def lookup(
@@ -237,7 +237,7 @@ class ObjectConfig(
 
 /** An empty configuration instance.
   */
-object EmptyConfig extends Config {
+private[config] object EmptyConfig extends Config {
 
   val origin: Origin = Origin.root
 
@@ -254,7 +254,7 @@ object Config {
 
   type ConfigResult[T] = Either[ConfigError, T]
 
-  type IncludeMap = Map[IncludeResource, Either[ConfigError, ObjectBuilderValue]]
+  private[laika] type IncludeMap = Map[IncludeResource, Either[ConfigError, ObjectBuilderValue]]
 
   val empty: Config = EmptyConfig
 

--- a/core/shared/src/main/scala/laika/config/ConfigBuilder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigBuilder.scala
@@ -27,7 +27,7 @@ import laika.collection.TransitionalCollectionOps._
   *
   * @author Jens Halm
   */
-class ConfigBuilder(fields: Seq[Field], origin: Origin, fallback: Config = EmptyConfig) {
+class ConfigBuilder private (fields: Seq[Field], origin: Origin, fallback: Config = EmptyConfig) {
 
   /** Returns a new builder instance adding the specified value to the existing set of values.
     */

--- a/core/shared/src/main/scala/laika/parse/hocon/ConfigBuilderValue.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/ConfigBuilderValue.scala
@@ -27,61 +27,67 @@ import laika.parse.Failure
   *
   * @author Jens Halm
   */
-sealed trait ConfigBuilderValue extends Product with Serializable
+private[laika] sealed trait ConfigBuilderValue extends Product with Serializable
 
 /** A concatenated value (either all objects, all arrays, all simple values or invalid). */
-case class ConcatValue(first: ConfigBuilderValue, rest: Seq[ConcatPart])
+private[laika] case class ConcatValue(first: ConfigBuilderValue, rest: Seq[ConcatPart])
     extends ConfigBuilderValue {
   val allParts: Seq[ConcatPart] = ConcatPart("", first) +: rest
 }
 
 /** A single part of a concatenated value with the whitespace between this and the previous value preserved. */
-case class ConcatPart(whitespace: String, value: ConfigBuilderValue)
+private[laika] case class ConcatPart(whitespace: String, value: ConfigBuilderValue)
 
 /** A merged value with "last one wins" semantics for the provided values (objects will be merged instead). */
-case class MergedValue(values: Seq[ConfigBuilderValue]) extends ConfigBuilderValue
+private[laika] case class MergedValue(values: Seq[ConfigBuilderValue]) extends ConfigBuilderValue
 
 /** A substitution reference that may be marked as optional. */
-case class SubstitutionValue(ref: Key, optional: Boolean) extends ConfigBuilderValue
+private[laika] case class SubstitutionValue(ref: Key, optional: Boolean) extends ConfigBuilderValue
 
-object SubstitutionValue {
+private[laika] object SubstitutionValue {
   def apply(ref: String, optional: Boolean): SubstitutionValue = apply(Key(ref), optional)
 }
 
-sealed trait StringBuilderValue extends ConfigBuilderValue {
+private[laika] sealed trait StringBuilderValue extends ConfigBuilderValue {
   def value: String
 }
 
-case class ValidStringValue(value: String)                     extends StringBuilderValue
-case class InvalidStringValue(value: String, failure: Failure) extends StringBuilderValue
+private[laika] case class ValidStringValue(value: String) extends StringBuilderValue
+
+private[laika] case class InvalidStringValue(value: String, failure: Failure)
+    extends StringBuilderValue
 
 /** A marker for a self reference, a reference to an earlier definition with the same key. */
-case object SelfReference extends ConfigBuilderValue
+private[laika] case object SelfReference extends ConfigBuilderValue
 
 /** An array value with all its elements. */
-case class ArrayBuilderValue(values: Seq[ConfigBuilderValue]) extends ConfigBuilderValue
+private[laika] case class ArrayBuilderValue(values: Seq[ConfigBuilderValue])
+    extends ConfigBuilderValue
 
 /** An object value with all its fields. */
-case class ObjectBuilderValue(values: Seq[BuilderField]) extends ConfigBuilderValue
+private[laika] case class ObjectBuilderValue(values: Seq[BuilderField]) extends ConfigBuilderValue
 
 /** A single field of an object value. */
-case class BuilderField(key: Either[InvalidStringValue, Key], value: ConfigBuilderValue) {
+private[laika] case class BuilderField(
+    key: Either[InvalidStringValue, Key],
+    value: ConfigBuilderValue
+) {
   def validKey: Key = key.getOrElse(Key.root)
 }
 
-object BuilderField {
+private[laika] object BuilderField {
   def apply(key: String, value: ConfigBuilderValue): BuilderField = apply(Right(Key(key)), value)
   def apply(key: Key, value: ConfigBuilderValue): BuilderField    = apply(Right(key), value)
 }
 
-case class InvalidBuilderValue(value: ConfigBuilderValue, failure: Failure)
+private[laika] case class InvalidBuilderValue(value: ConfigBuilderValue, failure: Failure)
     extends ConfigBuilderValue
 
 /** A simple configuration value that does not need to be recursively resolved. */
-case class ResolvedBuilderValue(value: SimpleConfigValue) extends ConfigBuilderValue
+private[laika] case class ResolvedBuilderValue(value: SimpleConfigValue) extends ConfigBuilderValue
 
 /** Description of a resource to be included in the current configuration. */
-sealed trait IncludeResource {
+private[laika] sealed trait IncludeResource {
   def resourceId: StringBuilderValue
   def isRequired: Boolean
 
@@ -94,16 +100,18 @@ sealed trait IncludeResource {
 
 }
 
-case class IncludeUrl(resourceId: StringBuilderValue, isRequired: Boolean = false)
+private[laika] case class IncludeUrl(resourceId: StringBuilderValue, isRequired: Boolean = false)
     extends IncludeResource
 
-case class IncludeFile(resourceId: StringBuilderValue, isRequired: Boolean = false)
+private[laika] case class IncludeFile(resourceId: StringBuilderValue, isRequired: Boolean = false)
     extends IncludeResource
 
-case class IncludeClassPath(resourceId: StringBuilderValue, isRequired: Boolean = false)
+private[laika] case class IncludeClassPath(
+    resourceId: StringBuilderValue,
+    isRequired: Boolean = false
+) extends IncludeResource
+
+private[laika] case class IncludeAny(resourceId: StringBuilderValue, isRequired: Boolean = false)
     extends IncludeResource
 
-case class IncludeAny(resourceId: StringBuilderValue, isRequired: Boolean = false)
-    extends IncludeResource
-
-case class IncludeBuilderValue(resource: IncludeResource) extends ConfigBuilderValue
+private[laika] case class IncludeBuilderValue(resource: IncludeResource) extends ConfigBuilderValue

--- a/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
@@ -37,7 +37,7 @@ import scala.collection.mutable
   *
   * @author Jens Halm
   */
-object ConfigResolver {
+private[laika] object ConfigResolver {
 
   /** Translates the interim configuration model (usually obtained from a HOCON parser)
     * into the final object model. It turns a root `ObjectBuilderValue` into

--- a/core/shared/src/main/scala/laika/parse/hocon/HoconParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/HoconParsers.scala
@@ -24,7 +24,7 @@ import laika.parse.code.common.NumberLiteral.DigitParsers
 import laika.parse.text.{ CharGroup, Characters }
 import laika.parse.builders._
 import laika.parse.implicits._
-import laika.parse.{ Failure, Message, Parser, SourceCursor, Success }
+import laika.parse.{ Failure, Message, Parser, SourceCursor }
 
 import scala.annotation.nowarn
 import scala.util.Try
@@ -36,11 +36,7 @@ import scala.util.Try
   *
   * @author Jens Halm
   */
-object HoconParsers {
-
-  val consumeAllInput: Parser[Unit] = Parser { in =>
-    Success((), in.consume(in.remaining))
-  }
+private[laika] object HoconParsers {
 
   implicit class ClosingParserOps[T](parser: Parser[T]) {
 
@@ -61,7 +57,7 @@ object HoconParsers {
 
   }
 
-  def failWith[T](fallbackParser: Parser[Int], msg: => String)(
+  private def failWith[T](fallbackParser: Parser[Int], msg: => String)(
       captureError: Failure => T
   ): Parser[T] = {
 

--- a/core/shared/src/test/scala/laika/parse/hocon/ConfigResolverSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/hocon/ConfigResolverSpec.scala
@@ -26,7 +26,7 @@ class ConfigResolverSpec extends FunSuite with ResultBuilders {
 
   def parseAndResolve(
       input: String,
-      fallback: Config = EmptyConfig,
+      fallback: Config = Config.empty,
       includes: IncludeMap = Map.empty
   ): Either[ConfigError, ObjectValue] = for {
     builder <- ConfigParser.parse(input).unresolved

--- a/core/shared/src/test/scala/laika/parse/hocon/HoconJsonSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/hocon/HoconJsonSpec.scala
@@ -23,9 +23,9 @@ import munit.FunSuite
   */
 class HoconJsonSpec extends FunSuite with ResultBuilders {
 
-  def f(key: String, value: String): BuilderField = BuilderField(key, stringValue(value))
+  private def f(key: String, value: String): BuilderField = BuilderField(key, stringValue(value))
 
-  def result(fields: BuilderField*): Either[String, ObjectBuilderValue] = Right(
+  private def result(fields: BuilderField*): Either[String, ObjectBuilderValue] = Right(
     ObjectBuilderValue(fields)
   )
 

--- a/core/shared/src/test/scala/laika/parse/hocon/HoconParserSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/hocon/HoconParserSpec.scala
@@ -24,7 +24,7 @@ import munit.FunSuite
   */
 class HoconParserSpec extends FunSuite with ResultBuilders {
 
-  def f(key: String, value: String): BuilderField = BuilderField(key, stringValue(value))
+  private def f(key: String, value: String): BuilderField = BuilderField(key, stringValue(value))
 
   private val nestedObject = BuilderField(
     "obj",
@@ -49,11 +49,9 @@ class HoconParserSpec extends FunSuite with ResultBuilders {
 
   def parse(input: String): Either[String, ObjectBuilderValue] = rootObject.parse(input).toEither
 
-  def result(fields: BuilderField*): Either[String, ObjectBuilderValue] = Right(
-    ObjectBuilderValue(fields)
-  )
-
-  def run(input: String, expectedFields: BuilderField*)(implicit loc: munit.Location): Unit =
+  private def run(input: String, expectedFields: BuilderField*)(implicit
+      loc: munit.Location
+  ): Unit =
     assertEquals(parse(input), Right(ObjectBuilderValue(expectedFields)))
 
   test("empty root object that is not enclosed in braces") {


### PR DESCRIPTION
This is the third PR for #452.

This case is really simple: The Hocon parser becomes and implementation detail, removing the entire package `laika.parse.hocon` from public API. The user-facing config API in `laika.config` on the other hand remains almost entirely public apart from some esoteric details which are now hidden.