### PR TITLE
shrink public API surface in laika.theme + laika.helium

### DIFF
--- a/io/src/main/scala/laika/helium/config/HeliumIcon.scala
+++ b/io/src/main/scala/laika/helium/config/HeliumIcon.scala
@@ -52,7 +52,7 @@ object HeliumIcon {
   val github: Icon   = InlineSVGIcon(SVGIcons.githubIcon, Some("Source Code"), Styles("github"))
   val mastodon: Icon = InlineSVGIcon(SVGIcons.mastodonIcon, Some("Mastodon"), Styles("mastodon"))
 
-  val registry: IconRegistry = IconRegistry(
+  private[helium] val registry: IconRegistry = IconRegistry(
     "navigationMenu" -> navigationMenu,
     "home"           -> home,
     "link"           -> link,

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -238,7 +238,7 @@ private[laika] object ConfigGenerator {
 /** Utility for splitting a collection into a balanced group of items as opposed to the unbalanced
   * `grouped` method of the Scala collection API.
   */
-object BalancedGroups {
+private[laika] object BalancedGroups {
 
   /** Creates a balanced group of items based on the given desired size.
     */

--- a/io/src/main/scala/laika/helium/generate/DownloadPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/DownloadPageGenerator.scala
@@ -117,12 +117,7 @@ private[helium] object DownloadPageGenerator {
           RootElement(blocks),
           config = tree.root.config.withValue("helium.markupEditLinks", false).build
         )
-        val newRoot = tree.root.copy(
-          tree = tree.root.tree.copy(
-            content = doc +: tree.root.tree.content
-          )
-        )
-        new ParsedTree(newRoot, tree.staticDocuments)
+        tree.modifyTree(_.prependContent(doc))
       }
 
       Sync[F].fromEither(treeWithDownloadPage.leftMap(ConfigException.apply))

--- a/io/src/main/scala/laika/helium/generate/FOStyles.scala
+++ b/io/src/main/scala/laika/helium/generate/FOStyles.scala
@@ -434,7 +434,7 @@ private[laika] class FOStyles(helium: Helium) {
 
 }
 
-object FOStyles {
+private[laika] object FOStyles {
 
   val defaultPath: Path = Root / "styles.fo.css"
 

--- a/io/src/main/scala/laika/theme/TreeProcessorBuilder.scala
+++ b/io/src/main/scala/laika/theme/TreeProcessorBuilder.scala
@@ -18,7 +18,6 @@ package laika.theme
 
 import cats.Monad
 import cats.data.Kleisli
-import cats.effect.Sync
 import laika.io.model.ParsedTree
 import laika.io.ops.TreeMapperOps
 import laika.theme.Theme.TreeProcessor
@@ -27,7 +26,7 @@ import laika.theme.Theme.TreeProcessor
   *
   * @author Jens Halm
   */
-abstract class TreeProcessorBuilder[F[_]: Monad] extends TreeMapperOps[F] {
+class TreeProcessorBuilder[F[_]: Monad] private () extends TreeMapperOps[F] {
 
   type MapRes = TreeProcessor[F]
 
@@ -38,6 +37,6 @@ abstract class TreeProcessorBuilder[F[_]: Monad] extends TreeMapperOps[F] {
   */
 object TreeProcessorBuilder {
 
-  def apply[F[_]: Sync]: TreeProcessorBuilder[F] = new TreeProcessorBuilder[F] {}
+  def apply[F[_]: Monad]: TreeProcessorBuilder[F] = new TreeProcessorBuilder[F]()
 
 }

--- a/io/src/main/scala/laika/theme/config/Font.scala
+++ b/io/src/main/scala/laika/theme/config/Font.scala
@@ -107,6 +107,8 @@ object Font {
 /** Base trait for the types of embedded fonts Laika supports, which are either a file-system or classpath resource.
   */
 sealed trait EmbeddedFont {
+
+  /** The virtual path within the output tree that the font resource will be placed at. */
   def path: Path
 }
 
@@ -116,7 +118,7 @@ case class EmbeddedFontFile(file: FilePath) extends EmbeddedFont {
   val path: Path = Root / "laika" / "fonts" / file.name
 }
 
-/** Represent a font files as a classpath resource.
+/** Represent a font file as a classpath resource.
   */
 case class EmbeddedFontResource(name: String) extends EmbeddedFont {
   val path: Path = Root / "laika" / "fonts" / VirtualPath.parse(name).name


### PR DESCRIPTION
This is the fifth PR for #452.

It covers packages `laika.theme` and `laika.helium`.

This one only has minimal changes as these are newer APIs which had already been designed with binary compatibility in mind. Here we only correct a few minor oversights.