### PR TITLE
shrink public API surface in sbt plugin and preview server

### DIFF
--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -179,7 +179,7 @@ private[preview] object SiteTransformer {
 
 }
 
-class SiteResults[F[_]](map: Map[Path, SiteResult[F]]) {
+private[preview] class SiteResults[F[_]](map: Map[Path, SiteResult[F]]) {
 
   def get(path: Path): Option[SiteResult[F]] = map.get(path)
 
@@ -188,7 +188,9 @@ class SiteResults[F[_]](map: Map[Path, SiteResult[F]]) {
 }
 
 @nowarn
-sealed abstract class SiteResult[F[_]: Async] extends Product with Serializable
+private[preview] sealed abstract class SiteResult[F[_]: Async] extends Product with Serializable
 
-case class RenderedResult[F[_]: Async](content: String)            extends SiteResult[F]
-case class StaticResult[F[_]: Async](content: fs2.Stream[F, Byte]) extends SiteResult[F]
+private[preview] case class RenderedResult[F[_]: Async](content: String) extends SiteResult[F]
+
+private[preview] case class StaticResult[F[_]: Async](content: fs2.Stream[F, Byte])
+    extends SiteResult[F]

--- a/sbt/src/main/scala/laika/sbt/ExtensionBundles.scala
+++ b/sbt/src/main/scala/laika/sbt/ExtensionBundles.scala
@@ -36,7 +36,7 @@ import laika.render.{ FOFormatter, HTMLFormatter }
   *
   * @author Jens Halm
   */
-trait ExtensionBundles {
+private[sbt] trait ExtensionBundles {
 
   /** Create an extension bundle based on the specified custom HTML render function.
     */

--- a/sbt/src/main/scala/laika/sbt/LaikaConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaConfig.scala
@@ -29,7 +29,7 @@ import scala.io.Codec
   *
   * @author Jens Halm
   */
-case class LaikaConfig(
+case class LaikaConfig private (
     encoding: Codec = Codec.UTF8,
     bundleFilter: BundleFilter = BundleFilter(),
     configBuilder: ConfigBuilder = ConfigBuilder.empty,
@@ -106,5 +106,7 @@ object LaikaConfig {
   /** The default settings for the Laika plugin that can be modified with the methods of the returned instance.
     */
   def defaults: LaikaConfig = LaikaConfig()
+
+  private def unapply(conf: LaikaConfig) = conf
 
 }

--- a/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
@@ -157,7 +157,7 @@ object LaikaPlugin extends AutoPlugin {
     laikaConfig                 := LaikaConfig(),
     laikaPreviewConfig          := LaikaPreviewConfig.defaults,
     laikaTheme                  := Helium.defaults.build,
-    laikaDescribe               := Settings.describe.value,
+    laikaDescribe               := Tasks.describe.value,
     laikaIncludeAPI             := false,
     laikaIncludeEPUB            := Settings.validated(
       Settings.parserConfig.value.baseConfig.get[Boolean]("helium.site.includeEPUB", false)

--- a/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
@@ -27,11 +27,11 @@ import scala.concurrent.duration.FiniteDuration
   * @param pollInterval the interval at which input file resources are polled for changes (default 3 seconds)
   * @param isVerbose whether each served page and each detected file change should be logged (default false)
   */
-class LaikaPreviewConfig(
-    val port: Port,
-    val host: Host,
-    val pollInterval: FiniteDuration,
-    val isVerbose: Boolean
+case class LaikaPreviewConfig private (
+    port: Port,
+    host: Host,
+    pollInterval: FiniteDuration,
+    isVerbose: Boolean
 ) {
 
   private def copy(
@@ -61,7 +61,7 @@ class LaikaPreviewConfig(
 
 }
 
-/** Companion for preview server configuration instances.
+/** Companion for creating preview server configuration instances.
   */
 object LaikaPreviewConfig {
 
@@ -72,5 +72,7 @@ object LaikaPreviewConfig {
     ServerConfig.defaultPollInterval,
     false
   )
+
+  private def unapply(conf: LaikaPreviewConfig) = conf
 
 }

--- a/sbt/src/main/scala/laika/sbt/Logs.scala
+++ b/sbt/src/main/scala/laika/sbt/Logs.scala
@@ -26,7 +26,7 @@ import sbt.Logger
   *
   * @author Jens Halm
   */
-object Logs {
+private[sbt] object Logs {
 
   def s(num: Int): String = if (num == 1) "" else "s"
 


### PR DESCRIPTION
This is the sixth PR for #452.

It covers the packages `laika.sbt` (the sbt plugin) and `laika.preview` (the preview server).

Changes are fairly minimal here, as both are rather small modules:

* `ServerBuilder` does no longer extend `Http4sDsl` as that was polluting the scaladoc.
* Some model classes in the preview server are now internal.
* Configuration case classes now have private constructors and extractors to enable binary-compatible field additions.
* `describe` moves from `Settings` to `Tasks` as it had been converted from setting to task in an earlier 0.x version.