### PR TITLE
shrink public API surface in EPUB and PDF renderer

### DIFF
--- a/io/src/main/scala/laika/render/epub/ContainerWriter.scala
+++ b/io/src/main/scala/laika/render/epub/ContainerWriter.scala
@@ -30,7 +30,7 @@ import laika.render.TagFormatter
   *
   * @author Jens Halm
   */
-class ContainerWriter {
+private[laika] class ContainerWriter {
 
   private val opfRenderer = new OPFRenderer
   private val navRenderer = new HtmlNavRenderer

--- a/io/src/main/scala/laika/render/epub/HtmlNavRenderer.scala
+++ b/io/src/main/scala/laika/render/epub/HtmlNavRenderer.scala
@@ -25,7 +25,7 @@ import laika.render.epub.StyleSupport.collectStylePaths
   *
   * @author Jens Halm
   */
-class HtmlNavRenderer {
+private[epub] class HtmlNavRenderer {
 
   /** Inserts the specified (pre-rendered) navPoints into the NCX document template
     * and returns the content of the entire NCX file.

--- a/io/src/main/scala/laika/render/epub/MimeTypes.scala
+++ b/io/src/main/scala/laika/render/epub/MimeTypes.scala
@@ -21,7 +21,7 @@ package laika.render.epub
   *
   * @author Jens Halm
   */
-object MimeTypes {
+private[epub] object MimeTypes {
 
   /** Maps files suffixes to mime types.
     */

--- a/io/src/main/scala/laika/render/epub/NCXRenderer.scala
+++ b/io/src/main/scala/laika/render/epub/NCXRenderer.scala
@@ -26,7 +26,7 @@ import laika.render.TagFormatter
   *
   * @author Jens Halm
   */
-class NCXRenderer {
+private[epub] class NCXRenderer {
 
   /** Inserts the specified (pre-rendered) navPoints into the NCX document template
     * and returns the content of the entire NCX file.

--- a/io/src/main/scala/laika/render/epub/NavigationBuilder.scala
+++ b/io/src/main/scala/laika/render/epub/NavigationBuilder.scala
@@ -20,7 +20,7 @@ import laika.ast.Path.Root
 import laika.ast.{ InternalTarget, _ }
 import laika.io.model.RenderedTree
 
-object NavigationBuilder {
+private[epub] object NavigationBuilder {
 
   /** Provides the full path to the document relative to the EPUB container root
     * from the specified virtual path of the Laika document tree.

--- a/io/src/main/scala/laika/render/epub/OPFRenderer.scala
+++ b/io/src/main/scala/laika/render/epub/OPFRenderer.scala
@@ -26,7 +26,7 @@ import laika.rewrite.link.SlugBuilder
   *
   * @author Jens Halm
   */
-class OPFRenderer {
+private[epub] class OPFRenderer {
 
   /** Inserts the specified spine references into the OPF document template
     * and returns the content of the entire OPF file.

--- a/io/src/main/scala/laika/render/epub/StaticContent.scala
+++ b/io/src/main/scala/laika/render/epub/StaticContent.scala
@@ -20,7 +20,7 @@ package laika.render.epub
   *
   * @author Jens Halm
   */
-object StaticContent {
+private[epub] object StaticContent {
 
   /** The content of the `mimetype` file in the EPUB root directory.
     */

--- a/io/src/main/scala/laika/render/epub/StyleSupport.scala
+++ b/io/src/main/scala/laika/render/epub/StyleSupport.scala
@@ -23,12 +23,7 @@ import laika.io.model.RenderedTreeRoot
   *
   * @author Jens Halm
   */
-object StyleSupport {
-
-  /** Path for the fallback styles that will be inserted
-    * when the user has not added any CSS documents to the input tree.
-    */
-  val fallbackStylePath: Path = Path.Root / "styles" / "fallback.css"
+private[epub] object StyleSupport {
 
   /** Collects all CSS inputs (recursively) in the provided document tree.
     * CSS inputs are recognized by file suffix).

--- a/io/src/main/scala/laika/render/epub/XHTMLRenderer.scala
+++ b/io/src/main/scala/laika/render/epub/XHTMLRenderer.scala
@@ -23,7 +23,7 @@ import laika.render.{ HTMLFormatter, HTMLRenderer }
   *
   *  @author Jens Halm
   */
-object XHTMLRenderer extends HTMLRenderer(format = "epub") {
+private[laika] object XHTMLRenderer extends HTMLRenderer(format = "epub") {
 
   def renderChoices(
       fmt: HTMLFormatter,

--- a/io/src/main/scala/laika/render/epub/ZipWriter.scala
+++ b/io/src/main/scala/laika/render/epub/ZipWriter.scala
@@ -25,7 +25,7 @@ import java.io.OutputStream
 
 /** @author Jens Halm
   */
-object ZipWriter {
+private[epub] object ZipWriter {
 
   /** Writes an EPUB Zip file to the specified output.
     * The virtual path of the given inputs will also become the path within

--- a/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
@@ -32,7 +32,7 @@ import laika.rewrite.{ DefaultTemplatePath, OutputContext }
   *
   * @author Jens Halm
   */
-object FOConcatenation {
+private[laika] object FOConcatenation {
 
   /** Concatenates the XSL-FO that serves as a basis for producing the final PDF output
     * and applies the default XSL-FO template to the entire result.

--- a/pdf/src/main/scala/laika/render/pdf/FopFactoryBuilder.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FopFactoryBuilder.scala
@@ -28,7 +28,7 @@ import org.apache.fop.apps.{ FopConfParser, FopFactory }
   *
   * @author Jens Halm
   */
-object FopFactoryBuilder {
+private[laika] object FopFactoryBuilder {
 
   def generateXMLConfig(config: PDF.BookConfig): String = {
     // since there is no API to define fonts for Apache FOP we have to generate configuration XML here

--- a/pdf/src/main/scala/laika/render/pdf/FopResourceResolver.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FopResourceResolver.scala
@@ -38,8 +38,10 @@ import org.apache.xmlgraphics.io.{ Resource, ResourceResolver }
   *
   * @author Jens Halm
   */
-class FopResourceResolver[F[_]: Async](input: Seq[BinaryInput[F]], dispatcher: Dispatcher[F])
-    extends ResourceResolver {
+private[pdf] class FopResourceResolver[F[_]: Async](
+    input: Seq[BinaryInput[F]],
+    dispatcher: Dispatcher[F]
+) extends ResourceResolver {
 
   private val fallbackResolver = ResourceResolverFactory.createDefaultResourceResolver()
 

--- a/pdf/src/main/scala/laika/render/pdf/PDFNavigation.scala
+++ b/pdf/src/main/scala/laika/render/pdf/PDFNavigation.scala
@@ -23,7 +23,7 @@ import laika.io.model.RenderedTreeRoot
   *
   * @author Jens Halm
   */
-object PDFNavigation {
+private[pdf] object PDFNavigation {
 
   /** Generates bookmarks for the structure of the DocumentTree.
     *

--- a/pdf/src/main/scala/laika/render/pdf/PDFRenderer.scala
+++ b/pdf/src/main/scala/laika/render/pdf/PDFRenderer.scala
@@ -34,7 +34,7 @@ import org.apache.xmlgraphics.util.MimeConstants
   *
   * @author Jens Halm
   */
-class PDFRenderer[F[_]: Async](fopFactory: FopFactory, dispatcher: Dispatcher[F]) {
+private[laika] class PDFRenderer[F[_]: Async](fopFactory: FopFactory, dispatcher: Dispatcher[F]) {
 
   /** Render the given XSL-FO input as a PDF to the specified binary output.
     *


### PR DESCRIPTION
This is the seventh PR for #452.

It covers the packages `laika.render.epub` and `laika.render.pdf`.

This is the simplest and most radical change so far. It simply removes both packages entirely from the public API.

Implementation details for the renderers can safely be categorized as internal in nature. The user-facing APIs are covered by the types `laika.format.PDF` and `laika.format.EPUB` respectively, which are used to specify the render target for a `Renderer` or `Transformer`. Configuration happens centrally through types in `laika.config`. Therefore, the actual render implementations are not needed from the user perspective and evolving Laika past 1.0 will be easier without committing to API stability for those.