### PR TITLE
shrink public API surface in core runtime

### DIFF
--- a/core/shared/src/main/scala/laika/render/ASTRenderer.scala
+++ b/core/shared/src/main/scala/laika/render/ASTRenderer.scala
@@ -22,7 +22,7 @@ import laika.ast._
   *
   * @author Jens Halm
   */
-object ASTRenderer extends ((TextFormatter, Element) => String) {
+private[laika] object ASTRenderer extends ((TextFormatter, Element) => String) {
 
   /**  The maximum width of a single text element.
     *  For any text that exceeds this limit only the beginning
@@ -31,7 +31,7 @@ object ASTRenderer extends ((TextFormatter, Element) => String) {
     *  for the majority of cases where primarily the document
     *  structure is relevant.
     */
-  val maxTextWidth = 50
+  private val maxTextWidth = 50
 
   private case class Content(content: Seq[Element], desc: String, options: Options = NoOpt)
       extends Element with ElementContainer[Element] {

--- a/core/shared/src/main/scala/laika/render/FOProperties.scala
+++ b/core/shared/src/main/scala/laika/render/FOProperties.scala
@@ -21,7 +21,7 @@ package laika.render
   *
   *  @author Jens Halm
   */
-trait FOProperties {
+private[laika] trait FOProperties {
 
   private val border = Set(
     "border",
@@ -338,7 +338,7 @@ trait FOProperties {
 
 }
 
-object FOProperties {
+private[laika] object FOProperties {
 
   /* https://www.w3.org/TR/xsl11/#prtab1 */
   private val inherited = Set(

--- a/core/shared/src/main/scala/laika/render/FORenderer.scala
+++ b/core/shared/src/main/scala/laika/render/FORenderer.scala
@@ -25,7 +25,7 @@ import laika.rst.ast.{ Line, LineBlock }
   *
   * @author Jens Halm
   */
-object FORenderer extends ((FOFormatter, Element) => String) {
+private[laika] object FORenderer extends ((FOFormatter, Element) => String) {
 
   private val formats: NonEmptySet[String] = NonEmptySet.of("pdf", "fo", "xslfo", "xsl-fo")
 

--- a/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
@@ -22,7 +22,7 @@ import laika.ast._
   *
   * @author Jens Halm
   */
-class HTMLRenderer(format: String)
+private[laika] class HTMLRenderer(format: String)
     extends ((HTMLFormatter, Element) => String) {
 
   def apply(fmt: HTMLFormatter, element: Element): String = {
@@ -387,4 +387,4 @@ class HTMLRenderer(format: String)
 
 }
 
-object HTMLRenderer extends HTMLRenderer(format = "html")
+private[laika] object HTMLRenderer extends HTMLRenderer(format = "html")

--- a/core/shared/src/main/scala/laika/render/TagFormatter.scala
+++ b/core/shared/src/main/scala/laika/render/TagFormatter.scala
@@ -43,7 +43,7 @@ abstract class TagFormatter[Rep <: BaseFormatter[Rep]](
   type StyleHint
 
   /** Renders the specified string on the same line,
-    *  with all special XML/HTML characters converted to entities.
+    * with all special XML/HTML characters converted to entities.
     */
   def text(str: String): String = TagFormatter.escape(str, newLine)
 
@@ -128,7 +128,7 @@ abstract class TagFormatter[Rep <: BaseFormatter[Rep]](
 
 }
 
-object TagFormatter {
+private[laika] object TagFormatter {
 
   /** Replaces all special XML/HTML characters with entities. */
   def escape(str: String, newLine: String = "\n"): String = {

--- a/core/shared/src/main/scala/laika/render/TextFormatter.scala
+++ b/core/shared/src/main/scala/laika/render/TextFormatter.scala
@@ -29,7 +29,7 @@ import laika.factory.RenderContext
   *
   * @author Jens Halm
   */
-case class TextFormatter(
+class TextFormatter private[render] (
     renderChild: (TextFormatter, Element) => String,
     currentElement: Element,
     parents: List[Element],
@@ -42,27 +42,18 @@ case class TextFormatter(
     ) {
 
   protected def withChild(element: Element): TextFormatter =
-    copy(parents = currentElement :: parents, currentElement = element)
+    new TextFormatter(renderChild, element, currentElement :: parents, indentation)
 
   protected def withIndentation(newIndentation: Indentation): TextFormatter =
-    copy(indentation = newIndentation)
-
-}
-
-/** Default factory for TextFormatters, based on a provided RenderContext.
-  */
-object TextFormatter extends (RenderContext[TextFormatter] => TextFormatter) {
-
-  def apply(context: RenderContext[TextFormatter]): TextFormatter =
-    TextFormatter(context.renderChild, context.root, Nil, context.indentation)
+    new TextFormatter(renderChild, currentElement, parents, newIndentation)
 
 }
 
 /** Default factory for ASTFormatters, based on a provided RenderContext.
   */
-object ASTFormatter extends (RenderContext[TextFormatter] => TextFormatter) {
+private[laika] object ASTFormatter extends (RenderContext[TextFormatter] => TextFormatter) {
 
   def apply(context: RenderContext[TextFormatter]): TextFormatter =
-    TextFormatter(context.renderChild, context.root, Nil, Indentation.dotted)
+    new TextFormatter(context.renderChild, context.root, Nil, Indentation.dotted)
 
 }

--- a/core/shared/src/main/scala/laika/rewrite/DefaultTemplatePath.scala
+++ b/core/shared/src/main/scala/laika/rewrite/DefaultTemplatePath.scala
@@ -27,7 +27,7 @@ object DefaultTemplatePath {
 
   private val base: Path = Root / "default"
 
-  def forSuffix(suffix: String): Path = base.withSuffix(s"template.$suffix")
+  private[laika] def forSuffix(suffix: String): Path = base.withSuffix(s"template.$suffix")
 
   def forHTML: Path = forSuffix("html")
   def forEPUB: Path = forSuffix("epub.xhtml")

--- a/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
@@ -39,10 +39,9 @@ case class ReferenceResolver(config: Config) {
 
 }
 
-/** Companion for constructing ReferenceResolvers for a particular
-  *  target Document.
+/** Companion for constructing ReferenceResolvers for a particular target Document.
   */
-object ReferenceResolver {
+private[laika] object ReferenceResolver {
 
   object CursorKeys {
 

--- a/core/shared/src/main/scala/laika/rewrite/link/DocumentTargets.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/DocumentTargets.scala
@@ -25,7 +25,7 @@ import scala.annotation.tailrec
   *
   *  @author Jens Halm
   */
-case class DocumentTargets(document: Document, slugBuilder: String => String) {
+private[link] class DocumentTargets(document: Document, slugBuilder: String => String) {
 
   /** Generates symbol identifiers.
     * Contains a predefined list of ten symbols to generate.

--- a/core/shared/src/main/scala/laika/rewrite/link/IconRegistry.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/IconRegistry.scala
@@ -5,7 +5,7 @@ import laika.config.{ ConfigEncoder, DefaultKey, LaikaKeys }
 
 /** Registers Icon AST elements for use with the `@:icon` directive and the `IconReference` AST element.
   */
-case class IconRegistry(icons: Map[String, Icon])
+case class IconRegistry private (icons: Map[String, Icon])
 
 object IconRegistry {
 

--- a/core/shared/src/main/scala/laika/rewrite/link/LinkResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/LinkResolver.scala
@@ -41,7 +41,7 @@ import scala.annotation.tailrec
   *
   *  @author Jens Halm
   */
-class LinkResolver(root: DocumentTreeRoot, slugBuilder: String => String)
+private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String => String)
     extends RewriteRulesBuilder {
 
   val targets = new TreeTargets(root, slugBuilder)

--- a/core/shared/src/main/scala/laika/rewrite/link/Selector.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/Selector.scala
@@ -23,7 +23,7 @@ import laika.ast.Path
   *  from both, the ids rendered in the final document
   *  and the ids used for display.
   */
-sealed trait Selector {
+private[link] sealed trait Selector {
 
   /** Indicates whether this selector is applicable
     * beyond the boundaries of a single document.
@@ -43,14 +43,14 @@ sealed trait Selector {
 
 /** A selector that can be used for a sequence of targets.
   */
-sealed trait SequenceSelector extends Selector {
+private[link] sealed trait SequenceSelector extends Selector {
   val global = false
   val unique = false
 }
 
 /** A selector that can is a globally unique identifier.
   */
-sealed trait UniqueSelector extends Selector {
+private[link] sealed trait UniqueSelector extends Selector {
   val global = true
   val unique = true
   def description: String
@@ -58,30 +58,30 @@ sealed trait UniqueSelector extends Selector {
 
 /** A selector for a rendered target in a document.
   */
-case class TargetIdSelector(id: String) extends UniqueSelector {
+private[link] case class TargetIdSelector(id: String) extends UniqueSelector {
   val description = s"link target with id '$id'"
 }
 
 /** A selector for a definition for an internal or external link.
   */
-case class LinkDefinitionSelector(id: String) extends UniqueSelector {
+private[link] case class LinkDefinitionSelector(id: String) extends UniqueSelector {
   val description = s"link definition with id '$id'"
 }
 
 /** A selector based on a path, optionally including a fragment component.
   */
-case class PathSelector(path: Path) extends UniqueSelector {
+private[link] case class PathSelector(path: Path) extends UniqueSelector {
   val description = s"link target with path '$path'"
 }
 
 /** An anonymous selector (usually matched by position).
   */
-case object AnonymousSelector extends SequenceSelector
+private[link] case object AnonymousSelector extends SequenceSelector
 
 /** An auto-number selector (usually matched by position).
   */
-case object AutonumberSelector extends SequenceSelector
+private[link] case object AutonumberSelector extends SequenceSelector
 
 /** An auto-symbol selector (usually matched by position).
   */
-case object AutosymbolSelector extends SequenceSelector
+private[link] case object AutosymbolSelector extends SequenceSelector

--- a/core/shared/src/main/scala/laika/rewrite/link/TargetResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/TargetResolver.scala
@@ -23,7 +23,7 @@ import laika.rewrite.nav.TargetFormats
 /** Represents the source of a link, its document path
   * and the actual inline span that is representing the link.
   */
-case class LinkSource(span: Span, path: Path)
+private[link] case class LinkSource(span: Span, path: Path)
 
 /** Represents a resolver for a target that has its final identifier generated
   * (if necessary) and can be used to resolve matching reference nodes.
@@ -31,7 +31,7 @@ case class LinkSource(span: Span, path: Path)
   * @param selector the selector to use to identify reference nodes matching this target
   * @param precedence the precedence in comparison to other resolvers with the same selector
   */
-abstract sealed class TargetResolver(
+private[link] abstract sealed class TargetResolver(
     val selector: Selector,
     val targetFormats: TargetFormats = TargetFormats.All,
     val precedence: Int = 0
@@ -53,7 +53,7 @@ abstract sealed class TargetResolver(
 
 }
 
-object ReferenceResolver {
+private[link] object ReferenceResolver {
   def lift(f: PartialFunction[LinkSource, Span]): LinkSource => Option[Span] = f.lift
 
   def internalLink(target: Path): LinkSource => Option[Span] = lift {
@@ -78,14 +78,13 @@ object ReferenceResolver {
 
 }
 
-object TargetReplacer {
+private[link] object TargetReplacer {
   def lift(f: PartialFunction[Block, Block]): Block => Option[Block] = f.lift
   def addId(id: String): Block => Option[Block] = block => Some(block.withId(id))
-  val removeId: Block => Option[Block]          = block => Some(block.withoutId)
   val removeTarget: Block => Option[Block]      = Function.const(None)
 }
 
-object TargetResolver {
+private[link] object TargetResolver {
 
   def create(
       selector: Selector,
@@ -201,7 +200,7 @@ object TargetResolver {
 /** Represents a resolver for a sequence of targets where matching reference nodes get determined by position.
   * The `resolveReference` and `resolveTarget` methods can be invoked as many times as this sequence contains elements.
   */
-case class TargetSequenceResolver(targets: Seq[TargetResolver], sel: Selector)
+private[link] case class TargetSequenceResolver(targets: Seq[TargetResolver], sel: Selector)
     extends TargetResolver(sel) {
   private val refIt    = targets.iterator
   private val targetIt = targets.iterator
@@ -216,7 +215,7 @@ case class TargetSequenceResolver(targets: Seq[TargetResolver], sel: Selector)
 
 }
 
-case class LinkAliasResolver(
+private[link] case class LinkAliasResolver(
     sourceSelector: TargetIdSelector,
     targetSelector: TargetIdSelector,
     referenceResolver: LinkSource => Option[Span],
@@ -241,7 +240,7 @@ case class LinkAliasResolver(
 
 }
 
-object LinkAliasResolver {
+private[link] object LinkAliasResolver {
 
   def unresolved(
       sourceSelector: TargetIdSelector,

--- a/core/shared/src/main/scala/laika/rewrite/link/TreeTargets.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/TreeTargets.scala
@@ -24,7 +24,7 @@ import laika.ast.{ DocumentTreeRoot, Path, StaticDocument }
   *
   * @author Jens Halm
   */
-class TreeTargets(root: DocumentTreeRoot, slugBuilder: String => String) {
+private[link] class TreeTargets(root: DocumentTreeRoot, slugBuilder: String => String) {
 
   private val targetMap: Map[(Path, Selector), TargetResolver] = {
 
@@ -42,7 +42,7 @@ class TreeTargets(root: DocumentTreeRoot, slugBuilder: String => String) {
       } yield ((path, target.selector), target)
 
     val targets                           = root.allDocuments.flatMap { doc =>
-      val targets = DocumentTargets(doc, slugBuilder).targets
+      val targets = new DocumentTargets(doc, slugBuilder).targets
       val global  =
         if (doc.path == Root) Nil
         else mapToKeys(allPaths(doc.path.parent), targets.filter(_.selector.global))

--- a/core/shared/src/main/scala/laika/rewrite/nav/AutonumberConfig.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/AutonumberConfig.scala
@@ -34,11 +34,9 @@ case class AutonumberConfig(
     maxDepth: Int = Int.MaxValue
 )
 
-case class ConfigurationException(msg: String) extends RuntimeException(msg)
+private[nav] sealed trait Scope
 
-sealed trait Scope
-
-object Scope {
+private[nav] object Scope {
   case object Documents extends Scope
   case object Sections  extends Scope
   case object All       extends Scope

--- a/core/shared/src/main/scala/laika/rewrite/nav/CoverImage.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/CoverImage.scala
@@ -53,7 +53,7 @@ object CoverImage {
 
 }
 
-case class CoverImages(default: Option[Path], classified: Map[String, Path]) {
+private[laika] case class CoverImages(default: Option[Path], classified: Map[String, Path]) {
 
   def getImageFor(classifier: String): Option[Path] = classified.get(classifier).orElse(default)
 
@@ -63,7 +63,7 @@ case class CoverImages(default: Option[Path], classified: Map[String, Path]) {
 
 }
 
-object CoverImages {
+private[laika] object CoverImages {
 
   def forPDF(config: Config): ConfigResult[CoverImages] =
     extract(config, LaikaKeys.root.child("pdf"), LaikaKeys.root)

--- a/core/shared/src/main/scala/laika/rewrite/nav/NavigationOrder.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/NavigationOrder.scala
@@ -20,14 +20,13 @@ import laika.config.{ Config, LaikaKeys }
 import laika.ast._
 import laika.config.Config.ConfigResult
 
-/** Responsible for applying the navigation order to the
-  *  contents of a document tree, either based on user-specified
-  *  configuration or by the alphabetical order of the names of
-  *  the documents and subtrees.
+/** Responsible for applying the navigation order to the contents of a document tree,
+  * either based on user-specified configuration
+  * or by the alphabetical order of the names of the documents and subtrees.
   *
-  *  @author Jens Halm
+  * @author Jens Halm
   */
-object NavigationOrder {
+private[laika] object NavigationOrder {
 
   def applyTo(
       content: Seq[Cursor],

--- a/core/shared/src/main/scala/laika/rewrite/nav/SectionBuilder.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/SectionBuilder.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable.ListBuffer
   *
   * @author Jens Halm
   */
-object SectionBuilder extends RewriteRulesBuilder {
+private[laika] object SectionBuilder extends RewriteRulesBuilder {
 
   private class DefaultRule(
       autonumberConfig: AutonumberConfig,

--- a/core/shared/src/main/scala/laika/rewrite/nav/TitleDocumentConfig.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/TitleDocumentConfig.scala
@@ -23,7 +23,7 @@ import laika.config.{ Config, LaikaKeys }
   *
   * @author Jens Halm
   */
-object TitleDocumentConfig {
+private[laika] object TitleDocumentConfig {
 
   val defaultInputName: String  = "README"
   val defaultOutputName: String = "index"


### PR DESCRIPTION
This is the penultimate PR for #452.

It covers the packages `laika.render` and  `laika.rewrite`.

These packages represent parts of the internal runtime and the few remaining public types in these packages will move in the final milestone.

**`laika.render`**

* The renderer implementations are removed from the public API as they are usually not directly referenced in user code.
* The formatter implementations remain public API, as they are used when writing render overrides or implementing a new type of renderer, but will most likely receive some redesign and cleanup in the final milestone for 1.0.

**`laika.rewrite`**

* Remaining public types are usually used in configuration code and will move to either `laika.bundle` or `laika.config` in the final milestone.
* Removed from public API: `ReferenceResolver`, `LinkResolver`, `DocumentTargets`, `TreeTargets` and all their helper ADTs, `TitleDocumentConfig`, `SectionBuilder` , `NavigationOrder`.