### PR TITLE
shrink public API surface in markup parsers

### DIFF
--- a/core/shared/src/main/scala/laika/format/ReStructuredText.scala
+++ b/core/shared/src/main/scala/laika/format/ReStructuredText.scala
@@ -25,29 +25,22 @@ import laika.rst._
 import laika.rst.bundle._
 
 /** A parser for text written in reStructuredText markup. Instances of this class may be passed directly
-  *  to the `Parseer` or `Transformer` APIs:
+  * to the `Parseer` or `Transformer` APIs:
   *
-  *  {{{
-  *  val document = MarkupParser.of(ReStructuredText).build.parse(inputString)
+  * {{{
+  * val document = MarkupParser.of(ReStructuredText).build.parse(inputString)
   *
-  *  Transformer.from(ReStructuredText).to(HTML).build.transform(inputString)
-  *  }}}
+  * Transformer.from(ReStructuredText).to(HTML).build.transform(inputString)
+  * }}}
   *
-  *  reStructuredText has several types of extension points that are fully supported by Laika.
-  *  For more information on how to implement and register those see [[laika.rst.bundle.RstExtensionRegistry]].
+  * In addition to the implementing the standard reStructuredText directives,
+  * the Laika APIs also supports a custom directive type unique to Laika.
+  * They represent a library-wide extension mechanism and allow you to implement
+  * tags which can be used in any of the supported markup formats or in templates.
   *
-  *  In addition to the standard reStructuredText directives, the API also supports a custom directive
-  *  type unique to Laika. They represent a library-wide extension mechanism and allow you to implement
-  *  tags which can be used in any of the supported markup formats or in templates. If you need this
-  *  level of flexibility, it is recommended to use the Laika directives, if you want to stay compatible
-  *  with the reStructuredText reference parser, you should pick the standard directives.
+  * Laika directives can be registered with the [[laika.directive.DirectiveRegistry]] extension bundle.
   *
-  *  Laika directives can be registered with the [[laika.directive.DirectiveRegistry]] extension bundle.
-  *  The DSLs for creating directives are similar, but still different,
-  *  due to differences in the feature set of the two variants. The Laika directives try to avoid some
-  *  of the unnecessary complexities of reStructuredText directives.
-  *
-  *  @author Jens Halm
+  * @author Jens Halm
   */
 case object ReStructuredText extends MarkupFormat { self =>
 
@@ -89,9 +82,9 @@ case object ReStructuredText extends MarkupFormat { self =>
     InlineParsers.email
   )
 
-  override lazy val escapedChar = InlineParsers.escapedChar
+  override lazy val escapedChar: Parser[String] = InlineParsers.escapedChar
 
-  object BundledDefaults extends ExtensionBundle {
+  private object BundledDefaults extends ExtensionBundle {
 
     val description: String = "Default extensions for reStructuredText"
 

--- a/core/shared/src/main/scala/laika/markdown/BlockParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/BlockParsers.scala
@@ -24,40 +24,39 @@ import laika.parse.builders._
 import laika.parse.implicits._
 import laika.parse.text.{ PrefixedParser, WhitespacePreprocessor }
 
-/** Provides all block parsers for Markdown text except for for lists which
-  *  are factored out into a separate parser object and those blocks dealing
-  *  with verbatim HTML markup which this library treats as an optional
-  *  feature that has to be explicitly mixed in.
+/** Provides all block parsers for Markdown text except for lists
+  * which are factored out into a separate parser object
+  * and those blocks dealing with verbatim HTML markup
+  * which this library treats as an optional feature that has to be explicitly mixed in.
   *
-  *  Block parsers are only concerned with splitting the document into
-  *  (potentially nested) blocks. They are used in the first phase of parsing,
-  *  while delegating to inline parsers for the 2nd phase.
+  * Block parsers are only concerned with splitting the document into (potentially nested) blocks.
+  * They are used in the first phase of parsing, while delegating to inline parsers for the 2nd phase.
   *
-  *  @author Jens Halm
+  * @author Jens Halm
   */
-object BlockParsers {
+private[laika] object BlockParsers {
 
   /** Parses a single tab or space character.
     */
   val tabOrSpace: Parser[Unit] = oneOf(' ', '\t').void
 
-  /** Parses up to 3 space characters. In Markdown an indentation
-    *  of up to 3 spaces is optional and does not have any influence
-    *  on the parsing logic.
+  /** Parses up to 3 space characters.
+    * In Markdown an indentation of up to 3 spaces is optional
+    * and does not have any influence on the parsing logic.
     */
   val insignificantSpaces: Parser[Unit] = anyOf(' ').max(3).void
 
   /** Parses the decoration (underline) of a setext header.
     */
-  val setextDecoration: Parser[String] = (someOf('=') | someOf('-')) <~ wsEol
+  private val setextDecoration: Parser[String] = (someOf('=') | someOf('-')) <~ wsEol
 
-  /**  Parses a single Markdown block. In contrast to the generic block parser of the
-    *  generic block parsers this method also consumes and ignores up to three optional space
-    *  characters at the start of each line.
+  /** Parses a single Markdown block. In contrast to the generic block parser of the
+    * generic block parsers this method also consumes and ignores up to three optional space
+    * characters at the start of each line.
     *
-    *  @param firstLinePrefix parser that recognizes the start of the first line of this block
-    *  @param linePrefix parser that recognizes the start of subsequent lines that still belong to the same block
-    *  @param nextBlockPrefix parser that recognizes whether a line after one or more blank lines still belongs to the same block
+    * @param firstLinePrefix parser that recognizes the start of the first line of this block
+    * @param linePrefix parser that recognizes the start of subsequent lines that still belong to the same block
+    * @param nextBlockPrefix parser that recognizes whether a line after one or more blank lines still belongs to the same block
     */
   def mdBlock(
       firstLinePrefix: Parser[Any],
@@ -67,15 +66,14 @@ object BlockParsers {
     block(firstLinePrefix, insignificantSpaces ~ linePrefix, nextBlockPrefix)
   }
 
-  /**  Parses a single Markdown block. In contrast to the `mdBlock` parser
-    *  this method also verifies that the second line is not a setext header
-    *  decoration.
+  /** Parses a single Markdown block. In contrast to the `mdBlock` parser
+    * this method also verifies that the second line is not a setext header decoration.
     *
-    *  @param firstLinePrefix parser that recognizes the start of the first line of this block
-    *  @param linePrefix parser that recognizes the start of subsequent lines that still belong to the same block
-    *  @param nextBlockPrefix parser that recognizes whether a line after one or more blank lines still belongs to the same block
+    * @param firstLinePrefix parser that recognizes the start of the first line of this block
+    * @param linePrefix parser that recognizes the start of subsequent lines that still belong to the same block
+    * @param nextBlockPrefix parser that recognizes whether a line after one or more blank lines still belongs to the same block
     */
-  def decoratedBlock(
+  private def decoratedBlock(
       firstLinePrefix: Parser[Any],
       linePrefix: Parser[Any],
       nextBlockPrefix: Parser[Any]
@@ -159,9 +157,9 @@ object BlockParsers {
   }.rootOnly
 
   /** Parses an ATX header, a line that starts with 1 to 6 `'#'` characters,
-    *  with the number of hash characters corresponding to the level of the header.
-    *  Markdown also allows to decorate the line with trailing `'#'` characters which
-    *  this parser will remove.
+    * with the number of hash characters corresponding to the level of the header.
+    * Markdown also allows to decorate the line with trailing `'#'` characters which
+    * this parser will remove.
     */
   val atxHeader: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     def stripDecoration(text: String) = text.trim.reverse.dropWhile(_ == '#').reverse.trim
@@ -173,7 +171,7 @@ object BlockParsers {
   }
 
   /** Parses a horizontal rule, a line only decorated with three or more `'*'`, `'-'` or `'_'`
-    *  characters with optional spaces between them
+    * characters with optional spaces between them
     */
   val rules: BlockParserBuilder = BlockParserBuilder.standalone {
     val decoChar = oneOf('*', '-', '_')
@@ -193,7 +191,7 @@ object BlockParsers {
   }
 
   /** Parses a quoted block, a paragraph starting with a `'>'` character,
-    *  with subsequent lines optionally starting with a `'>'`, too.
+    * with subsequent lines optionally starting with a `'>'`, too.
     */
   val quotedBlock: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     PrefixedParser('>') {

--- a/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
@@ -16,35 +16,33 @@
 
 package laika.markdown
 
-import laika.ast._
+import laika.ast.*
 import laika.bundle.SpanParserBuilder
 import laika.parse.{ LineSource, Parser, SourceFragment }
 import laika.parse.markup.InlineParsers.text
 import laika.parse.markup.RecursiveSpanParsers
-import laika.parse.builders._
-import laika.parse.implicits._
+import laika.parse.builders.*
+import laika.parse.implicits.*
 import laika.parse.text.{ DelimitedText, PrefixedParser }
 
 import scala.util.Try
 
-/** Provides all inline parsers for Markdown text except for those dealing
-  *  with verbatim HTML markup which this library treats as an optional
-  *  feature that has to be explicitly mixed in.
+/** Provides all inline parsers for Markdown text except for those dealing with verbatim HTML markup
+  * which this library treats as an optional feature that has to be explicitly mixed in.
   *
-  *  Inline parsers deal with markup within a block of text, such as a
-  *  link or emphasized text. They are used in the second phase of parsing,
-  *  after the block parsers have cut the document into a (potentially nested)
-  *  block structure.
+  * Inline parsers deal with markup within a block of text, such as a link or emphasized text.
+  * They are used in the second phase of parsing,
+  * after the block parsers have cut the document into a (potentially nested) block structure.
   *
-  *  @author Jens Halm
+  * @author Jens Halm
   */
-object InlineParsers {
+private[laika] object InlineParsers {
 
-  /**  Parses a single escaped character, only recognizing the characters the Markdown syntax document
-    *  specifies as escapable.
-    *  The `|` has been added to that list to support escaping in tables in the GitHub Flavor syntax.
+  /** Parses a single escaped character, only recognizing the characters the Markdown syntax document
+    * specifies as escapable.
+    * The `|` has been added to that list to support escaping in tables in the GitHub Flavor syntax.
     *
-    *  Note: escaping > is not mandated by the official syntax description, but by the official test suite.
+    * Note: escaping > is not mandated by the official syntax description, but by the official test suite.
     */
   val escapedChar: Parser[String] =
     oneOf('\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '#', '+', '-', '.', '!', '>', '|')
@@ -88,7 +86,7 @@ object InlineParsers {
   /** Parses a span enclosed by a single occurrence of the specified character.
     *  Recursively parses nested spans, too.
     */
-  def enclosedBySingleChar(
+  private def enclosedBySingleChar(
       c: Char
   )(implicit recParsers: RecursiveSpanParsers): PrefixedParser[List[Span]] = {
     val start = delimiter(c).nextNot(' ', '\n', c)
@@ -117,8 +115,6 @@ object InlineParsers {
   }
 
   private def normalizeId(id: String): String = id.toLowerCase.replaceAll("[\n ]+", " ")
-
-  type RecParser = String => List[Span]
 
   /** Parses a link, including nested spans in the link text.
     *  Recognizes both, an inline link `[text](url)` and a link reference `[text][id]`.

--- a/core/shared/src/main/scala/laika/markdown/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/ListParsers.scala
@@ -16,20 +16,20 @@
 
 package laika.markdown
 
-import laika.ast._
+import laika.ast.*
 import laika.bundle.BlockParserBuilder
 import laika.parse.Parser
 import laika.parse.combinator.Parsers.opt
 import laika.parse.markup.RecursiveParsers
 import laika.parse.text.{ CharGroup, PrefixedParser }
-import laika.parse.builders._
+import laika.parse.builders.*
 
 /** Provides parsers for bullet lists ("unordered list" in the Markdown spec)
   * and enumerated lists ("ordered list" in the Markdown spec).
   *
   * @author Jens Halm
   */
-object ListParsers {
+private[laika] object ListParsers {
 
   private val bulletChar: Parser[String] = oneOf('*', '-', '+')
   private val enumChar: Parser[String]   = oneOf(CharGroup.digit)
@@ -39,22 +39,15 @@ object ListParsers {
   private val enumStartRest: Parser[String] =
     (anyOf(CharGroup.digit) ~ "." ~ wsAfterItemStart).as("")
 
-  /** Parses the start of a bullet list item.
-    */
-  val bulletListItemStart: Parser[String] = bulletChar <~ wsAfterItemStart
-
-  /** Parses the start of an enumerated list item.
-    */
-  val enumListItemStart: Parser[String] = enumChar ~> enumStartRest
-
   /** Parses a list based on the specified helper parsers.
     *
-    *  @param itemStartChar the parser for the character that starts a list item
-    *  @param itemStartRest parser that recognizes the start of a list item after the first character, result will be discarded
-    *  @param newList function that produces a block element for the document tree
-    *  @param newItem function that produces a new list item element based on position and content arguments
+    * @param itemStartChar the parser for the character that starts a list item
+    * @param itemStartRest parser that recognizes the start of a list item after the first character,
+    *                      result will be discarded
+    * @param newList function that produces a block element for the document tree
+    * @param newItem function that produces a new list item element based on position and content arguments
     */
-  def list[T <: Block, I <: ListItem](
+  private def list[T <: Block, I <: ListItem](
       itemStartChar: Parser[Any],
       itemStartRest: Parser[Any],
       newList: List[I] => T,

--- a/core/shared/src/main/scala/laika/markdown/ast/elements.scala
+++ b/core/shared/src/main/scala/laika/markdown/ast/elements.scala
@@ -58,8 +58,8 @@ case class HTMLStartTag(name: String, attributes: List[HTMLAttribute], options: 
   def withOptions(options: Options): HTMLStartTag = copy(options = options)
 }
 
-/** Represents an empty element (like `&lt;br/&gt;` or `&lt;hr/&gt;`) 
-  * in case it contains the explicit slash to mark it as closed. 
+/** Represents an empty element (like `&lt;br/&gt;` or `&lt;hr/&gt;`)
+  * in case it contains the explicit slash to mark it as closed.
   * Otherwise it will be classified as a start tag.
   */
 case class HTMLEmptyElement(name: String, attributes: List[HTMLAttribute], options: Options = NoOpt)

--- a/core/shared/src/main/scala/laika/markdown/ast/elements.scala
+++ b/core/shared/src/main/scala/laika/markdown/ast/elements.scala
@@ -16,12 +16,13 @@
 
 package laika.markdown.ast
 
-import laika.ast._
+import laika.ast.*
 
-/** A top level HTML block as defined by the Markdown syntaxt description. It is surrounded by blank lines
-  *  and has a block-level element (one that is not classified as "phrasing content" in the HTML specification)
-  *  as its root element. It may contain other nested HTML elements and tags, but no spans produced by standard
-  *  Markdown markup.
+/** A top level HTML block as defined by the Markdown syntax description.
+  * It is surrounded by blank lines and has a block-level element
+  * (one that is not classified as "phrasing content" in the HTML specification)
+  * as its root element.
+  * It may contain other nested HTML elements and tags, but no spans produced by standard Markdown markup.
   */
 case class HTMLBlock(root: HTMLElement, options: Options = NoOpt) extends Block {
   type Self = HTMLBlock
@@ -32,8 +33,9 @@ case class HTMLBlock(root: HTMLElement, options: Options = NoOpt) extends Block 
   */
 abstract class HTMLSpan extends Span
 
-/** Represents a full HTML element with matching start and end tags. The content of this span container
-  *  may contain further nested HTML elements and tags as well as simple text elements.
+/** Represents a full HTML element with matching start and end tags.
+  * The content of this span container may contain further nested HTML elements
+  * and tags as well as simple text elements.
   */
 case class HTMLElement(startTag: HTMLStartTag, content: Seq[Span], options: Options = NoOpt)
     extends HTMLSpan with SpanContainer {
@@ -42,11 +44,13 @@ case class HTMLElement(startTag: HTMLStartTag, content: Seq[Span], options: Opti
   def withOptions(options: Options): HTMLElement      = copy(options = options)
 }
 
-/** Represent a start tag. When this element is part of a final document tree, it represents
-  *  an orphaned start tag without matching end tag. In HTML this may be legal (some tags like the p
-  *  tag are defined as "auto-closing" under certain circumstances). This library however does not
-  *  implement the full logic of a proper HTML parser to distinguish between legal and faulty
-  *  occurrences of unmatched start tags.
+/** Represent a start tag.
+  * When this element is part of a final document tree,
+  * it represents an orphaned start tag without matching end tag.
+  *
+  * In HTML this may be legal (some tags like the `p` tag are defined as "auto-closing" under certain circumstances).
+  * This library however does not implement the full logic of a proper HTML parser
+  * to distinguish between legal and faulty occurrences of unmatched start tags.
   */
 case class HTMLStartTag(name: String, attributes: List[HTMLAttribute], options: Options = NoOpt)
     extends HTMLSpan with Block {
@@ -54,8 +58,9 @@ case class HTMLStartTag(name: String, attributes: List[HTMLAttribute], options: 
   def withOptions(options: Options): HTMLStartTag = copy(options = options)
 }
 
-/** Represents an empty element (like `&lt;br/&gt;` or `&lt;hr/&gt;`) in case it contains the explicit
-  *  slash to mark it as closed. Otherwise it will be classified as a start tag.
+/** Represents an empty element (like `&lt;br/&gt;` or `&lt;hr/&gt;`) 
+  * in case it contains the explicit slash to mark it as closed. 
+  * Otherwise it will be classified as a start tag.
   */
 case class HTMLEmptyElement(name: String, attributes: List[HTMLAttribute], options: Options = NoOpt)
     extends HTMLSpan with Block {

--- a/core/shared/src/main/scala/laika/markdown/bundle/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/markdown/bundle/HTMLRenderer.scala
@@ -20,31 +20,27 @@ import laika.ast.{ Element, TextContainer }
 import laika.markdown.ast._
 import laika.render.HTMLFormatter
 
-/**  Renderer for verbatim HTML elements. Since verbatim HTML is treated as an optional feature
-  *  by this library as it aims to also support renderers for other formats than HTML,
-  *  the nodes in the document tree produced by the verbatim HTML parsers are not known by the standard
-  *  renderers. This partial renderer complements the regular HTML renderer and simply writes
-  *  the HTML elements out as they were read. Of course, in contrast to regular text, without
-  *  escaping any of the special HTML characters.
-  *
-  *  It must be applied explicitly as part of the `VerbatimHTML` bundle when enabling verbatim HTML:
-  *
-  *  {{{
-  *  val transformer = Transformer.from(Markdown).to(HTML).withRawContent
-  *  }}}
+/** Renderer for verbatim HTML elements.
+  * Since verbatim HTML is treated as an optional feature by this library
+  * as it aims to also support renderers for other formats than HTML,
+  * the nodes in the document tree produced by the verbatim HTML parsers are not known
+  * by the standard renderers.
+  * This partial renderer complements the regular HTML renderer and simply writes
+  * the HTML elements out as they were read.
+  * Of course, in contrast to regular text, without escaping any of the special HTML characters.
   *
   *  @author Jens Halm
   */
-object HTMLRenderer {
+private[bundle] object HTMLRenderer {
 
-  def prepareAttributeValue(spans: List[TextContainer]): String =
+  private def prepareAttributeValue(spans: List[TextContainer]): String =
     spans.foldLeft("") {
       case (acc, span: HTMLCharacterReference) => acc + span.content
       case (acc, text)                         =>
         acc + text.content.replace("&", "&amp;").replace("\"", "&quot;").replace("'", "$#39;")
     }
 
-  def tagStart(tagName: String, attributes: List[HTMLAttribute]): String = {
+  private def tagStart(tagName: String, attributes: List[HTMLAttribute]): String = {
 
     val renderedAttrs = attributes.map { at =>
       val name  = " " + at.name

--- a/core/shared/src/main/scala/laika/markdown/bundle/VerbatimHTML.scala
+++ b/core/shared/src/main/scala/laika/markdown/bundle/VerbatimHTML.scala
@@ -20,22 +20,21 @@ import laika.bundle.{ BundleOrigin, ExtensionBundle, ParserBundle, RenderOverrid
 import laika.format.HTML
 import laika.markdown.HTMLParsers
 
-/**  Markdown extension that also parses verbatim HTML elements alongside
-  *  the standard Markdown markup.
+/** Markdown extension that also parses verbatim HTML elements alongside the standard Markdown markup.
   *
-  *  Since verbatim HTML is treated as an optional feature
-  *  by this library as it aims to also support renderers for other formats than HTML,
-  *  this extension is disabled by default.
+  * Since verbatim HTML is treated as an optional feature by this library
+  * as it aims to also support renderers for other formats than HTML,
+  * this extension is disabled by default.
   *
-  *  You can enable it with the Transform API:
+  * You can enable it with the Transform API:
   *
-  *  {{{
-  *  val transformer = Transformer.from(Markdown).to(HTML).withRawContent
-  *  }}}
+  * {{{
+  * val transformer = Transformer.from(Markdown).to(HTML).withRawContent
+  * }}}
   *
-  *  @author Jens Halm
+  * @author Jens Halm
   */
-object VerbatimHTML extends ExtensionBundle {
+private[laika] object VerbatimHTML extends ExtensionBundle {
 
   val description: String = "Support for verbatim HTML in markup"
 

--- a/core/shared/src/main/scala/laika/markdown/github/AutoLinks.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/AutoLinks.scala
@@ -29,7 +29,7 @@ import laika.parse.uri.AutoLinkParsers
   *
   * @author Jens Halm
   */
-object AutoLinks {
+private[github] object AutoLinks {
 
   private val startChars = NonEmptySet.of('*', '_', '~', '(', ' ', '\n')
   private val endChars   = NonEmptySet.of('*', '_', '~', ')', '?', '!', '.', ',', ':', ' ', '\n')

--- a/core/shared/src/main/scala/laika/markdown/github/FencedCodeBlocks.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/FencedCodeBlocks.scala
@@ -29,7 +29,7 @@ import laika.parse.{ BlockSource, Failure, Parser, Success }
   *
   * @author Jens Halm
   */
-object FencedCodeBlocks {
+private[github] object FencedCodeBlocks {
 
   private def reverse(offset: Int, p: => Parser[String]): Parser[String] = Parser { in =>
     p.parse(in.reverse.consume(offset)) match {
@@ -40,37 +40,38 @@ object FencedCodeBlocks {
 
   /** Creates a parser for a fenced code block with the specified fence character.
     */
-  def codeBlock(fenceChar: Char): BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
-    val infoString                       = restOfLine.map(
-      Some(_)
-        .filter(_.nonEmpty)
-        .flatMap(_.trim.split(" ").headOption)
-    )
-    def indent(offset: Int): Parser[Int] = reverse(offset, anyOf(' ')).map(_.length)
-    val openingFence                     = someOf(fenceChar).min(3).count >> { fence =>
-      (indent(fence) ~ infoString).mapN((fence, _, _))
-    }
+  private def codeBlock(fenceChar: Char): BlockParserBuilder = BlockParserBuilder.recursive {
+    recParsers =>
+      val infoString                       = restOfLine.map(
+        Some(_)
+          .filter(_.nonEmpty)
+          .flatMap(_.trim.split(" ").headOption)
+      )
+      def indent(offset: Int): Parser[Int] = reverse(offset, anyOf(' ')).map(_.length)
+      val openingFence                     = someOf(fenceChar).min(3).count >> { fence =>
+        (indent(fence) ~ infoString).mapN((fence, _, _))
+      }
 
-    openingFence >> { case (fenceLength, indent, info) =>
-      val closingFence = anyOf(' ').max(3) ~ anyOf(fenceChar).min(fenceLength) ~ wsEol
-      val lines        = (not(closingFence | eof) ~ anyOf(' ').max(indent) ~> restOfLine.line).rep
+      openingFence >> { case (fenceLength, indent, info) =>
+        val closingFence = anyOf(' ').max(3) ~ anyOf(fenceChar).min(fenceLength) ~ wsEol
+        val lines        = (not(closingFence | eof) ~ anyOf(' ').max(indent) ~> restOfLine.line).rep
 
-      (lines <~ opt(closingFence)).evalMap { lines =>
-        val trimmedLines =
-          if (lines.lastOption.exists(_.input.trim.isEmpty)) lines.dropRight(1) else lines
-        val codeSource   = NonEmptyChain.fromSeq(trimmedLines).map(BlockSource(_))
-        (info, codeSource) match {
-          case (Some(lang), Some(src)) =>
-            recParsers.getSyntaxHighlighter(lang).fold[Either[String, Seq[Span]]](
-              Right(Seq(Text(src.input)))
-            ) { highlighter =>
-              highlighter.parse(src).toEither
-            }.map { CodeBlock(lang, _) }
-          case _                       =>
-            Right(LiteralBlock(trimmedLines.map(_.input).mkString("\n")))
+        (lines <~ opt(closingFence)).evalMap { lines =>
+          val trimmedLines =
+            if (lines.lastOption.exists(_.input.trim.isEmpty)) lines.dropRight(1) else lines
+          val codeSource   = NonEmptyChain.fromSeq(trimmedLines).map(BlockSource(_))
+          (info, codeSource) match {
+            case (Some(lang), Some(src)) =>
+              recParsers.getSyntaxHighlighter(lang).fold[Either[String, Seq[Span]]](
+                Right(Seq(Text(src.input)))
+              ) { highlighter =>
+                highlighter.parse(src).toEither
+              }.map { CodeBlock(lang, _) }
+            case _                       =>
+              Right(LiteralBlock(trimmedLines.map(_.input).mkString("\n")))
+          }
         }
       }
-    }
   }.interruptsParagraphWith(oneOf(fenceChar))
 
   /** Parsers for fenced code blocks delimited by any of the two fence characters

--- a/core/shared/src/main/scala/laika/markdown/github/Strikethrough.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/Strikethrough.scala
@@ -26,7 +26,7 @@ import laika.markdown.InlineParsers.enclosedByDoubleChar
   *
   * @author Jens Halm
   */
-object Strikethrough {
+private[github] object Strikethrough {
 
   val parser: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     enclosedByDoubleChar('~').map { Deleted(_) }

--- a/core/shared/src/main/scala/laika/markdown/github/Tables.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/Tables.scala
@@ -30,7 +30,7 @@ import laika.parse.implicits._
   *
   * @author Jens Halm
   */
-object Tables {
+private[github] object Tables {
 
   val parser: BlockParserBuilder = BlockParserBuilder.withSpans { spanParsers =>
     def cell(textParser: Parser[LineSource], cellType: CellType): Parser[Cell] =

--- a/core/shared/src/main/scala/laika/rst/BaseParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/BaseParsers.scala
@@ -25,12 +25,12 @@ import laika.parse.text.{ CharGroup, Characters }
 
 /** @author Jens Halm
   */
-object BaseParsers {
+private[laika] object BaseParsers {
 
   /** Set of punctuation characters as supported by transitions (rules) and
     * overlines and underlines for header sections.
     */
-  private[laika] val punctuationChars: NonEmptySet[Char] =
+  val punctuationChars: NonEmptySet[Char] =
     NonEmptySet.of('!', '"', '#', '$', '%', '&', '\'', '(', ')', '[', ']', '{', '}', '*', '+', ',',
       '-', '.', ':', ';', '/', '<', '>', '=', '?', '@', '\\', '^', '_', '`', '|', '~')
 

--- a/core/shared/src/main/scala/laika/rst/BlockParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/BlockParsers.scala
@@ -48,11 +48,10 @@ import scala.collection.mutable.ListBuffer
   *
   * @author Jens Halm
   */
-object BlockParsers {
+private[laika] object BlockParsers {
 
-  val ws: Characters[String] = anyOf(
-    ' '
-  ) // other whitespace has been replaced with spaces by preprocessor
+  // other whitespace has been replaced with spaces by preprocessor
+  val ws: Characters[String] = anyOf(' ')
 
   /** Parses a transition (rule).
     *
@@ -62,8 +61,9 @@ object BlockParsers {
     (punctuationChar.min(4) ~ wsEol ~ lookAhead(blankLine)).as(Rule())
   }
 
-  /** Parses a single paragraph. Everything between two blank lines that is not
-    * recognized as a special reStructuredText block type will be parsed as a regular paragraph.
+  /** Parses a single paragraph.
+    * Everything between two blank lines that is not recognized
+    * as a special reStructuredText block type will be parsed as a regular paragraph.
     */
   lazy val paragraph: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val interruptions = recParsers.paragraphInterruptions()
@@ -85,7 +85,7 @@ object BlockParsers {
 
   /** Parses a section header with both overline and underline.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections]].
     */
   lazy val headerWithOverline: BlockParserBuilder = BlockParserBuilder.withSpans { spanParsers =>
     val spanParser = punctuationChar.take(1) >> { start =>
@@ -107,7 +107,7 @@ object BlockParsers {
 
   /** Parses a section header with an underline, but no overline.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections]].
     */
   lazy val headerWithUnderline: BlockParserBuilder = BlockParserBuilder.withSpans { spanParsers =>
     val spanParser = nextNot(' ') ~ not(eof) ~> restOfLine.trim.line >> { title =>
@@ -127,11 +127,9 @@ object BlockParsers {
     }
   }
 
-  /** Parses a doctest block. This is a feature which is very specific to the
-    *  world of Python where reStructuredText originates. Therefore the resulting
-    *  `DoctestBlock` tree element is not part of the standard Laika AST model.
-    *  When this block type is used the corresponding special renderers must
-    *  be enabled (e.g. the `ExtendedHTMLRenderer` renderer for HTML).
+  /** Parses a doctest block.
+    * This is a feature which is very specific to the world of Python where reStructuredText originates.
+    * Therefore the resulting `DoctestBlock` tree element is not part of the standard Laika AST model.
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#doctest-blocks]]
     */
@@ -142,7 +140,7 @@ object BlockParsers {
 
   /** Parses a block quote with an optional attribution.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#block-quotes]]
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#block-quotes]]
     */
   lazy val blockQuote: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val attributionStart = "---" | "--" | "\u2014" // em dash
@@ -161,9 +159,9 @@ object BlockParsers {
   }
 
   /** Parses a literal block, either quoted or indented.
-    *  Only used when the preceding block ends with a double colon (`::`).
+    * Only used when the preceding block ends with a double colon (`::`).
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#literal-blocks]]
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#literal-blocks]]
     */
   val literalBlock: Parser[Block] = {
     val indented = indentedBlock(firstLineIndented = true).map(src => LiteralBlock(src.input))
@@ -175,17 +173,17 @@ object BlockParsers {
     indented | quoted
   }
 
-  /**  Builds a parser for a list of blocks based on the parser for a single block.
+  /** Builds a parser for a list of blocks based on the parser for a single block.
     *
-    *  Adds the processing required for cases where a block has influence
-    *  on the parsing or processing of the subsequent block.
+    * Adds the processing required for cases where a block has influence
+    * on the parsing or processing of the subsequent block.
     *
-    *  This includes checking each Paragraph for a double colon ending which turns
-    *  the following block into a literal block as well as processing internal
-    *  link targets and section headers.
+    * This includes checking each Paragraph for a double colon ending which turns
+    * the following block into a literal block as well as processing internal
+    * link targets and section headers.
     *
-    *  @param blockParser the parser for a single block element
-    *  @return a parser for a list of blocks
+    * @param blockParser the parser for a single block element
+    * @return a parser for a list of blocks
     */
   def createBlockListParser(blockParser: Parser[Block]): Parser[Seq[Block]] = Parser { in =>
     val defaultBlock = blockParser <~ opt(blankLines)

--- a/core/shared/src/main/scala/laika/rst/ExplicitBlockParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/ExplicitBlockParsers.scala
@@ -32,7 +32,7 @@ import laika.parse.text.PrefixedParser
   *
   * @author Jens Halm
   */
-class ExplicitBlockParsers(recParsers: RecursiveParsers) {
+private[laika] class ExplicitBlockParsers(recParsers: RecursiveParsers) {
 
   import recParsers._
 
@@ -40,7 +40,7 @@ class ExplicitBlockParsers(recParsers: RecursiveParsers) {
 
   /** Parses all types of explicit block items.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#explicit-markup-blocks]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#explicit-markup-blocks]].
     */
   lazy val explicitBlockItem: PrefixedParser[Block] =
     (explicitStart ~> (footnote | citation | linkTarget | comment)) |
@@ -48,7 +48,7 @@ class ExplicitBlockParsers(recParsers: RecursiveParsers) {
 
   /** Parses a footnote.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#footnotes]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#footnotes]].
     */
   lazy val footnote: Parser[FootnoteDefinition] = {
 
@@ -78,7 +78,7 @@ class ExplicitBlockParsers(recParsers: RecursiveParsers) {
 
   /** Parses a citation.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#citations]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#citations]].
     */
   lazy val citation: Parser[Citation] = {
     val prefix = "[" ~> simpleRefName <~ "]" ~ ws
@@ -88,7 +88,7 @@ class ExplicitBlockParsers(recParsers: RecursiveParsers) {
 
   /** Parses a link definition, either an internal, external or indirect link.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-targets]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-targets]].
     */
   lazy val linkTarget: Parser[Block with Span] = {
 
@@ -119,7 +119,7 @@ class ExplicitBlockParsers(recParsers: RecursiveParsers) {
 
   /** Parses a comment.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#comments]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#comments]].
     */
   val comment: Parser[Comment] = indentedBlock().map(src => Comment(src.input.trim))
 
@@ -148,10 +148,10 @@ object ExplicitBlockParsers {
     }
   }
 
-  /**  Parses the short variant of an anonymous link definition
-    *  (that starts with `__` instead of `.. __:`)
+  /** Parses the short variant of an anonymous link definition
+    * (that starts with `__` instead of `.. __:`)
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks]].
     */
   lazy val shortAnonymousLinkTarget: BlockParserBuilder = BlockParserBuilder.standalone {
     "__ " ~> linkDefinitionBody.map(LinkDefinition.create("", _))

--- a/core/shared/src/main/scala/laika/rst/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/InlineParsers.scala
@@ -38,7 +38,7 @@ import laika.rst.ast.{ InterpretedText, ReferenceName, RstStyle, SubstitutionRef
   *
   *  @author Jens Halm
   */
-object InlineParsers {
+private[laika] object InlineParsers {
 
   /** Parses an escaped character. For most characters it produces the character
     * itself as the result with the only exception being an escaped space character
@@ -258,7 +258,7 @@ object InlineParsers {
 
   /** Parses a span of emphasized text.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#emphasis]]
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#emphasis]]
     */
   lazy val em: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     span(delimiter('*').prevNot('*'), delimiter("*").nextNot('*')).map(Emphasized(_))
@@ -266,7 +266,7 @@ object InlineParsers {
 
   /** Parses a span of text with strong emphasis.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#strong-emphasis]]
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#strong-emphasis]]
     */
   lazy val strong: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     val delim = literal("**")
@@ -282,7 +282,7 @@ object InlineParsers {
 
   /** Parses an inline literal element.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-literals]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-literals]].
     */
   lazy val inlineLiteral: SpanParserBuilder = SpanParserBuilder.standalone {
     markupStart("``", "``") ~> delimitedBy(markupEnd("``")).map(Literal(_))
@@ -426,13 +426,13 @@ object InlineParsers {
 
   /** Parses a standalone HTTP or HTTPS hyperlink (with no surrounding markup).
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks]]
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks]]
     */
   lazy val uri: SpanParserBuilder = autoLinks.http
 
   /** Parses a standalone email address (with no surrounding markup).
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks]]
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks]]
     */
   lazy val email: SpanParserBuilder = autoLinks.email
 

--- a/core/shared/src/main/scala/laika/rst/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/ListParsers.scala
@@ -33,7 +33,7 @@ import scala.collection.mutable.ListBuffer
   *
   * @author Jens Halm
   */
-object ListParsers {
+private[laika] object ListParsers {
 
   private def listItem[I <: ListItem](itemStart: Parser[String], newListItem: Seq[Block] => I)(
       implicit recParsers: RecursiveParsers
@@ -94,7 +94,7 @@ object ListParsers {
 
   /** Parses a bullet list with any of the supported bullet characters.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#bullet-lists]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#bullet-lists]].
     */
   lazy val bulletList: BlockParserBuilder = BlockParserBuilder.recursive { implicit recParsers =>
     lookAhead(bulletListStart <~ ws.min(1)) >> { symbol =>
@@ -141,7 +141,7 @@ object ListParsers {
 
   /** Parses an enumerated list in any of the supported combinations of enumeration style and formatting.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#enumerated-lists]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#enumerated-lists]].
     */
   lazy val enumList: BlockParserBuilder = BlockParserBuilder.recursive { implicit recParsers =>
     import EnumType._
@@ -184,7 +184,7 @@ object ListParsers {
 
   /** Parses a definition list.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#definition-lists]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#definition-lists]].
     */
   lazy val definitionList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val tableStart    = anyOf(' ', '=') ~ eol
@@ -212,7 +212,7 @@ object ListParsers {
 
   /** Parses a field list.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists]].
     */
   lazy val fieldList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val nameParser = ":" ~> recParsers.escapedUntil(':').line <~ (lookAhead(eol).as("") | " ")
@@ -227,7 +227,7 @@ object ListParsers {
 
   /** Parses an option list.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#option-lists]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#option-lists]].
     */
   lazy val optionList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val optionString = someOf(CharGroup.alphaNum.add('_').add('-'))
@@ -259,7 +259,7 @@ object ListParsers {
 
   /** Parses a block of lines with line breaks preserved.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#line-blocks]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#line-blocks]].
     */
   lazy val lineBlock: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val itemStart = oneOf('|')

--- a/core/shared/src/main/scala/laika/rst/TableParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/TableParsers.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.ListBuffer
   *
   * @author Jens Halm
   */
-object TableParsers {
+private[laika] object TableParsers {
 
   private abstract class TableElement
 
@@ -62,8 +62,8 @@ object TableParsers {
     private var currentLine: Option[LineSource]      = None
     private def allLines: mutable.Buffer[LineSource] = previousLines ++ currentLine.toBuffer
 
-    var rowSpan = 1
-    var colSpan = 1
+    private var rowSpan = 1
+    private var colSpan = 1
 
     var removed: Boolean = false
 
@@ -92,7 +92,7 @@ object TableParsers {
     }
 
     @nowarn("cat=deprecation")
-    def trimmedCellContent: Option[BlockSource] = {
+    private def trimmedCellContent: Option[BlockSource] = {
       NonEmptyChain.fromSeq(allLines.toSeq).map { nonEmptyLines =>
         val minIndent    = nonEmptyLines.map { line =>
           if (line.input.trim.isEmpty) Int.MaxValue
@@ -109,7 +109,7 @@ object TableParsers {
       }
     }
 
-    def parsedCellContent: Seq[Block] = trimmedCellContent.fold[Seq[Block]](Nil)(src =>
+    private def parsedCellContent: Seq[Block] = trimmedCellContent.fold[Seq[Block]](Nil)(src =>
       recParser.recursiveBlocks.parse(src).getOrElse(Nil)
     )
 
@@ -214,7 +214,7 @@ object TableParsers {
 
   /** Parses a grid table.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables]].
     */
   lazy val gridTable: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val intersectChar = '+'
@@ -309,7 +309,7 @@ object TableParsers {
 
   /** Parses a simple table.
     *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables]].
+    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables]].
     */
   lazy val simpleTable: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val intersect   = someOf(' ').count

--- a/core/shared/src/main/scala/laika/rst/ast/RstStyle.scala
+++ b/core/shared/src/main/scala/laika/rst/ast/RstStyle.scala
@@ -18,11 +18,12 @@ package laika.rst.ast
 
 import laika.ast.{ Options, Styles }
 
-/** Constants for style names wrapped in Options instances which are commonly used by Laika's reStructuredText parsers and rewrite rules.
+/** Constants for style names wrapped in Options instances
+  * which are commonly used by Laika's reStructuredText parsers and rewrite rules.
   *
   * @author Jens Halm
   */
-object RstStyle {
+private[rst] object RstStyle {
 
   val line: Options           = Styles("line")
   val lineBlock: Options      = Styles("line-block")

--- a/core/shared/src/main/scala/laika/rst/ast/elements.scala
+++ b/core/shared/src/main/scala/laika/rst/ast/elements.scala
@@ -21,7 +21,8 @@ import laika.parse.SourceFragment
 
 /** A two-column table-like structure used for bibliographic fields or directive options.
   */
-case class FieldList(content: Seq[Field], options: Options = NoOpt) extends Block with ListContainer
+private[rst] case class FieldList(content: Seq[Field], options: Options = NoOpt) extends Block
+    with ListContainer
     with RewritableContainer {
   type Self = FieldList
 
@@ -36,7 +37,8 @@ case class FieldList(content: Seq[Field], options: Options = NoOpt) extends Bloc
 
 /** A single entry in a field list consisting of name and body.
   */
-case class Field(name: Seq[Span], content: Seq[Block], options: Options = NoOpt) extends ListItem
+private[rst] case class Field(name: Seq[Span], content: Seq[Block], options: Options = NoOpt)
+    extends ListItem
     with BlockContainer {
 
   type Self = Field
@@ -50,7 +52,7 @@ case class Field(name: Seq[Span], content: Seq[Block], options: Options = NoOpt)
 
 /** A classifier for a term in a definition list.
   */
-case class Classifier(content: Seq[Span], options: Options = NoOpt) extends Span
+private[rst] case class Classifier(content: Seq[Span], options: Options = NoOpt) extends Span
     with SpanContainer {
   type Self = Classifier
   def withContent(newContent: Seq[Span]): Classifier = copy(content = newContent)
@@ -59,7 +61,8 @@ case class Classifier(content: Seq[Span], options: Options = NoOpt) extends Span
 
 /** A list of command line options and descriptions.
   */
-case class OptionList(content: Seq[OptionListItem], options: Options = NoOpt) extends Block
+private[rst] case class OptionList(content: Seq[OptionListItem], options: Options = NoOpt)
+    extends Block
     with ListContainer
     with RewritableContainer {
   type Self = OptionList
@@ -72,7 +75,7 @@ case class OptionList(content: Seq[OptionListItem], options: Options = NoOpt) ex
 
 /** A single item in an option list. The content property serves as the description of the option.
   */
-case class OptionListItem(
+private[rst] case class OptionListItem(
     programOptions: Seq[ProgramOption],
     content: Seq[Block],
     options: Options = NoOpt
@@ -85,44 +88,54 @@ case class OptionListItem(
 
 /** A single option, including its name and all arguments, but not the description.
   */
-case class ProgramOption(name: String, argument: Option[OptionArgument], options: Options = NoOpt)
-    extends Element {
+private[rst] case class ProgramOption(
+    name: String,
+    argument: Option[OptionArgument],
+    options: Options = NoOpt
+) extends Element {
   type Self = ProgramOption
   def withOptions(options: Options): ProgramOption = copy(options = options)
 }
 
 /** A single option argument.
   */
-case class OptionArgument(value: String, delimiter: String, options: Options = NoOpt)
+private[rst] case class OptionArgument(value: String, delimiter: String, options: Options = NoOpt)
     extends Element {
   type Self = OptionArgument
   def withOptions(options: Options): OptionArgument = copy(options = options)
 }
 
 /** A substitution definition with its span content that will be inserted
-  *  wherever this substitution is referenced in flow content.
+  * wherever this substitution is referenced in flow content.
   */
-case class SubstitutionDefinition(name: String, content: Span, options: Options = NoOpt)
-    extends Definition with Hidden {
+private[rst] case class SubstitutionDefinition(
+    name: String,
+    content: Span,
+    options: Options = NoOpt
+) extends Definition with Hidden {
   type Self = SubstitutionDefinition
   def withOptions(options: Options): SubstitutionDefinition = copy(options = options)
 }
 
 /** Refers to a substitution definition with the same name.
-  *  This type of element will only temporarily be part of the document tree and replaced
-  *  by the content of the substitution definition in a rewrite step.
+  * This type of element will only temporarily be part of the document tree and replaced
+  * by the content of the substitution definition in a rewrite step.
   */
-case class SubstitutionReference(name: String, source: SourceFragment, options: Options = NoOpt)
-    extends Reference {
+private[rst] case class SubstitutionReference(
+    name: String,
+    source: SourceFragment,
+    options: Options = NoOpt
+) extends Reference {
   type Self = SubstitutionReference
   def withOptions(options: Options): SubstitutionReference = copy(options = options)
   lazy val unresolvedMessage: String = s"Unresolved substitution reference with name '$name'"
 }
 
-/** Represents an interactive Python session. Somewhat unlikely to be used in
-  *  the context of this library, but included for the sake of completeness.
+/** Represents an interactive Python session.
+  * Somewhat unlikely to be used in the context of this library,
+  * but included for the sake of completeness.
   */
-case class DoctestBlock(content: String, options: Options = NoOpt) extends Block
+private[rst] case class DoctestBlock(content: String, options: Options = NoOpt) extends Block
     with TextContainer {
   type Self = DoctestBlock
   def withOptions(options: Options): DoctestBlock = copy(options = options)
@@ -130,17 +143,17 @@ case class DoctestBlock(content: String, options: Options = NoOpt) extends Block
 
 /** Header decoration consisting of both an overline and an underline.
   */
-case class OverlineAndUnderline(char: Char) extends HeaderDecoration
+private[rst] case class OverlineAndUnderline(char: Char) extends HeaderDecoration
 
 /** Header decoration consisting of an underline only.
   */
-case class Underline(char: Char) extends HeaderDecoration
+private[rst] case class Underline(char: Char) extends HeaderDecoration
 
 /** Temporary element to represent interpreted text with its associated role name.
-  *  In a post-processing step this text will be replaced by the result of calling
-  *  the corresponding role function.
+  * In a post-processing step this text will be replaced by the result of calling
+  * the corresponding role function.
   */
-case class InterpretedText(
+private[rst] case class InterpretedText(
     role: String,
     content: String,
     source: SourceFragment,
@@ -156,8 +169,11 @@ case class InterpretedText(
   *  to spans of interpreted text referring to the name of this role and passing
   *  the text as the argument to the function.
   */
-case class CustomizedTextRole(name: String, apply: String => Span, options: Options = NoOpt)
-    extends Definition with Hidden {
+private[rst] case class CustomizedTextRole(
+    name: String,
+    apply: String => Span,
+    options: Options = NoOpt
+) extends Definition with Hidden {
   type Self = CustomizedTextRole
   def withOptions(options: Options): CustomizedTextRole = copy(options = options)
 }
@@ -165,7 +181,8 @@ case class CustomizedTextRole(name: String, apply: String => Span, options: Opti
 /** Temporary element representing a file inclusion.
   * The path is interpreted as relative to the path of the processed document if it is not an absolute path.
   */
-case class Include(path: String, source: SourceFragment, options: Options = NoOpt) extends Block
+private[rst] case class Include(path: String, source: SourceFragment, options: Options = NoOpt)
+    extends Block
     with BlockResolver {
 
   type Self = Include
@@ -183,7 +200,7 @@ case class Include(path: String, source: SourceFragment, options: Options = NoOp
 
 /** Generates a table of contents element inside a topic.
   */
-case class Contents(
+private[rst] case class Contents(
     title: String,
     source: SourceFragment,
     depth: Int = Int.MaxValue,
@@ -211,27 +228,28 @@ case class Contents(
 
 /** A single item inside a line block.
   */
-abstract class LineBlockItem extends Block with RewritableContainer {
+private[rst] abstract class LineBlockItem extends Block with RewritableContainer {
   type Self <: LineBlockItem
 }
 
 /** A single line inside a line block.
   */
-case class Line(content: Seq[Span], options: Options = NoOpt) extends LineBlockItem
+private[laika] case class Line(content: Seq[Span], options: Options = NoOpt) extends LineBlockItem
     with SpanContainer {
   type Self = Line
   def withContent(newContent: Seq[Span]): Line = copy(content = newContent)
   def withOptions(options: Options): Line      = copy(options = options)
 }
 
-object Line extends SpanContainerCompanion {
+private[laika] object Line extends SpanContainerCompanion {
   type ContainerType = Line
   protected def createSpanContainer(spans: Seq[Span]): Line = Line(spans)
 }
 
 /** A block containing lines which preserve line breaks and optionally nested line blocks.
   */
-case class LineBlock(content: Seq[LineBlockItem], options: Options = NoOpt) extends LineBlockItem
+private[laika] case class LineBlock(content: Seq[LineBlockItem], options: Options = NoOpt)
+    extends LineBlockItem
     with ElementTraversal with RewritableContainer {
   type Self = LineBlock
 
@@ -241,14 +259,14 @@ case class LineBlock(content: Seq[LineBlockItem], options: Options = NoOpt) exte
   def withOptions(options: Options): LineBlock = copy(options = options)
 }
 
-object LineBlock {
+private[laika] object LineBlock {
   def apply(item: LineBlockItem, items: LineBlockItem*): LineBlock = LineBlock(item +: items.toList)
 }
 
 /** Represent a reference name.
-  *  When resolving references whitespace needs to be normalized
-  *  and the name converted to lower case.
+  * When resolving references whitespace needs to be normalized
+  * and the name converted to lower case.
   */
-case class ReferenceName(original: String) {
+private[rst] case class ReferenceName(original: String) {
   lazy val normalized: String = original.replaceAll("[\n ]+", " ").toLowerCase
 }

--- a/core/shared/src/main/scala/laika/rst/bundle/DocInfoExtractor.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/DocInfoExtractor.scala
@@ -19,15 +19,14 @@ package laika.rst.bundle
 import laika.ast._
 import laika.rst.ast.FieldList
 
-/** Responsible for extracting a docInfo block at the start
-  * of a reStructuredText document and inserting it into the
-  * `docInfo` element in the config object for that document.
+/** Responsible for extracting a docInfo block at the start of a reStructuredText document
+  * and inserting it into the `docInfo` element in the config object for that document.
   *
   * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#bibliographic-fields]].
   *
   * @author Jens Halm
   */
-object DocInfoExtractor extends (UnresolvedDocument => UnresolvedDocument) {
+private[laika] object DocInfoExtractor extends (UnresolvedDocument => UnresolvedDocument) {
 
   def apply(doc: UnresolvedDocument): UnresolvedDocument = {
 

--- a/core/shared/src/main/scala/laika/rst/bundle/ExtendedHTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/ExtendedHTMLRenderer.scala
@@ -33,7 +33,7 @@ import laika.rst.ast._
   *
   *  @author Jens Halm
   */
-class ExtendedHTMLRenderer {
+private[laika] class ExtendedHTMLRenderer {
 
   private case class ProgramOptions(opts: Seq[Element], options: Options = NoOpt) extends Block {
     type Self = ProgramOptions
@@ -42,7 +42,7 @@ class ExtendedHTMLRenderer {
 
   /** Converts an `OptionList` to an interim table model for rendering.
     */
-  def toTable(ol: OptionList): Table = {
+  private def toTable(ol: OptionList): Table = {
     def intersperse[T](list: List[T], sep: T): List[T] = list match {
       case one :: two :: rest => one :: sep :: intersperse(two :: rest, sep)
       case short              => short
@@ -63,7 +63,7 @@ class ExtendedHTMLRenderer {
 
   /** Converts a `FieldList` to an interim table model for rendering.
     */
-  def toTable(fl: FieldList): Table = {
+  private def toTable(fl: FieldList): Table = {
     def name(value: Seq[Span])  = HeadCell(SpanSequence(value :+ Text(":")))
     def body(value: Seq[Block]) = BodyCell(value)
     val rows                    = fl.content map (f => Row(List(name(f.name), body(f.content))))
@@ -94,4 +94,4 @@ class ExtendedHTMLRenderer {
 
 }
 
-object ExtendedHTMLRenderer extends ExtendedHTMLRenderer
+private[laika] object ExtendedHTMLRenderer extends ExtendedHTMLRenderer

--- a/core/shared/src/main/scala/laika/rst/bundle/LinkTargetProcessor.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/LinkTargetProcessor.scala
@@ -22,13 +22,12 @@ import scala.collection.mutable.ListBuffer
 
 /** Processes link targets in a sequence of blocks.
   *
-  * In reStructuredText internal link targets provide
-  * the id of subsequent block items. This functions gets
-  * applied recursively to all block lists.
+  * In reStructuredText internal link targets provide the id of subsequent block items.
+  * This functions gets applied recursively to all block lists.
   *
   * @author Jens Halm
   */
-object LinkTargetProcessor extends (Seq[Block] => Seq[Block]) {
+private[laika] object LinkTargetProcessor extends (Seq[Block] => Seq[Block]) {
 
   def apply(blocks: Seq[Block]): Seq[Block] = {
 

--- a/core/shared/src/main/scala/laika/rst/bundle/RewriteRules.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/RewriteRules.scala
@@ -27,26 +27,25 @@ import laika.rst.ast.{
 }
 import laika.rst.ext.TextRoles.TextRole
 
-/**  The default rewrite rules that get applied to the raw document tree after parsing
-  *  reStructuredText markup. These rules are responsible for resolving  substitution
-  *  references and interpreted text which are specific to reStructuredText and get usually
-  *  executed alongside the generic rules. .
+/** The default rewrite rules that get applied to the raw document tree after parsing reStructuredText markup.
+  * These rules are responsible for resolving  substitution references and interpreted text
+  * which are specific to reStructuredText and get usually executed alongside the generic rules.
   *
-  *  @author Jens Halm
+  * @author Jens Halm
   */
-class RewriteRules(textRoles: Seq[TextRole]) extends RewriteRulesBuilder {
+private[bundle] class RewriteRules(textRoles: Seq[TextRole]) extends RewriteRulesBuilder {
 
-  val baseRoleElements: Map[String, String => Span] = textRoles.map { role =>
+  private val baseRoleElements: Map[String, String => Span] = textRoles.map { role =>
     (role.name, role.default)
   }.toMap
 
-  class DefaultRules(cursor: DocumentCursor) {
+  private class DefaultRules(cursor: DocumentCursor) {
 
-    val substitutions: Map[String, Span] = cursor.target.content.collect {
+    private val substitutions: Map[String, Span] = cursor.target.content.collect {
       case SubstitutionDefinition(id, content, _) => (id, content)
     }.toMap
 
-    val textRoles: Map[String, String => Span] = cursor.target.content.collect {
+    private val textRoles: Map[String, String => Span] = cursor.target.content.collect {
       case CustomizedTextRole(id, f, _) => (id, f)
     }.toMap ++ baseRoleElements
 

--- a/core/shared/src/main/scala/laika/rst/bundle/RstExtensionRegistry.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/RstExtensionRegistry.scala
@@ -69,7 +69,7 @@ import laika.rst.std.{ StandardBlockDirectives, StandardSpanDirectives, Standard
   *    Specification entry:
   *    [[http://docutils.sourceforge.net/docs/ref/rst/directives.html#custom-interpreted-text-roles]]
   */
-trait RstExtensionRegistry extends ExtensionBundle {
+private[rst] trait RstExtensionRegistry extends ExtensionBundle {
 
   val description: String = "Registry for reStructuredText directives"
 
@@ -175,7 +175,7 @@ trait RstExtensionRegistry extends ExtensionBundle {
   *
   * This extension is installed by default when using the reStructuredText parser.
   */
-object StandardExtensions extends RstExtensionRegistry {
+private[laika] object StandardExtensions extends RstExtensionRegistry {
 
   override val description: String = "Standard directives for reStructuredText"
 
@@ -199,7 +199,7 @@ object StandardExtensions extends RstExtensionRegistry {
   *   .build
   * }}}
   */
-object RawContentExtensions extends RstExtensionRegistry {
+private[laika] object RawContentExtensions extends RstExtensionRegistry {
 
   override val description: String = "Raw content extensions for reStructuredText"
 

--- a/core/shared/src/main/scala/laika/rst/bundle/RstExtensionSupport.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/RstExtensionSupport.scala
@@ -32,7 +32,7 @@ import laika.rst.ext.TextRoles.TextRole
   *
   * @author Jens Halm
   */
-class RstExtensionSupport(
+private[rst] class RstExtensionSupport(
     blockDirectives: Seq[Directive[Block]],
     spanDirectives: Seq[Directive[Span]],
     textRoles: Seq[TextRole],
@@ -73,11 +73,12 @@ class RstExtensionSupport(
 
 /** Empty base instance as a basis for registering reStructuredText extensions.
   */
-object RstExtensionSupport extends RstExtensionSupport(Nil, Nil, Nil, "title-reference")
+private[laika] object RstExtensionSupport
+    extends RstExtensionSupport(Nil, Nil, Nil, "title-reference")
 
 /** Common base trait for reStructuredText extensions (directives and text roles).
   */
-trait RstExtension[P] {
+private[rst] trait RstExtension[P] {
 
   /** The name the extension is identified by in text markup.
     */
@@ -92,7 +93,7 @@ trait RstExtension[P] {
 
 /** Companion with utilities for initializing extensions.
   */
-object RstExtension {
+private[rst] object RstExtension {
 
   /** Initializes the specified extensions with the given recursive parsers
     * and returns them as a map keyed by the name of the extension.

--- a/core/shared/src/main/scala/laika/rst/ext/Directives.scala
+++ b/core/shared/src/main/scala/laika/rst/ext/Directives.scala
@@ -192,7 +192,7 @@ import laika.rst.ext.ExtensionParsers.Result
   *
   * @author Jens Halm
   */
-object Directives {
+private[rst] object Directives {
 
   /** API to implement by the actual directive parser.
     *

--- a/core/shared/src/main/scala/laika/rst/ext/ExtensionParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/ext/ExtensionParsers.scala
@@ -34,7 +34,7 @@ import laika.rst.ext.TextRoles._
   *
   * @author Jens Halm
   */
-class ExtensionParsers(
+private[rst] class ExtensionParsers(
     recParsers: RecursiveParsers,
     blockDirectives: Map[String, DirectivePartBuilder[Block]],
     spanDirectives: Map[String, DirectivePartBuilder[Span]],
@@ -57,7 +57,7 @@ class ExtensionParsers(
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#substitution-definitions]].
     */
-  lazy val substitutionDefinition: Parser[Block] = {
+  private lazy val substitutionDefinition: Parser[Block] = {
     val prefix = delimiter('|').nextNot(' ') ~>
       escapedText(delimitedBy(delimiter('|').prevNot(' ')).failOn('\n').nonEmpty)
 
@@ -149,7 +149,7 @@ class ExtensionParsers(
     *
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/directives.html#custom-interpreted-text-roles]].
     */
-  lazy val roleDirective: Parser[Block] = {
+  private lazy val roleDirective: Parser[Block] = {
 
     val nameParser = reverseWS ~ ("role::" ~ ws ~> simpleRefName) ~ opt("(" ~> simpleRefName <~ ")")
 
@@ -223,23 +223,23 @@ class ExtensionParsers(
       }
     }
 
-    def requiredArg(p: => Parser[SourceFragment]): Parser[SourceFragment] =
+    private def requiredArg(p: => Parser[SourceFragment]): Parser[SourceFragment] =
       p.withFailureMessage("missing required argument")
 
-    val arg: Parser[SourceFragment] = requiredArg((someNot(' ', '\n') <~ ws).line)
+    private val arg: Parser[SourceFragment] = requiredArg((someNot(' ', '\n') <~ ws).line)
 
-    val argWithWS: Parser[SourceFragment] = {
+    private val argWithWS: Parser[SourceFragment] = {
       val p = indentedBlock(linePredicate = not(":"), endsOnBlankLine = true).evalMap { block =>
         if (block.input.nonEmpty) Right(block) else Left("missing required argument")
       }
       requiredArg(p)
     }
 
-    val bodyParser: Parser[SourceFragment] =
+    private val bodyParser: Parser[SourceFragment] =
       prevIn('\n') ~> indentedBlock(firstLineIndented = true) | indentedBlock()
 
     // TODO - some duplicate logic with original fieldList parser
-    lazy val directiveFieldList: Parser[Vector[Part]] = {
+    private lazy val directiveFieldList: Parser[Vector[Part]] = {
 
       val nameParser = ":" ~> escapedUntil(':') <~ (lookAhead(eol).as("") | " ")
 
@@ -265,7 +265,7 @@ class ExtensionParsers(
       }
     }
 
-    val contentSeparator: Parser[Unit] =
+    private val contentSeparator: Parser[Unit] =
       ((prevIn('\n') | eol) ~ blankLine).void | failure(
         "blank line required to separate arguments and/or options from the body"
       )
@@ -311,7 +311,7 @@ class ExtensionParsers(
   *
   * @author Jens Halm
   */
-object ExtensionParsers {
+private[rst] object ExtensionParsers {
 
   type Result[+A] = Either[String, A]
 

--- a/core/shared/src/main/scala/laika/rst/ext/TextRoles.scala
+++ b/core/shared/src/main/scala/laika/rst/ext/TextRoles.scala
@@ -135,7 +135,7 @@ import laika.rst.ext.ExtensionParsers.Result
   *
   * @author Jens Halm
   */
-object TextRoles {
+private[rst] object TextRoles {
 
   /** API to implement by the actual directive parser.
     *

--- a/core/shared/src/main/scala/laika/rst/std/StandardBlockDirectives.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardBlockDirectives.scala
@@ -17,14 +17,14 @@
 package laika.rst.std
 
 import cats.data.NonEmptySet
-import laika.ast._
+import laika.ast.*
 import laika.config.{ Field, LaikaKeys, ObjectValue, Origin, StringValue }
 import laika.parse.{ GeneratedSource, SourceFragment }
 import laika.parse.markup.RecursiveParsers
 import laika.rst.ast.{ Contents, FieldList, Include, RstStyle }
-import laika.rst.ext.Directives.Parts._
-import laika.rst.ext.Directives._
-import laika.rst.std.StandardDirectiveParts._
+import laika.rst.ext.Directives.Parts.*
+import laika.rst.ext.Directives.*
+import laika.rst.std.StandardDirectiveParts.*
 
 import scala.collection.immutable.TreeSet
 
@@ -81,7 +81,7 @@ import scala.collection.immutable.TreeSet
   *
   *  @author Jens Halm
   */
-class StandardBlockDirectives {
+private[rst] class StandardBlockDirectives {
 
   private def positiveInt(value: SourceFragment) = try {
     val i = value.input.toInt
@@ -112,7 +112,7 @@ class StandardBlockDirectives {
   /** The admonition directive,
     *  see [[http://docutils.sourceforge.net/docs/ref/rst/directives.html#generic-admonition]] for details.
     */
-  lazy val genericAdmonition: DirectivePartBuilder[Block] = {
+  private lazy val genericAdmonition: DirectivePartBuilder[Block] = {
     (spanArgument ~ blockContent ~ stdOpt).map { case title ~ content ~ opt =>
       TitledBlock(title, content, opt + RstStyle.admonition)
     }
@@ -160,7 +160,7 @@ class StandardBlockDirectives {
   /** The title directive,
     *  see [[http://docutils.sourceforge.net/docs/ref/rst/directives.html#metadata-document-title]] for details.
     */
-  lazy val titleDirective: DirectivePartBuilder[EmbeddedConfigValue] =
+  private lazy val titleDirective: DirectivePartBuilder[EmbeddedConfigValue] =
     argument().map(EmbeddedConfigValue(LaikaKeys.title.toString, _))
 
   /** The meta directive,
@@ -261,7 +261,7 @@ class StandardBlockDirectives {
   /** The parsed-literal directive, see
     *  [[http://docutils.sourceforge.net/docs/ref/rst/directives.html#parsed-literal-block]] for details.
     */
-  lazy val parsedLiteral: DirectivePartBuilder[Block] = {
+  private lazy val parsedLiteral: DirectivePartBuilder[Block] = {
     (spanContent ~ stdOpt).map { case content ~ opt =>
       ParsedLiteralBlock(content, opt)
     }
@@ -298,7 +298,7 @@ class StandardBlockDirectives {
   /** The image directive for block elements,
     *  see [[http://docutils.sourceforge.net/docs/ref/rst/directives.html#image]] for details.
     */
-  def imageBlock(p: RecursiveParsers): DirectivePartBuilder[Block] = image(p) map { img =>
+  private def imageBlock(p: RecursiveParsers): DirectivePartBuilder[Block] = image(p) map { img =>
     val hAlign =
       Set("align-left", "align-right", "align-center") // promote horizontal align to parent block
     val (pOpt, imgOpt) = img.options.styles.foldLeft((NoOpt: Options, Options(img.options.id))) {

--- a/core/shared/src/main/scala/laika/rst/std/StandardDirectiveParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardDirectiveParsers.scala
@@ -16,12 +16,12 @@
 
 package laika.rst.std
 
-import laika.ast._
+import laika.ast.*
 import laika.parse.{ BlockSource, Parser, SourceFragment }
 import laika.parse.markup.{ RecursiveParsers, RecursiveSpanParser }
 import laika.parse.text.CharGroup
-import laika.parse.builders._
-import laika.parse.implicits._
+import laika.parse.builders.*
+import laika.parse.implicits.*
 import laika.rst.BaseParsers.simpleRefName
 import laika.rst.TableParsers
 import laika.rst.ast.ReferenceName
@@ -33,7 +33,7 @@ import laika.rst.ast.ReferenceName
   *
   *  @author Jens Halm
   */
-object StandardDirectiveParsers {
+private[std] object StandardDirectiveParsers {
 
   /** Utility method to be used by custom parsers for directive argument or body.
     *  It translates a `Success` into a `Right` and a `NoSuccess` into a `Left`.

--- a/core/shared/src/main/scala/laika/rst/std/StandardDirectiveParts.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardDirectiveParts.scala
@@ -16,18 +16,18 @@
 
 package laika.rst.std
 
-import laika.ast._
-import laika.parse.implicits._
+import laika.ast.*
+import laika.parse.implicits.*
 import laika.parse.markup.RecursiveParsers
 import laika.parse.text.{ CharGroup, TextParsers }
 import laika.parse.{ GeneratedSource, SourceFragment }
 import laika.rst.BaseParsers.sizeAndUnit
 import laika.rst.ext.Directives.DirectivePartBuilder
-import laika.rst.ext.Directives.Parts._
+import laika.rst.ext.Directives.Parts.*
 
 /** @author Jens Halm
   */
-object StandardDirectiveParts {
+private[std] object StandardDirectiveParts {
 
   /** The name option which is supported by almost all reStructuredText directives.
     */
@@ -35,7 +35,7 @@ object StandardDirectiveParts {
 
   /** The class option which is supported by almost all reStructuredText directives.
     */
-  val classOpt: DirectivePartBuilder[Option[String]] = optField("class")
+  private val classOpt: DirectivePartBuilder[Option[String]] = optField("class")
 
   /** The standard class and name options supported by most directives,
     *  combined in the result into an Options instance.

--- a/core/shared/src/main/scala/laika/rst/std/StandardSpanDirectives.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardSpanDirectives.scala
@@ -37,7 +37,7 @@ import laika.time.PlatformDateTime
   *
   *  @author Jens Halm
   */
-class StandardSpanDirectives {
+private[rst] class StandardSpanDirectives {
 
   /** The replace directive,
     *  see [[http://docutils.sourceforge.net/docs/ref/rst/directives.html#replacement-text]] for details.

--- a/core/shared/src/main/scala/laika/rst/std/StandardTextRoles.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardTextRoles.scala
@@ -68,7 +68,7 @@ import scala.collection.immutable.TreeSet
   *
   *  @author Jens Halm
   */
-class StandardTextRoles {
+private[rst] class StandardTextRoles {
 
   private val classOption = optField(
     "class",

--- a/core/shared/src/test/scala/laika/rst/ListParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/ListParsersSpec.scala
@@ -476,9 +476,9 @@ class DefinitionListSpec extends FunSuite with ListParserRunner with TestSourceB
 
 class FieldListSpec extends FunSuite with ListParserRunner {
 
-  def fl(fields: Field*): FieldList = FieldList(fields.toList)
+  private def fl(fields: Field*): FieldList = FieldList(fields.toList)
 
-  def field(name: String, blocks: Block*): Field = Field(List(Text(name)), blocks.toList)
+  private def field(name: String, blocks: Block*): Field = Field(List(Text(name)), blocks.toList)
 
   test("list with all bodies on the same line as the name") {
     val input =
@@ -522,15 +522,15 @@ class FieldListSpec extends FunSuite with ListParserRunner {
 
 class OptionListSpec extends FunSuite with ListParserRunner {
 
-  def optL(items: OptionListItem*): OptionList = OptionList(items.toList)
+  private def optL(items: OptionListItem*): OptionList = OptionList(items.toList)
 
-  def oli(name: String, value: Block*): OptionListItem =
+  private def oli(name: String, value: Block*): OptionListItem =
     OptionListItem(List(ProgramOption(name, None)), value.toList)
 
-  def oli(name: String, value: String): OptionListItem =
+  private def oli(name: String, value: String): OptionListItem =
     OptionListItem(List(ProgramOption(name, None)), List(p(value)))
 
-  def oli(name: String, argDelim: String, arg: String, value: String): OptionListItem =
+  private def oli(name: String, argDelim: String, arg: String, value: String): OptionListItem =
     OptionListItem(List(ProgramOption(name, Some(OptionArgument(arg, argDelim)))), List(p(value)))
 
   test("list with short posix options") {

--- a/core/shared/src/test/scala/laika/rst/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/RewriteRulesSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.rst
+
+import laika.api.builder.OperationConfig
+import laika.ast.*
+import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
+import laika.config.Config.ConfigResult
+import laika.config.{ Config, ConfigBuilder, LaikaKeys }
+import laika.parse.GeneratedSource
+import laika.rst.ast.Underline
+import munit.FunSuite
+
+class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with TestSourceBuilders {
+
+  private def rewritten(
+      root: RootElement,
+      withTitles: Boolean = true
+  ): ConfigResult[RootElement] = {
+    val config =
+      if (withTitles)
+        ConfigBuilder.empty.withValue(LaikaKeys.firstHeaderAsTitle, true).build
+      else Config.empty
+    val doc    = Document(Path.Root / "doc", root, config = config)
+    OperationConfig.default
+      .rewriteRulesFor(doc, RewritePhase.Resolve)
+      .flatMap(doc.rewrite(_).map(_.content))
+  }
+
+  private def linkIdRef(id: String = "name") =
+    LinkIdReference(List(Text("text")), id, generatedSource(s"<<$id>>"))
+
+  private def extLink(url: String) = SpanLink.external(url)("text")
+
+  private def runRoot(input: RootElement, expected: RootElement): Unit =
+    assertEquals(rewritten(input), Right(expected))
+
+  private def runRootWithoutTitles(input: RootElement, expected: RootElement): Unit =
+    assertEquals(rewritten(input, withTitles = false), Right(expected))
+
+  test("link id refs - resolve references when some parent element also gets rewritten") {
+    val rootElem = RootElement(
+      DecoratedHeader(Underline('#'), List(Text("text "), linkIdRef()), GeneratedSource),
+      LinkDefinition("name", ExternalTarget("http://foo/"))
+    )
+    val resolved =
+      RootElement(Title(List(Text("text "), extLink("http://foo/")), Id("text-text") + Style.title))
+    runRoot(rootElem, resolved)
+  }
+
+  test("decorated headers - set the level of the header in a flat list of headers") {
+    val rootElem = RootElement(
+      DecoratedHeader(Underline('#'), List(Text("Title")), GeneratedSource),
+      DecoratedHeader(Underline('#'), List(Text("Header 1")), GeneratedSource),
+      DecoratedHeader(Underline('#'), List(Text("Header 2")), GeneratedSource)
+    )
+    val expected = RootElement(
+      Title(List(Text("Title")), Id("title") + Style.title),
+      Section(Header(1, List(Text("Header 1")), Id("header-1") + Style.section), Nil),
+      Section(Header(1, List(Text("Header 2")), Id("header-2") + Style.section), Nil)
+    )
+    runRoot(rootElem, expected)
+  }
+
+  test("decorated headers - set the level of the header in a nested list of headers") {
+    val rootElem = RootElement(
+      DecoratedHeader(Underline('#'), List(Text("Title")), GeneratedSource),
+      DecoratedHeader(Underline('#'), List(Text("Header 1")), GeneratedSource),
+      DecoratedHeader(Underline('-'), List(Text("Header 2")), GeneratedSource),
+      DecoratedHeader(Underline('#'), List(Text("Header 3")), GeneratedSource)
+    )
+    val expected = RootElement(
+      Title(List(Text("Title")), Id("title") + Style.title),
+      Section(
+        Header(1, List(Text("Header 1")), Id("header-1") + Style.section),
+        List(Section(Header(2, List(Text("Header 2")), Id("header-2") + Style.section), Nil))
+      ),
+      Section(Header(1, List(Text("Header 3")), Id("header-3") + Style.section), Nil)
+    )
+    runRoot(rootElem, expected)
+  }
+
+  test(
+    "decorated headers - do not create title nodes in the default configuration for orphan documents"
+  ) {
+    val rootElem = RootElement(
+      DecoratedHeader(Underline('#'), List(Text("Title")), GeneratedSource),
+      DecoratedHeader(Underline('#'), List(Text("Header 1")), GeneratedSource),
+      DecoratedHeader(Underline('#'), List(Text("Header 2")), GeneratedSource)
+    )
+    val expected = RootElement(
+      Section(Header(1, List(Text("Title")), Id("title") + Style.section), Nil),
+      Section(Header(1, List(Text("Header 1")), Id("header-1") + Style.section), Nil),
+      Section(Header(1, List(Text("Header 2")), Id("header-2") + Style.section), Nil)
+    )
+    runRootWithoutTitles(rootElem, expected)
+  }
+
+}


### PR DESCRIPTION
This is the final PR for #452.

It covers the packages `laika.markdown` (Markdown parser) and  `laika.rst` (reStructuredText parser) and all their sub-packages.

Both parsers are completely removed from public API, as it is unlikely that user code will need to reference the internals directly. Only two aspects are worth mentioning explicitly:

The `GitHubFlavor` extension which needs to be enabled explicitly by user code remains public for this purpose. It will move to a different package in a later milestone (e.g. `laika.bundle` which could host all built-in extensions).

And secondly, removing the reStructuredText parser from public API means that this also includes the APIs for builing "rst-native" directives, which have a different syntax than Laika's own directives. These APIs have never been documented in the manual and it is generally recommended that developers use the more versatile Laika syntax which can be used for any markup format. The implementation must be kept simply to support the existing directives as defined in the rst spec.