### PR TITLE
RewriteRules should not be a case class

### DIFF
--- a/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
@@ -50,13 +50,8 @@ private[api] trait TransformerBuilderOps[FMT] extends ParserBuilderOps
     *  been processed.
     */
   def usingRules(newRules: RewriteRules): ThisType = using(new ExtensionBundle {
-    val description: String = "Custom rewrite rules"
-
-    override def rewriteRules: RewritePhaseBuilder = {
-      case RewritePhase.Build     => Seq(newRules.copy(templateRules = Nil).asBuilder)
-      case RewritePhase.Render(_) =>
-        Seq(RewriteRules(templateRules = newRules.templateRules).asBuilder)
-    }
+    val description: String                        = "Custom rewrite rules"
+    override def rewriteRules: RewritePhaseBuilder = newRules.asDefaultPhaseBuilder
 
   })
 

--- a/core/shared/src/main/scala/laika/ast/containers.scala
+++ b/core/shared/src/main/scala/laika/ast/containers.scala
@@ -62,7 +62,7 @@ trait RewritableContainer extends Element {
     * elements they contain, plus optionally for any other elements that have custom support for rewriting.
     */
   def rewriteSpans(rule: RewriteRule[Span]): Self = rewriteChildren(
-    RewriteRules(spanRules = Seq(rule))
+    RewriteRules.forSpans(rule)
   )
 
 }
@@ -80,7 +80,7 @@ trait BlockContainer extends ElementContainer[Block] with RewritableContainer {
     * elements they contain, plus optionally for any other elements that have custom support for rewriting.
     */
   def rewriteBlocks(rules: RewriteRule[Block]): Self = rewriteChildren(
-    RewriteRules(blockRules = Seq(rules))
+    RewriteRules.forBlocks(rules)
   )
 
   def rewriteChildren(rules: RewriteRules): Self = withContent(rules.rewriteBlocks(content))

--- a/core/shared/src/main/scala/laika/ast/templates.scala
+++ b/core/shared/src/main/scala/laika/ast/templates.scala
@@ -36,7 +36,7 @@ trait TemplateSpanContainer extends ElementContainer[TemplateSpan] with Rewritab
     * elements they contain, plus optionally for any other elements that have custom support for rewriting.
     */
   def rewriteTemplateSpans(rules: RewriteRule[TemplateSpan]): Self = rewriteChildren(
-    RewriteRules(templateRules = Seq(rules))
+    RewriteRules.forTemplates(rules)
   )
 
   def rewriteChildren(rules: RewriteRules): Self = withContent(rules.rewriteTemplateSpans(content))

--- a/io/src/main/scala/laika/theme/ThemeBuilder.scala
+++ b/io/src/main/scala/laika/theme/ThemeBuilder.scala
@@ -121,11 +121,7 @@ class ThemeBuilder[F[_]: Monad] private[laika] (
       themeName,
       inputs,
       extensions,
-      bundleBuilder.addRewriteRules {
-        case RewritePhase.Build     => Seq(rules.copy(templateRules = Nil).asBuilder)
-        case RewritePhase.Render(_) =>
-          Seq(RewriteRules(templateRules = rules.templateRules).asBuilder)
-      },
+      bundleBuilder.addRewriteRules(rules.asDefaultPhaseBuilder),
       treeProcessors
     )
 


### PR DESCRIPTION
This type captures partial functions and does not naturally support structural equality.

The `copy` method is not essential either, as it's a type that is commonly just constructed once and then passed to the Laika setup APIs. If needed, multiple instances can be constructed and combined with `++`.