### PR TITLE
reduce use of case classes in Document APIs

### DIFF
--- a/core/shared/src/main/scala/laika/api/MarkupParser.scala
+++ b/core/shared/src/main/scala/laika/api/MarkupParser.scala
@@ -88,9 +88,7 @@ class MarkupParser private[laika] (val format: MarkupFormat, val config: Operati
       val embeddedConfig = unresolved.document.content.collect { case c: EmbeddedConfigValue =>
         (c.key, c.value)
       }
-      unresolved.document.copy(
-        config = merge(docConfig, embeddedConfig)
-      )
+      unresolved.document.withConfig(merge(docConfig, embeddedConfig))
     }
 
     def rewritePhase(doc: Document, phase: RewritePhase): Either[ParserError, Document] = for {

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -289,7 +289,7 @@ class TreeCursor private (
       )
 
     (rewrittenTitle, rewrittenContent).parMapN { (title, content) =>
-      target.withContent(content).withTitleDocument(title).withPosition(position)
+      target.replaceContent(content).withTitleDocument(title).withPosition(position)
     }
       .leftMap(TreeConfigErrors.apply)
   }

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -17,18 +17,20 @@
 package laika.ast
 
 import cats.data.NonEmptyChain
-import cats.syntax.all._
+import cats.syntax.all.*
 import laika.ast.Path.Root
 import laika.ast.RewriteRules.RewriteRulesBuilder
-import laika.collection.TransitionalCollectionOps._
+import laika.collection.TransitionalCollectionOps.*
 import laika.config.Config.ConfigResult
 import laika.config.{
   Config,
   ConfigEncoder,
+  ConfigError,
   ConfigValue,
   DocumentConfigErrors,
   Key,
   LaikaKeys,
+  Origin,
   TreeConfigErrors
 }
 import laika.parse.SourceFragment
@@ -123,7 +125,7 @@ class RootCursor private (
   /** The cursor for the cover document of this tree.
     */
   lazy val coverDocument: Option[DocumentCursor] = target.coverDocument.map { cover =>
-    DocumentCursor(cover, tree, cover.config, TreePosition.root)
+    DocumentCursor(cover, tree)
   }
 
   /** All documents contained in this tree, fetched recursively, depth-first.
@@ -198,32 +200,37 @@ object RootCursor {
 
 }
 
-/** Cursor for an entire document tree, providing access to all
-  * child cursors of this tree and allowing to trigger rewrite
-  * operations.
+/** Cursor for an entire document tree, providing access to all child cursors of this tree
+  * and allowing to trigger rewrite operations.
   *
   * @param target the document tree this cursor points to
   * @param parent the immediate parent of this tree or `None` if this is the root
   * @param root the root of this tree
-  * @param config the configuration associated with this tree
-  * @param position the position of this tree within the document tree
   */
-case class TreeCursor(
-    target: DocumentTree,
-    parent: Option[TreeCursor],
-    root: RootCursor,
-    config: Config,
-    position: TreePosition
+class TreeCursor private (
+    val target: DocumentTree,
+    val parent: Option[TreeCursor],
+    val root: RootCursor
 ) extends Cursor {
 
   type Target = DocumentTree
 
   val path: Path = target.path
 
+  val position: TreePosition = target.position
+
+  val config: Config = target.config
+
   /** The cursor for the title document of this tree.
     */
   lazy val titleDocument: Option[DocumentCursor] = target.titleDocument.map { title =>
-    DocumentCursor(title, this, title.config, position)
+    DocumentCursor(
+      title.copy(
+        config = AutonumberConfig.withoutSectionNumbering(title.config),
+        position = position
+      ),
+      this
+    )
   }
 
   /** The cursors for all children of this node in the document tree.
@@ -232,9 +239,9 @@ case class TreeCursor(
 
     target.content.zipWithIndex map {
       case (doc: Document, index)      =>
-        DocumentCursor(doc, this, doc.config, position.forChild(index + 1))
+        DocumentCursor(doc.copy(position = position.forChild(index + 1)), this)
       case (tree: DocumentTree, index) =>
-        TreeCursor(tree, Some(this), root, tree.config, position.forChild(index + 1))
+        new TreeCursor(tree.copy(position = position.forChild(index + 1)), Some(this), root)
     }
   }
 
@@ -252,6 +259,9 @@ case class TreeCursor(
     collect(this)
   }
 
+  private[laika] def applyPosition(position: TreePosition): TreeCursor =
+    new TreeCursor(target.copy(position = position), parent, root)
+
   /** Returns a new tree, with all the document models contained in it
     * rewritten based on the specified rewrite rule.
     */
@@ -264,7 +274,6 @@ case class TreeCursor(
     val rewrittenTitle = titleDocument
       .traverse { doc =>
         doc
-          .copy(config = AutonumberConfig.withoutSectionNumbering(doc.config))
           .rewriteTarget(rules)
           .toEitherNec
       }
@@ -290,7 +299,7 @@ case class TreeCursor(
 object TreeCursor {
 
   private[ast] def apply(root: RootCursor): TreeCursor =
-    apply(root.target.tree, None, root, root.config, TreePosition.root)
+    new TreeCursor(root.target.tree, None, root)
 
   /** Creates a new cursor for the specified document tree.
     */
@@ -309,24 +318,28 @@ object TreeCursor {
   *  @param target the document this cursor points to
   *  @param parent the parent document tree of the referred document
   *  @param resolver the resolver for references in templates
-  *  @param config the configuration associated with the target document
   *  @param templatePath the path of the template that has been applied to this document
-  *  @param position the position of the target document inside a tree hierarchy
   */
-case class DocumentCursor(
-    target: Document,
-    parent: TreeCursor,
+class DocumentCursor private (
+    val target: Document,
+    val parent: TreeCursor,
     resolver: ReferenceResolver,
-    config: Config,
-    templatePath: Option[Path],
-    position: TreePosition
+    val templatePath: Option[Path]
 ) extends Cursor { self =>
 
   type Target = Document
 
   val path: Path = target.path
 
+  val position: TreePosition = target.position
+
   lazy val root: RootCursor = parent.root
+
+  /** The configuration for this document cursor,
+    * containing all config values of the underlying target document,
+    * plus additional values for navigating parents and siblings.
+    */
+  val config: Config = resolver.config
 
   private lazy val validator = new LinkValidator(this, root.targetLookup)
 
@@ -426,7 +439,39 @@ case class DocumentCursor(
     *  for a nested part inside the directive tags.
     */
   def withReferenceContext[T: ConfigEncoder](refValue: T): DocumentCursor =
-    copy(resolver = ReferenceResolver(resolver.config.withValue("_", refValue).build))
+    new DocumentCursor(
+      target,
+      parent,
+      new ReferenceResolver(config.withValue("_", refValue).build),
+      templatePath
+    )
+
+  // TODO - M3 - temp??
+  private[laika] def applyPosition(position: TreePosition): DocumentCursor =
+    new DocumentCursor(target.copy(position = position), parent, resolver, templatePath)
+
+  /** Creates a new cursor for this document where the specified template
+    * is associated with the new cursor.
+    */
+  private[laika] def applyTemplate(
+      template: TemplateDocument
+  ): Either[ConfigError, DocumentCursor] =
+    template.config.resolve(
+      Origin(Origin.TemplateScope, template.path),
+      config,
+      root.target.includes
+    ).map { mergedConfig =>
+      val mergedTarget = target.copy(config = mergedConfig)
+      new DocumentCursor(
+        mergedTarget,
+        parent,
+        resolver = ReferenceResolver.forDocument(
+          mergedTarget,
+          parent
+        ),
+        templatePath = Some(template.path)
+      )
+    }
 
   /** Validates the specified link, verifying that the target exists and supports a matching set of target formats.
     * The returned ADT provides one of three possible outcomes, apart from a valid or invalid result,
@@ -463,24 +508,20 @@ object DocumentCursor {
       outputContext: Option[OutputContext] = None
   ): Either[TreeConfigErrors, DocumentCursor] =
     TreeCursor(DocumentTree(Root, Seq(document)), outputContext)
-      .map(apply(document, _, document.config, document.position))
+      .map(apply(document, _))
 
   /** Creates a cursor for a document and full context information:
     * its parent, configuration and position within the document tree.
     */
   private[ast] def apply(
       document: Document,
-      parent: TreeCursor,
-      config: Config,
-      position: TreePosition
+      parent: TreeCursor
   ): DocumentCursor =
-    apply(
+    new DocumentCursor(
       document,
       parent,
-      ReferenceResolver.forDocument(document, parent, config),
-      config,
-      None,
-      position
+      ReferenceResolver.forDocument(document, parent),
+      None
     )
 
 }

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -139,7 +139,7 @@ class RootCursor private (
     val result = for {
       rewrittenCover <- coverDocument.traverse(_.rewriteTarget(rules).toEitherNec)
       rewrittenTree  <- tree.rewriteTarget(rules).leftMap(_.failures)
-    } yield target.copy(coverDocument = rewrittenCover, tree = rewrittenTree)
+    } yield target.withCoverDocument(rewrittenCover).modifyTree(_ => rewrittenTree)
     result.leftMap(TreeConfigErrors.apply)
   }
 

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -241,7 +241,7 @@ class TreeCursor private (
       case (doc: Document, index)      =>
         DocumentCursor(doc.copy(position = position.forChild(index + 1)), this)
       case (tree: DocumentTree, index) =>
-        new TreeCursor(tree.withPosition(position.forChild(index + 1)), Some(this), root)
+        new TreeCursor(tree.withPosition(index + 1), Some(this), root)
     }
   }
 
@@ -259,8 +259,8 @@ class TreeCursor private (
     collect(this)
   }
 
-  private[laika] def applyPosition(position: TreePosition): TreeCursor =
-    new TreeCursor(target.withPosition(position), parent, root)
+  private[laika] def applyPosition(index: Int): TreeCursor =
+    new TreeCursor(target.withPosition(index), parent, root)
 
   /** Returns a new tree, with all the document models contained in it
     * rewritten based on the specified rewrite rule.
@@ -289,7 +289,7 @@ class TreeCursor private (
       )
 
     (rewrittenTitle, rewrittenContent).parMapN { (title, content) =>
-      target.replaceContent(content).withTitleDocument(title).withPosition(position)
+      target.replaceContent(content).withTitleDocument(title)
     }
       .leftMap(TreeConfigErrors.apply)
   }

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -241,7 +241,7 @@ class TreeCursor private (
       case (doc: Document, index)      =>
         DocumentCursor(doc.copy(position = position.forChild(index + 1)), this)
       case (tree: DocumentTree, index) =>
-        new TreeCursor(tree.copy(position = position.forChild(index + 1)), Some(this), root)
+        new TreeCursor(tree.withPosition(position.forChild(index + 1)), Some(this), root)
     }
   }
 
@@ -260,7 +260,7 @@ class TreeCursor private (
   }
 
   private[laika] def applyPosition(position: TreePosition): TreeCursor =
-    new TreeCursor(target.copy(position = position), parent, root)
+    new TreeCursor(target.withPosition(position), parent, root)
 
   /** Returns a new tree, with all the document models contained in it
     * rewritten based on the specified rewrite rule.
@@ -289,7 +289,7 @@ class TreeCursor private (
       )
 
     (rewrittenTitle, rewrittenContent).parMapN { (title, content) =>
-      target.copy(content = content, titleDocument = title, position = position)
+      target.withContent(content).withTitleDocument(title).withPosition(position)
     }
       .leftMap(TreeConfigErrors.apply)
   }
@@ -507,7 +507,7 @@ object DocumentCursor {
       document: Document,
       outputContext: Option[OutputContext] = None
   ): Either[TreeConfigErrors, DocumentCursor] =
-    TreeCursor(DocumentTree(Root, Seq(document)), outputContext)
+    TreeCursor(DocumentTree.builder.addDocument(document).build, outputContext)
       .map(apply(document, _))
 
   /** Creates a cursor for a document and full context information:

--- a/core/shared/src/main/scala/laika/ast/DocumentTreeBuilder.scala
+++ b/core/shared/src/main/scala/laika/ast/DocumentTreeBuilder.scala
@@ -197,7 +197,10 @@ class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.Builde
     } yield {
       val (cover, content) = extract(resolvedTree.content, "cover")
       val rootTree         = resolvedTree.replaceContent(content)
-      DocumentTreeRoot(rootTree, cover, styles, includes = includes)
+      DocumentTreeRoot(rootTree)
+        .withCoverDocument(cover)
+        .addStyles(styles)
+        .addIncludes(includes)
     }
   }
 
@@ -255,7 +258,7 @@ class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.Builde
   def buildRoot(baseConfig: Config): DocumentTreeRoot = {
     val tree             = build(baseConfig)
     val (cover, content) = extract(tree.content, "cover")
-    DocumentTreeRoot(tree.replaceContent(content), cover)
+    DocumentTreeRoot(tree.withContent(content)).withCoverDocument(cover)
   }
 
   /** Builds a `DocumentTree` from the provided instances and wires the

--- a/core/shared/src/main/scala/laika/ast/DocumentTreeBuilder.scala
+++ b/core/shared/src/main/scala/laika/ast/DocumentTreeBuilder.scala
@@ -156,7 +156,7 @@ class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.Builde
       resolvedTree <- resolveAndBuildTree(tree, baseConfig, includes)
     } yield {
       val (cover, content) = extract(resolvedTree.content, "cover")
-      val rootTree         = resolvedTree.withContent(content)
+      val rootTree         = resolvedTree.replaceContent(content)
       DocumentTreeRoot(rootTree, cover, styles, includes = includes)
     }
   }
@@ -215,7 +215,7 @@ class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.Builde
   def buildRoot(baseConfig: Config): DocumentTreeRoot = {
     val tree             = build(baseConfig)
     val (cover, content) = extract(tree.content, "cover")
-    DocumentTreeRoot(tree.withContent(content), cover)
+    DocumentTreeRoot(tree.replaceContent(content), cover)
   }
 
   /** Builds a `DocumentTree` from the provided instances and wires the

--- a/core/shared/src/main/scala/laika/ast/DocumentTreeBuilder.scala
+++ b/core/shared/src/main/scala/laika/ast/DocumentTreeBuilder.scala
@@ -34,8 +34,8 @@ import scala.collection.mutable
   */
 class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.BuilderPart] = Nil) {
 
-  import laika.collection.TransitionalCollectionOps._
-  import DocumentTreeBuilder._
+  import laika.collection.TransitionalCollectionOps.*
+  import DocumentTreeBuilder.*
 
   private[laika] lazy val distinctParts: List[BuilderPart] = {
     /* distinctBy does not exist in 2.12
@@ -109,7 +109,7 @@ class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.Builde
       }
     } yield {
       val (title, content) = extract(resolvedContent, titleName)
-      DocumentTree(result.path, content, title, result.templates, treeConfig)
+      new DocumentTree(result.path, content, title, result.templates, treeConfig)
     }
   }
 
@@ -127,7 +127,7 @@ class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.Builde
       case _: MarkupPart     => None
     }
     val (title, content) = extract(allContent, titleName)
-    DocumentTree(result.path, content, title, result.templates, treeConfig)
+    new DocumentTree(result.path, content, title, result.templates, treeConfig)
   }
 
   private def collectStyles(parts: Seq[BuilderPart]): Map[String, StyleDeclarationSet] = parts
@@ -156,7 +156,7 @@ class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.Builde
       resolvedTree <- resolveAndBuildTree(tree, baseConfig, includes)
     } yield {
       val (cover, content) = extract(resolvedTree.content, "cover")
-      val rootTree         = resolvedTree.copy(content = content)
+      val rootTree         = resolvedTree.withContent(content)
       DocumentTreeRoot(rootTree, cover, styles, includes = includes)
     }
   }
@@ -215,7 +215,7 @@ class DocumentTreeBuilder private[laika] (parts: List[DocumentTreeBuilder.Builde
   def buildRoot(baseConfig: Config): DocumentTreeRoot = {
     val tree             = build(baseConfig)
     val (cover, content) = extract(tree.content, "cover")
-    DocumentTreeRoot(tree.copy(content = content), cover)
+    DocumentTreeRoot(tree.withContent(content), cover)
   }
 
   /** Builds a `DocumentTree` from the provided instances and wires the

--- a/core/shared/src/main/scala/laika/ast/TreePosition.scala
+++ b/core/shared/src/main/scala/laika/ast/TreePosition.scala
@@ -22,17 +22,16 @@ import scala.annotation.tailrec
   *
   * @author Jens Halm
   */
-class TreePosition private (private val positions: Option[Seq[Int]]) extends Ordered[TreePosition] {
+class TreePosition private (private val positions: Seq[Int]) extends Ordered[TreePosition] {
 
   /** The positions (one-based) of each nesting level of this instance
     * (an empty sequence for the root or orphan positions).
     */
-  def toSeq: Seq[Int] = positions.getOrElse(Nil)
+  def toSeq: Seq[Int] = positions
 
   override def toString: String = positions match {
-    case None      => "TreePosition.orphan"
-    case Some(Nil) => "TreePosition.root"
-    case Some(pos) => s"TreePosition(${pos.mkString(".")})"
+    case Nil => "TreePosition.root"
+    case pos => s"TreePosition(${pos.mkString(".")})"
   }
 
   /** This tree position as a span that can get rendered
@@ -46,7 +45,7 @@ class TreePosition private (private val positions: Option[Seq[Int]]) extends Ord
 
   /** Creates a position instance for a child of this element.
     */
-  def forChild(childPos: Int) = TreePosition(toSeq :+ childPos)
+  def forChild(childPos: Int): TreePosition = TreePosition(positions :+ childPos)
 
   def compare(other: TreePosition): Int = {
 
@@ -74,11 +73,6 @@ class TreePosition private (private val positions: Option[Seq[Int]]) extends Ord
 }
 
 object TreePosition {
-  def apply(pos: Seq[Int]) = new TreePosition(Some(pos))
-  val root                 = new TreePosition(Some(Nil))
-
-  /** A document has an orphaned position assigned when it is processed on its own,
-    * not as part of a tree of documents.
-    */
-  val orphan = new TreePosition(None)
+  def apply(pos: Seq[Int]) = new TreePosition(pos)
+  val root                 = new TreePosition(Nil)
 }

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -309,12 +309,15 @@ class DocumentTree(
   ): DocumentTree = new DocumentTree(path, content, titleDocument, templates, config, position)
 
   private[laika] def withPosition(pos: TreePosition): DocumentTree = copy(position = pos)
+  private[laika] def withoutTemplates: DocumentTree = copy(templates = Nil)
 
   def withConfig(config: Config): DocumentTree                = copy(config = config)
   def withTitleDocument(doc: Document): DocumentTree          = copy(titleDocument = Some(doc))
   def withTitleDocument(doc: Option[Document]): DocumentTree  = copy(titleDocument = doc)
   def withContent(newContent: Seq[TreeContent]): DocumentTree = copy(content = newContent)
-  def withTemplates(templates: Seq[TemplateDocument]): DocumentTree = copy(templates = templates)
+
+  def addTemplate(template: TemplateDocument): DocumentTree =
+    copy(templates = templates :+ template)
 
   /** The title of this tree, obtained from configuration.
     */

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -308,8 +308,9 @@ class DocumentTree(
       position: TreePosition = this.position
   ): DocumentTree = new DocumentTree(path, content, titleDocument, templates, config, position)
 
+  private[laika] def withPosition(pos: TreePosition): DocumentTree = copy(position = pos)
+
   def withConfig(config: Config): DocumentTree                = copy(config = config)
-  def withPosition(pos: TreePosition): DocumentTree           = copy(position = pos)
   def withTitleDocument(doc: Document): DocumentTree          = copy(titleDocument = Some(doc))
   def withTitleDocument(doc: Option[Document]): DocumentTree  = copy(titleDocument = doc)
   def withContent(newContent: Seq[TreeContent]): DocumentTree = copy(content = newContent)

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -353,10 +353,7 @@ class Document(
 
 object Document {
 
-  def apply(path: Path, content: RootElement): Document = apply(path, content, Map.empty)
-
-  // TODO - M3 - this might be unnecessary
-  def apply(path: Path, content: RootElement, fragments: Map[String, Element]): Document = {
+  def apply(path: Path, content: RootElement): Document = {
 
     def contextFor(path: Path): TreeNodeContext = {
       val parent = path.parent match {
@@ -366,7 +363,7 @@ object Document {
       TreeNodeContext(localPath = Some(path.name), parent = parent)
     }
 
-    new Document(contextFor(path), content, fragments)
+    new Document(contextFor(path), content)
   }
 
 }

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -96,11 +96,14 @@ sealed trait TreeContent extends Navigatable {
 /** A template document containing the element tree of a parsed template and its extracted
   *  configuration section (if present).
   */
-case class TemplateDocument(
-    path: Path,
-    content: TemplateRoot,
-    config: ConfigParser = ConfigParser.empty
+class TemplateDocument private (
+    val path: Path,
+    val content: TemplateRoot,
+    val config: ConfigParser
 ) extends Navigatable {
+
+  def withConfig(config: ConfigParser): TemplateDocument =
+    new TemplateDocument(path, content, config)
 
   /** Applies this template to the specified document, replacing all
     *  span and block resolvers in the template with the final resolved element.
@@ -112,6 +115,13 @@ case class TemplateDocument(
   ): Either[ConfigError, Document] =
     DocumentCursor(document, Some(outputContext))
       .flatMap(TemplateRewriter.applyTemplate(_, _ => Right(rules), this))
+
+}
+
+object TemplateDocument {
+
+  def apply(path: Path, root: TemplateRoot): TemplateDocument =
+    new TemplateDocument(path, root, ConfigParser.empty)
 
 }
 

--- a/core/shared/src/main/scala/laika/config/Config.scala
+++ b/core/shared/src/main/scala/laika/config/Config.scala
@@ -164,6 +164,8 @@ trait Config {
     */
   def withOrigin(origin: Origin): Config
 
+  private[laika] def withoutFallback: Config
+
 }
 
 /** The default implementation of the Config API.
@@ -224,6 +226,8 @@ private[laika] class ObjectConfig(
     case _           => new ObjectConfig(root, origin, fallback.withFallback(other))
   }
 
+  private[laika] def withoutFallback: Config = new ObjectConfig(root, origin)
+
   def withOrigin(newOrigin: Origin): Config = new ObjectConfig(root, newOrigin, fallback)
 
   override def hashCode: Int = (root, origin, fallback).hashCode
@@ -246,6 +250,8 @@ private[config] object EmptyConfig extends Config {
   def get[T](key: Key)(implicit decoder: ConfigDecoder[T]): ConfigResult[T] = Left(NotFound(key))
 
   def withFallback(other: Config): Config = other
+
+  private[laika] def withoutFallback: Config = this
 
   def withOrigin(newOrigin: Origin): Config = this
 }

--- a/core/shared/src/main/scala/laika/config/LaikaKeys.scala
+++ b/core/shared/src/main/scala/laika/config/LaikaKeys.scala
@@ -60,6 +60,8 @@ object LaikaKeys {
 
   val versions: Key = root.child("versions")
 
+  val orphan: Key = root.child("orphan")
+
   object titleDocuments {
     val inputName: Key  = root.child(Key("titleDocuments", "inputName"))
     val outputName: Key = root.child(Key("titleDocuments", "outputName"))

--- a/core/shared/src/main/scala/laika/directive/std/IncludeDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/IncludeDirectives.scala
@@ -107,7 +107,7 @@ private[laika] object IncludeDirectives {
 
     (attribute(0).as[Path], attribute(0).as[String], allAttributes, cursor, source).mapN {
       case (literalPath, pathKey, attributes, cursor, source) =>
-        resolvePath(literalPath, pathKey, cursor.resolver.config)
+        resolvePath(literalPath, pathKey, cursor.config)
           .flatMap(resolveTemplateReference(_, attributes, cursor, source))
     }
   }
@@ -126,7 +126,7 @@ private[laika] object IncludeDirectives {
       cursor,
       source
     ).mapN { case (literalPath, pathKey, attributes, body, cursor, source) =>
-      resolvePath(literalPath, pathKey, cursor.resolver.config)
+      resolvePath(literalPath, pathKey, cursor.config)
         .flatMap(resolveTemplateReference(_, attributes, cursor, source, Some(body)))
     }
   }
@@ -139,7 +139,7 @@ private[laika] object IncludeDirectives {
 
     (attribute(0).as[Path], attribute(0).as[String], allAttributes, cursor, source).mapN {
       case (literalPath, pathKey, attributes, cursor, source) =>
-        resolvePath(literalPath, pathKey, cursor.resolver.config)
+        resolvePath(literalPath, pathKey, cursor.config)
           .flatMap(resolveDocumentReference(_, attributes, cursor, source))
     }
   }
@@ -158,7 +158,7 @@ private[laika] object IncludeDirectives {
       cursor,
       source
     ).mapN { case (literalPath, pathKey, attributes, body, cursor, source) =>
-      resolvePath(literalPath, pathKey, cursor.resolver.config)
+      resolvePath(literalPath, pathKey, cursor.config)
         .flatMap(resolveDocumentReference(_, attributes, cursor, source, Some(body)))
     }
   }

--- a/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
@@ -137,7 +137,7 @@ private[laika] object StandardDirectives extends DirectiveRegistry {
             }
         }
 
-        val config = cursor.resolver.config
+        val config = cursor.config
         if (config.hasKey(pathKey))
           config.get[Target](pathKey).leftMap(_.message).flatMap(resolveTarget)
         else resolveTarget(literalTarget)
@@ -154,9 +154,9 @@ private[laika] object StandardDirectives extends DirectiveRegistry {
       cursor
     ).mapN { (refKey, pattern, localeAttr, cursor) =>
       val locale = localeAttr
-        .orElse(cursor.resolver.config.get[String](LaikaKeys.metadata.child("language")).toOption)
+        .orElse(cursor.config.get[String](LaikaKeys.metadata.child("language")).toOption)
 
-      cursor.resolver.config.get[PlatformDateTime.Type](refKey).leftMap(_.message).flatMap { date =>
+      cursor.config.get[PlatformDateTime.Type](refKey).leftMap(_.message).flatMap { date =>
         PlatformDateTime
           .formatConstant(date, pattern, locale)
           .getOrElse(PlatformDateTime.format(date, pattern, locale))

--- a/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
@@ -200,7 +200,7 @@ object DocumentParser {
   ): DocumentInput => Either[ParserError, UnresolvedDocument] =
     create(rootParser, configProvider.markupConfigHeader) { (path, config, root) =>
       val fragments = root.collect { case f: DocumentFragment => (f.name, f.root) }.toMap
-      UnresolvedDocument(Document(path, root, fragments), config)
+      UnresolvedDocument(Document(path, root).withFragments(fragments), config)
     }
 
   /** Combines the specified parsers for the root element and for (optional) configuration

--- a/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
@@ -211,7 +211,7 @@ object DocumentParser {
       configProvider: ConfigProvider
   ): DocumentInput => Either[ParserError, TemplateDocument] =
     create(rootParser, configProvider.templateConfigHeader) { (path, config, root) =>
-      TemplateDocument(path, root, config)
+      TemplateDocument(path, root).withConfig(config)
     }
 
   /** Builds a document parser for CSS documents based on the specified parser for style declarations.

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -81,7 +81,7 @@ private[laika] trait TemplateRewriter {
         case tree: TreeCursor    => applyTemplates(tree, rules, context)
       }
     } yield {
-      cursor.target.withContent(newContent).withTitleDocument(newTitle).withoutTemplates
+      cursor.target.replaceContent(newContent).withTitleDocument(newTitle).withoutTemplates
     }
   }
 

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -81,7 +81,7 @@ private[laika] trait TemplateRewriter {
         case tree: TreeCursor    => applyTemplates(tree, rules, context)
       }
     } yield {
-      cursor.target.withContent(newContent).withTitleDocument(newTitle).withTemplates(Nil)
+      cursor.target.withContent(newContent).withTitleDocument(newTitle).withoutTemplates
     }
   }
 

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -111,11 +111,7 @@ private[laika] trait TemplateRewriter {
           case TemplateRoot(List(EmbeddedRoot(content, _, _)), _) => RootElement(content)
           case other                                              => RootElement(other)
         }
-        mergedCursor.target
-          .withContent(newRoot, mergedCursor.target.fragments)
-          .withConfig(
-            mergedCursor.config
-          ) // TODO - M3 - try to remove this line, the target should already have the merged config applied
+        mergedCursor.target.withContent(newRoot)
       }
     }
   }

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -81,11 +81,7 @@ private[laika] trait TemplateRewriter {
         case tree: TreeCursor    => applyTemplates(tree, rules, context)
       }
     } yield {
-      cursor.target.copy(
-        titleDocument = newTitle,
-        content = newContent,
-        templates = Nil
-      )
+      cursor.target.withContent(newContent).withTitleDocument(newTitle).withTemplates(Nil)
     }
   }
 

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -60,10 +60,7 @@ private[laika] trait TemplateRewriter {
         .traverse(applyTemplate(_, rules, context))
       newTree  <- applyTemplates(cursor.tree, rules, context)
     } yield {
-      cursor.target.copy(
-        coverDocument = newCover,
-        tree = newTree
-      )
+      cursor.target.withCoverDocument(newCover).modifyTree(_ => newTree)
     }
   }
 

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -111,7 +111,11 @@ private[laika] trait TemplateRewriter {
           case TemplateRoot(List(EmbeddedRoot(content, _, _)), _) => RootElement(content)
           case other                                              => RootElement(other)
         }
-        mergedCursor.target.copy(content = newRoot, config = mergedCursor.config)
+        mergedCursor.target
+          .withContent(newRoot, mergedCursor.target.fragments)
+          .withConfig(
+            mergedCursor.config
+          ) // TODO - M3 - try to remove this line, the target should already have the merged config applied
       }
     }
   }

--- a/core/shared/src/main/scala/laika/rewrite/nav/AutonumberConfig.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/AutonumberConfig.scala
@@ -18,6 +18,7 @@ package laika.rewrite.nav
 
 import laika.config.{
   Config,
+  ConfigBuilder,
   ConfigDecoder,
   ConfigEncoder,
   DefaultKey,
@@ -91,13 +92,13 @@ object AutonumberConfig {
   /** Disables section numbering for the specified config instance.
     * Retains the existing value for auto-numbering of documents.
     */
-  def withoutSectionNumbering(config: Config): Config = {
+  def withoutSectionNumbering(config: Config)(builder: ConfigBuilder): ConfigBuilder = {
     val key = LaikaKeys.autonumbering.child(scopeKey)
-    config.get[Scope](key).toOption.fold(config) {
-      case Scope.Documents => config
-      case Scope.Sections  => config.withValue(key, "none").build
-      case Scope.All       => config.withValue(key, "documents").build
-      case Scope.None      => config
+    config.get[Scope](key).toOption.fold(builder) {
+      case Scope.Documents => builder
+      case Scope.Sections  => builder.withValue(key, "none")
+      case Scope.All       => builder.withValue(key, "documents")
+      case Scope.None      => builder
     }
   }
 

--- a/core/shared/src/main/scala/laika/rewrite/nav/NavigationOrder.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/NavigationOrder.scala
@@ -36,21 +36,10 @@ private[laika] object NavigationOrder {
 
     def reAssignPosition(
         cursor: Cursor,
-        position: TreePosition,
-        configF: Config => Config = identity
+        position: TreePosition
     ): Cursor = cursor match {
-      case doc: DocumentCursor =>
-        doc.copy(
-          position = position,
-          target = doc.target.copy(position = position),
-          config = configF(cursor.config)
-        )
-      case tree: TreeCursor    =>
-        tree.copy(
-          position = position,
-          target = tree.target.copy(position = position),
-          config = configF(cursor.config)
-        )
+      case doc: DocumentCursor => doc.applyPosition(position)
+      case tree: TreeCursor    => tree.applyPosition(position)
     }
 
     def reAssignPositions(content: Seq[Cursor]): Seq[Cursor] =

--- a/core/shared/src/main/scala/laika/rewrite/nav/NavigationOrder.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/NavigationOrder.scala
@@ -30,15 +30,14 @@ private[laika] object NavigationOrder {
 
   def applyTo(
       content: Seq[Cursor],
-      config: Config,
-      parentPosition: TreePosition
+      config: Config
   ): ConfigResult[Seq[Cursor]] = {
 
     def reAssignPosition(
         cursor: Cursor,
         index: Int
     ): Cursor = cursor match {
-      case doc: DocumentCursor => doc.applyPosition(parentPosition.forChild(index))
+      case doc: DocumentCursor => doc.applyPosition(index)
       case tree: TreeCursor    => tree.applyPosition(index)
     }
 

--- a/core/shared/src/main/scala/laika/rewrite/nav/NavigationOrder.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/NavigationOrder.scala
@@ -36,15 +36,15 @@ private[laika] object NavigationOrder {
 
     def reAssignPosition(
         cursor: Cursor,
-        position: TreePosition
+        index: Int
     ): Cursor = cursor match {
-      case doc: DocumentCursor => doc.applyPosition(position)
-      case tree: TreeCursor    => tree.applyPosition(position)
+      case doc: DocumentCursor => doc.applyPosition(parentPosition.forChild(index))
+      case tree: TreeCursor    => tree.applyPosition(index)
     }
 
     def reAssignPositions(content: Seq[Cursor]): Seq[Cursor] =
       content.zipWithIndex.map { case (cursor, index) =>
-        reAssignPosition(cursor, parentPosition.forChild(index + 1))
+        reAssignPosition(cursor, index + 1)
       }
 
     config

--- a/core/shared/src/main/scala/laika/rewrite/nav/SectionBuilder.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/SectionBuilder.scala
@@ -128,7 +128,7 @@ private[laika] object SectionBuilder extends RewriteRulesBuilder {
     )
     firstHeaderAsTitle <- cursor.config.get(
       LaikaKeys.firstHeaderAsTitle,
-      cursor.position != TreePosition.orphan
+      !cursor.config.get[Boolean](LaikaKeys.orphan).getOrElse(false)
     )
   } yield new DefaultRule(autonumbering, firstHeaderAsTitle, cursor.position).rewrite
 

--- a/core/shared/src/test/scala/laika/api/RenderAPISpec.scala
+++ b/core/shared/src/test/scala/laika/api/RenderAPISpec.scala
@@ -19,7 +19,6 @@ package laika.api
 import laika.ast.Path.Root
 import laika.ast._
 import laika.ast.sample.ParagraphCompanionShortcuts
-import laika.config.ConfigBuilder
 import laika.format._
 import laika.parse.{ GeneratedSource, SourceFragment }
 import munit.FunSuite
@@ -61,8 +60,8 @@ class RenderAPISpec extends FunSuite
       def withOptions(options: Options): TestResolver = copy(options = options)
     }
     val renderer = Renderer.of(HTML).build
-    val config   = ConfigBuilder.empty.withValue("testKey", "foo").build
-    val doc      = Document(Root / "doc", RootElement(TestResolver()), config = config)
+    val doc      = Document(Root / "doc", RootElement(TestResolver()))
+      .modifyConfig(_.withValue("testKey", "foo"))
     val expected = "<p>foo</p>"
     assertEquals(renderer.render(doc), Right(expected))
   }

--- a/core/shared/src/test/scala/laika/ast/DocumentAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentAPISpec.scala
@@ -134,19 +134,24 @@ class DocumentAPISpec extends FunSuite
                    |
                    |Some more text""".stripMargin
 
-    val raw       = defaultParser.parseUnresolved(markup).toOption.get.document
+    val raw       = defaultParser.parseUnresolved(markup).toOption.get.document.modifyConfig(
+      _.withValue(LaikaKeys.orphan, false)
+    )
     val testRule  = RewriteRules.forSpans { case Text("Some text", _) =>
       Replace(Text("Swapped"))
     }
     val rewritten = OperationConfig.default
-      .rewriteRulesFor(raw.copy(position = TreePosition.root), RewritePhase.Resolve)
+      .rewriteRulesFor(raw, RewritePhase.Resolve)
       .flatMap(r => raw.rewrite(testRule ++ r))
 
     assertEquals(
       rewritten.map(_.content),
       Right(
         RootElement(
-          Title(List(Text("Title")), Id("title") + Style.title),
+          Section(
+            Header(1, List(Text("Title")), Id("title") + Style.section),
+            Nil
+          ),
           Section(
             Header(1, List(Text("Section 1")), Id("section-1") + Style.section),
             List(p("Swapped"))

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -64,12 +64,12 @@ class DocumentTreeAPISpec extends FunSuite
       config: Option[String] = None
   ): DocumentTree = {
     val doc = Document(path / name, root, config = createConfig(path / name, config))
-    if (name == "README") DocumentTree(path, Nil, titleDocument = Some(doc))
-    else DocumentTree(path, List(doc))
+    if (name == "README") new DocumentTree(path, Nil, titleDocument = Some(doc))
+    else new DocumentTree(path, List(doc))
   }
 
   def treeWithTitleDoc(path: Path, root: RootElement, config: Option[String] = None): DocumentTree =
-    DocumentTree(
+    new DocumentTree(
       path,
       Nil,
       Some(Document(path / "title", root, config = createConfig(path / "title", config)))
@@ -82,7 +82,7 @@ class DocumentTreeAPISpec extends FunSuite
       root: RootElement,
       config: Option[String] = None
   ): DocumentTree =
-    DocumentTree(path, List(treeWithDoc(path / treeName, docName, root, config)))
+    new DocumentTree(path, List(treeWithDoc(path / treeName, docName, root, config)))
 
   def treeWithTwoSubtrees(
       contextRef: Option[String] = None,
@@ -228,7 +228,7 @@ class DocumentTreeAPISpec extends FunSuite
 
   test("allow to select a subtree in a child directory using a relative path") {
     val tree     = treeWithSubtree(Root / "top", "sub", "doc", RootElement.empty)
-    val treeRoot = DocumentTree(Root, List(tree))
+    val treeRoot = new DocumentTree(Root, List(tree))
     assertEquals(
       treeRoot.selectSubtree(CurrentTree / "top" / "sub").map(_.path),
       Some(Root / "top" / "sub")
@@ -251,7 +251,7 @@ class DocumentTreeAPISpec extends FunSuite
       "doc",
       RootElement.empty,
       Some("laika.template: /main.template.html")
-    ).copy(templates = List(template))
+    ).withTemplates(List(template))
     val result   = firstDocCursor(tree).flatMap(TemplateRewriter.selectTemplate(_, "html"))
     assertEquals(result, Right(Some(template)))
   }
@@ -264,7 +264,7 @@ class DocumentTreeAPISpec extends FunSuite
       "doc",
       RootElement.empty,
       Some("laika.html.template: /main.template.html")
-    ).copy(templates = List(template))
+    ).withTemplates(List(template))
     val result   = firstDocCursor(tree).flatMap(TemplateRewriter.selectTemplate(_, "html"))
     assertEquals(result, Right(Some(template)))
   }
@@ -277,7 +277,7 @@ class DocumentTreeAPISpec extends FunSuite
       "doc",
       RootElement.empty,
       Some("laika.template: ../main.template.html")
-    ).copy(templates = List(template))
+    ).withTemplates(List(template))
     val result   = firstDocCursor(tree).flatMap(TemplateRewriter.selectTemplate(_, "html"))
     assertEquals(result, Right(Some(template)))
   }
@@ -290,7 +290,7 @@ class DocumentTreeAPISpec extends FunSuite
       "doc",
       RootElement.empty,
       Some("laika.template: ../missing.template.html")
-    ).copy(templates = List(template))
+    ).withTemplates(List(template))
     val result   = firstDocCursor(tree).flatMap(TemplateRewriter.selectTemplate(_, "html"))
     assertEquals(
       result,

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -251,7 +251,7 @@ class DocumentTreeAPISpec extends FunSuite
       "doc",
       RootElement.empty,
       Some("laika.template: /main.template.html")
-    ).withTemplates(List(template))
+    ).addTemplate(template)
     val result   = firstDocCursor(tree).flatMap(TemplateRewriter.selectTemplate(_, "html"))
     assertEquals(result, Right(Some(template)))
   }
@@ -264,7 +264,7 @@ class DocumentTreeAPISpec extends FunSuite
       "doc",
       RootElement.empty,
       Some("laika.html.template: /main.template.html")
-    ).withTemplates(List(template))
+    ).addTemplate(template)
     val result   = firstDocCursor(tree).flatMap(TemplateRewriter.selectTemplate(_, "html"))
     assertEquals(result, Right(Some(template)))
   }
@@ -277,7 +277,7 @@ class DocumentTreeAPISpec extends FunSuite
       "doc",
       RootElement.empty,
       Some("laika.template: ../main.template.html")
-    ).withTemplates(List(template))
+    ).addTemplate(template)
     val result   = firstDocCursor(tree).flatMap(TemplateRewriter.selectTemplate(_, "html"))
     assertEquals(result, Right(Some(template)))
   }
@@ -290,7 +290,7 @@ class DocumentTreeAPISpec extends FunSuite
       "doc",
       RootElement.empty,
       Some("laika.template: ../missing.template.html")
-    ).withTemplates(List(template))
+    ).addTemplate(template)
     val result   = firstDocCursor(tree).flatMap(TemplateRewriter.selectTemplate(_, "html"))
     assertEquals(
       result,

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -63,7 +63,7 @@ class DocumentTreeAPISpec extends FunSuite
       root: RootElement,
       config: Option[String] = None
   ): DocumentTree = {
-    val doc = Document(path / name, root, config = createConfig(path / name, config))
+    val doc = Document(path / name, root).withConfig(createConfig(path / name, config))
     DocumentTree.builder
       .addDocument(doc)
       .build
@@ -194,7 +194,9 @@ class DocumentTreeAPISpec extends FunSuite
     val treeConfig = createConfig(Root, Some("laika.title: from-config"), TreeScope)
     val docConfig  = createConfig(Root / "doc", Some("foo: bar")).withFallback(treeConfig)
     val tree       = DocumentTree.builder
-      .addDocument(Document(Root / "doc", RootElement(laika.ast.Title(title)), config = docConfig))
+      .addDocument(
+        Document(Root / "doc", RootElement(laika.ast.Title(title))).withConfig(docConfig)
+      )
       .addConfig(treeConfig)
       .build
     assertEquals(tree.content.head.title, Some(SpanSequence(title)))

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -452,4 +452,20 @@ class DocumentTreeAPISpec extends FunSuite
     assertEquals(res, Left(expectedError))
   }
 
+  test("adjust the path property of documents when appending to a DocumentTree") {
+    val treePath = Root / "tree-1"
+    val tree     = DocumentTree.builder
+      .addDocument(Document(treePath / "doc-1.md", RootElement.empty))
+      .addDocument(Document(treePath / "doc-2.md", RootElement.empty))
+      .build
+    val subTree  = tree.content.head.asInstanceOf[DocumentTree].appendContent(
+      Document(Root / "doc-3.md", RootElement.empty),
+      Document(Root / "doc-4.md", RootElement.empty)
+    )
+    val paths    = subTree.allDocuments.map(_.path)
+    val expected = (1 to 4).map(num => treePath / s"doc-$num.md")
+
+    assertEquals(paths, expected)
+  }
+
 }

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
@@ -13,40 +13,42 @@ class DocumentTreeBuilderSpec extends FunSuite with DocumentTreeAssertions {
   }
 
   test("tree with documents in root and sub-trees") {
-    val doc1     = Document(Root / "doc-1.md", RootElement.empty)
-    val doc2     = Document(Root / "doc-2.md", RootElement.empty)
-    val doc3     = Document(Root / "tree" / "doc-3.md", RootElement.empty)
-    val doc4     = Document(Root / "tree" / "doc-4.md", RootElement.empty)
-    val tree     = DocumentTree.builder
+    val doc1          = Document(Root / "doc-1.md", RootElement.empty)
+    val doc2          = Document(Root / "doc-2.md", RootElement.empty)
+    val doc3          = Document(Root / "tree" / "doc-3.md", RootElement.empty)
+    val doc4          = Document(Root / "tree" / "doc-4.md", RootElement.empty)
+    val tree          = DocumentTree.builder
       .addDocuments(List(doc1, doc2, doc3, doc4))
       .build
-    val expected = new DocumentTree(
-      Root,
+    val parentContext = TreeNodeContext()
+    val expected      = new DocumentTree(
+      parentContext,
       Seq(
         doc1,
         doc2,
-        new DocumentTree(Root / "tree", Seq(doc3, doc4))
+        new DocumentTree(parentContext.child("tree"), Seq(doc3, doc4))
       )
     )
     tree.assertEquals(expected)
   }
 
   test("tree with documents and templates") {
-    val doc1      = Document(Root / "doc-1.md", RootElement.empty)
-    val doc2      = Document(Root / "tree" / "doc-2.md", RootElement.empty)
-    val template1 = TemplateDocument(Root / "tpl-1.template.html", TemplateRoot.empty)
-    val template2 = TemplateDocument(Root / "tree" / "tpl-2.template.html", TemplateRoot.empty)
-    val tree      = DocumentTree.builder
+    val doc1          = Document(Root / "doc-1.md", RootElement.empty)
+    val doc2          = Document(Root / "tree" / "doc-2.md", RootElement.empty)
+    val template1     = TemplateDocument(Root / "tpl-1.template.html", TemplateRoot.empty)
+    val template2     = TemplateDocument(Root / "tree" / "tpl-2.template.html", TemplateRoot.empty)
+    val tree          = DocumentTree.builder
       .addDocument(doc1)
       .addDocument(doc2)
       .addTemplate(template1)
       .addTemplate(template2)
       .build
-    val expected  = new DocumentTree(
-      Root,
+    val parentContext = TreeNodeContext()
+    val expected      = new DocumentTree(
+      parentContext,
       Seq(
         doc1,
-        new DocumentTree(Root / "tree", Seq(doc2), templates = Seq(template2))
+        new DocumentTree(parentContext.child("tree"), Seq(doc2), templates = Seq(template2))
       ),
       templates = Seq(template1)
     )
@@ -54,21 +56,22 @@ class DocumentTreeBuilderSpec extends FunSuite with DocumentTreeAssertions {
   }
 
   test("tree with title documents") {
-    val doc1     = Document(Root / "doc-1.md", RootElement.empty)
-    val doc2     = Document(Root / "tree" / "doc-2.md", RootElement.empty)
-    val title1   = Document(Root / "README.md", RootElement.empty)
-    val title2   = Document(Root / "tree" / "README.md", RootElement.empty)
-    val tree     = DocumentTree.builder
+    val doc1          = Document(Root / "doc-1.md", RootElement.empty)
+    val doc2          = Document(Root / "tree" / "doc-2.md", RootElement.empty)
+    val title1        = Document(Root / "README.md", RootElement.empty)
+    val title2        = Document(Root / "tree" / "README.md", RootElement.empty)
+    val tree          = DocumentTree.builder
       .addDocument(doc1)
       .addDocument(doc2)
       .addDocument(title1)
       .addDocument(title2)
       .build
-    val expected = new DocumentTree(
-      Root,
+    val parentContext = TreeNodeContext()
+    val expected      = new DocumentTree(
+      parentContext,
       Seq(
         doc1,
-        new DocumentTree(Root / "tree", Seq(doc2), titleDocument = Some(title2))
+        new DocumentTree(parentContext.child("tree"), Seq(doc2), titleDocument = Some(title2))
       ),
       titleDocument = Some(title1)
     )
@@ -83,7 +86,7 @@ class DocumentTreeBuilderSpec extends FunSuite with DocumentTreeAssertions {
       .addDocument(cover)
       .buildRoot
     val expected = DocumentTreeRoot(
-      tree = new DocumentTree(Root, Seq(doc)),
+      tree = new DocumentTree(TreeNodeContext(), Seq(doc)),
       coverDocument = Some(cover)
     )
     tree.assertEquals(expected)

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
@@ -98,7 +98,7 @@ class DocumentTreeBuilderSpec extends FunSuite with DocumentTreeAssertions {
     val treeOrigin = Origin(TreeScope, Root / "tree" / "directory.conf")
     val treeConfig =
       ConfigBuilder.withOrigin(treeOrigin).withValue("foo.baz", 9).build
-    val doc        = Document(docPath, RootElement.empty, config = docConfig)
+    val doc        = Document(docPath, RootElement.empty).withConfig(docConfig)
     val tree       = DocumentTree.builder
       .addDocument(doc)
       .addConfig(treeConfig)
@@ -113,7 +113,7 @@ class DocumentTreeBuilderSpec extends FunSuite with DocumentTreeAssertions {
     val docPath    = Root / "tree" / "doc"
     val docConfig  = ConfigBuilder.empty.withValue("foo.bar", 7).build
     val baseConfig = ConfigBuilder.empty.withValue("foo.baz", 9).build
-    val doc        = Document(docPath, RootElement.empty, config = docConfig)
+    val doc        = Document(docPath, RootElement.empty).withConfig(docConfig)
     val tree       = DocumentTree.builder
       .addDocument(doc)
       .build(baseConfig)
@@ -134,8 +134,10 @@ class DocumentTreeBuilderSpec extends FunSuite with DocumentTreeAssertions {
       .build
       .content
       .sortBy(_.path.name)
+      .collect { case d: Document => d }
     val expected = Seq(docC, docB)
-    assertEquals(docs, expected)
+    assertEquals(docs.map(_.path), expected.map(_.path))
+    assertEquals(docs.map(_.content), expected.map(_.content))
   }
 
 }

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
@@ -86,9 +86,9 @@ class DocumentTreeBuilderSpec extends FunSuite with DocumentTreeAssertions {
       .addDocument(cover)
       .buildRoot
     val expected = DocumentTreeRoot(
-      tree = new DocumentTree(TreeNodeContext(), Seq(doc)),
-      coverDocument = Some(cover)
+      new DocumentTree(TreeNodeContext(), Seq(doc))
     )
+      .withCoverDocument(cover)
     tree.assertEquals(expected)
   }
 

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
@@ -1,14 +1,15 @@
 package laika.ast
 
 import laika.ast.Path.Root
+import laika.ast.sample.DocumentTreeAssertions
 import laika.config.Origin.TreeScope
 import laika.config.{ ConfigBuilder, Origin }
 import munit.FunSuite
 
-class DocumentTreeBuilderSpec extends FunSuite {
+class DocumentTreeBuilderSpec extends FunSuite with DocumentTreeAssertions {
 
   test("empty tree") {
-    assertEquals(DocumentTree.builder.build, DocumentTree.empty)
+    DocumentTree.builder.build.assertEquals(DocumentTree.empty)
   }
 
   test("tree with documents in root and sub-trees") {
@@ -19,15 +20,15 @@ class DocumentTreeBuilderSpec extends FunSuite {
     val tree     = DocumentTree.builder
       .addDocuments(List(doc1, doc2, doc3, doc4))
       .build
-    val expected = DocumentTree(
+    val expected = new DocumentTree(
       Root,
       Seq(
         doc1,
         doc2,
-        DocumentTree(Root / "tree", Seq(doc3, doc4))
+        new DocumentTree(Root / "tree", Seq(doc3, doc4))
       )
     )
-    assertEquals(tree, expected)
+    tree.assertEquals(expected)
   }
 
   test("tree with documents and templates") {
@@ -41,15 +42,15 @@ class DocumentTreeBuilderSpec extends FunSuite {
       .addTemplate(template1)
       .addTemplate(template2)
       .build
-    val expected  = DocumentTree(
+    val expected  = new DocumentTree(
       Root,
       Seq(
         doc1,
-        DocumentTree(Root / "tree", Seq(doc2), templates = Seq(template2))
+        new DocumentTree(Root / "tree", Seq(doc2), templates = Seq(template2))
       ),
       templates = Seq(template1)
     )
-    assertEquals(tree, expected)
+    tree.assertEquals(expected)
   }
 
   test("tree with title documents") {
@@ -63,15 +64,15 @@ class DocumentTreeBuilderSpec extends FunSuite {
       .addDocument(title1)
       .addDocument(title2)
       .build
-    val expected = DocumentTree(
+    val expected = new DocumentTree(
       Root,
       Seq(
         doc1,
-        DocumentTree(Root / "tree", Seq(doc2), titleDocument = Some(title2))
+        new DocumentTree(Root / "tree", Seq(doc2), titleDocument = Some(title2))
       ),
       titleDocument = Some(title1)
     )
-    assertEquals(tree, expected)
+    tree.assertEquals(expected)
   }
 
   test("root tree with cover document") {
@@ -82,10 +83,10 @@ class DocumentTreeBuilderSpec extends FunSuite {
       .addDocument(cover)
       .buildRoot
     val expected = DocumentTreeRoot(
-      tree = DocumentTree(Root, Seq(doc)),
+      tree = new DocumentTree(Root, Seq(doc)),
       coverDocument = Some(cover)
     )
-    assertEquals(tree, expected)
+    tree.assertEquals(expected)
   }
 
   test("document config inherits from tree config") {

--- a/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
@@ -17,7 +17,7 @@
 package laika.ast.sample
 
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.config.{ Config, ConfigBuilder, LaikaKeys, Origin, TreeConfigErrors }
 import laika.rewrite.link.LinkValidation
 
@@ -151,14 +151,11 @@ trait SampleRootOps extends SampleOps { self =>
 
     def config(f: ConfigBuilder => ConfigBuilder): RootApi = addDocumentConfig(key, f)
 
-    // TODO - configValue API
-
     def content(f: BuilderKey => Seq[Block]): RootApi  = setDocumentContent(key, f)
     def content(blocks: Seq[Block]): RootApi           = setDocumentContent(key, _ => blocks)
     def content(block: Block, blocks: Block*): RootApi = content(block +: blocks)
     def suffix(value: String): RootApi                 = setDocumentSuffix(key, value)
 
-    def buildCursor: DocumentCursor = ???
   }
 
   abstract class TreeOps(num: Int) extends KeyedSampleOps {
@@ -244,7 +241,7 @@ class SampleTwoDocuments(protected val sampleRoot: SampleRoot) extends SampleRoo
 
 class SampleSixDocuments(protected val sampleRoot: SampleRoot) extends SampleRootOps { self =>
 
-  import BuilderKey._
+  import BuilderKey.*
 
   type RootApi = SampleSixDocuments
 
@@ -335,13 +332,16 @@ private[sample] case class SampleTree(
   val path = if (key.num == 0) Root else Root / s"${key.prefix}-${key.num}"
 
   def build(content: Seq[SampleDocument], parentConfig: Config, root: SampleRoot): DocumentTree = {
-    val conf = config.build(parentConfig, path)
+    val conf    = config.build(parentConfig, path)
+    val context = TreeNodeContext(
+      localPath = Some(path.name),
+      localConfig = conf
+    )
     new DocumentTree(
-      path,
+      context,
       content.map(_.build(path, conf, root)),
       titleDocument = titleDoc.map(_.build(path, conf, root)),
-      templates = templates,
-      config = conf
+      templates = templates
     )
   }
 

--- a/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
@@ -276,8 +276,8 @@ class SampleSixDocuments(protected val sampleRoot: SampleRoot) extends SampleRoo
   def build: DocumentTreeRoot = {
     val tree = buildTree(0, 0, Config.empty)
     DocumentTreeRoot(
-      tree = tree.copy(
-        content = tree.content ++ Seq(
+      tree = tree.appendContent(
+        Seq(
           buildTree(1, 2, tree.config),
           buildTree(2, 4, tree.config),
           buildStaticTree(1, tree.config),
@@ -336,7 +336,7 @@ private[sample] case class SampleTree(
 
   def build(content: Seq[SampleDocument], parentConfig: Config, root: SampleRoot): DocumentTree = {
     val conf = config.build(parentConfig, path)
-    DocumentTree(
+    new DocumentTree(
       path,
       content.map(_.build(path, conf, root)),
       titleDocument = titleDoc.map(_.build(path, conf, root)),

--- a/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
@@ -232,9 +232,8 @@ class SampleTwoDocuments(protected val sampleRoot: SampleRoot) extends SampleRoo
   private[sample] def copyWith(root: SampleRoot): RootApi         = new SampleTwoDocuments(root)
 
   def build: DocumentTreeRoot = DocumentTreeRoot(
-    tree = buildTree(0, 0, Config.empty),
-    staticDocuments = sampleRoot.staticDocuments
-  )
+    buildTree(0, 0, Config.empty)
+  ).addStaticDocuments(sampleRoot.staticDocuments)
 
   def buildCursor: Either[TreeConfigErrors, RootCursor] = RootCursor(build)
 }
@@ -273,16 +272,16 @@ class SampleSixDocuments(protected val sampleRoot: SampleRoot) extends SampleRoo
   def build: DocumentTreeRoot = {
     val tree = buildTree(0, 0, Config.empty)
     DocumentTreeRoot(
-      tree = tree.appendContent(
+      tree.appendContent(
         Seq(
           buildTree(1, 2, tree.config),
           buildTree(2, 4, tree.config),
           buildStaticTree(1, tree.config),
           buildStaticTree(2, tree.config)
         )
-      ),
-      staticDocuments = sampleRoot.staticDocuments
+      )
     )
+      .addStaticDocuments(sampleRoot.staticDocuments)
   }
 
   def buildCursor: Either[TreeConfigErrors, RootCursor] = RootCursor(build)

--- a/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
@@ -326,9 +326,6 @@ private[sample] case class SampleTree(
     titleDoc: Option[SampleDocument] = None
 ) {
 
-  def versioned: SampleTree   = ???
-  def unversioned: SampleTree = ???
-
   val path = if (key.num == 0) Root else Root / s"${key.prefix}-${key.num}"
 
   def build(content: Seq[SampleDocument], parentConfig: Config, root: SampleRoot): DocumentTree = {
@@ -364,9 +361,8 @@ private[sample] case class SampleDocument(
     val path         = treePath / (localName + suffixString)
     Document(
       path,
-      RootElement(content.getOrElse(root.defaultContent)(key)),
-      config = config.build(parentConfig, path)
-    )
+      RootElement(content.getOrElse(root.defaultContent)(key))
+    ).withConfig(config.build(parentConfig, path))
   }
 
 }

--- a/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
@@ -166,8 +166,8 @@ class OperationConfigSpec extends FunSuite {
     val expected = Document(Root, RootElement(Literal("foo"), Literal("bar")))
 
     assertEquals(
-      config.rewriteRulesFor(doc, RewritePhase.Resolve).flatMap(doc.rewrite),
-      Right(expected)
+      config.rewriteRulesFor(doc, RewritePhase.Resolve).flatMap(doc.rewrite).map(_.content),
+      Right(expected.content)
     )
   }
 
@@ -187,8 +187,8 @@ class OperationConfigSpec extends FunSuite {
     val expected = Document(Root, RootElement(Literal("foo!?")))
 
     assertEquals(
-      config.rewriteRulesFor(doc, RewritePhase.Resolve).flatMap(doc.rewrite),
-      Right(expected)
+      config.rewriteRulesFor(doc, RewritePhase.Resolve).flatMap(doc.rewrite).map(_.content),
+      Right(expected.content)
     )
   }
 
@@ -207,8 +207,8 @@ class OperationConfigSpec extends FunSuite {
     val expected = Document(Root, RootElement(Literal("foo!?")))
 
     assertEquals(
-      config.rewriteRulesFor(doc, RewritePhase.Resolve).flatMap(doc.rewrite),
-      Right(expected)
+      config.rewriteRulesFor(doc, RewritePhase.Resolve).flatMap(doc.rewrite).map(_.content),
+      Right(expected.content)
     )
   }
 

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -19,16 +19,16 @@ package laika.config
 import laika.api.MarkupParser
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.TestSourceBuilders
-import laika.bundle._
+import laika.bundle.*
 import laika.factory.MarkupFormat
-import laika.parse._
-import laika.parse.builders._
+import laika.parse.*
+import laika.parse.builders.*
 import laika.parse.combinator.Parsers
 import laika.parse.css.CSSParsers
 import laika.parse.directive.ConfigHeaderParser
-import laika.parse.implicits._
+import laika.parse.implicits.*
 import laika.parse.markup.DocumentParser.DocumentInput
 import laika.parse.text.TextParsers
 import laika.rewrite.ReferenceResolver.CursorKeys
@@ -100,9 +100,8 @@ class BlockParserConfigSpec extends FunSuite with ParserSetup {
   def doc(blocks: (Char, String)*): Document =
     Document(
       Root / "doc",
-      RootElement(blocks.map { case (deco, text) => DecoratedBlock(deco, Seq(Text(text))) }),
-      config = defaultDocConfig
-    )
+      RootElement(blocks.map { case (deco, text) => DecoratedBlock(deco, Seq(Text(text))) })
+    ).withConfig(defaultDocConfig)
 
   test("merge parsers from a host language with parsers from an app extension") {
     val format = createParser(blocks = Seq(blockFor('>')))
@@ -159,7 +158,7 @@ class BlockParserConfigSpec extends FunSuite with ParserSetup {
 
 class SpanParserConfigSpec extends FunSuite with ParserSetup {
 
-  import TextParsers._
+  import TextParsers.*
 
   val input = ">aaa +bbb"
 
@@ -187,9 +186,8 @@ class SpanParserConfigSpec extends FunSuite with ParserSetup {
         Paragraph(
           spans.map { case (deco, text) => DecoratedSpan(deco, text) }
         )
-      ),
-      config = defaultDocConfig
-    )
+      )
+    ).withConfig(defaultDocConfig)
 
   def parser(spans: SpanParserBuilder*): MarkupFormat = createParser(
     spans = spans,
@@ -272,7 +270,7 @@ class ParserHookSpec extends FunSuite with ParserSetup {
 
   def processDoc(append: String): UnresolvedDocument => UnresolvedDocument = { unresolved =>
     unresolved.copy(document =
-      unresolved.document.copy(content = appendString(unresolved.document.content, append))
+      unresolved.document.withContent(appendString(unresolved.document.content, append))
     )
   }
 
@@ -283,7 +281,7 @@ class ParserHookSpec extends FunSuite with ParserSetup {
   }
 
   def doc(text: String): Document =
-    Document(Root / "doc", RootElement(text), config = defaultDocConfig)
+    Document(Root / "doc", RootElement(text)).withConfig(defaultDocConfig)
 
   test(
     "preProcessInput - apply the hook from a parser extension before the hook in an app extension"

--- a/core/shared/src/test/scala/laika/directive/BlockDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/BlockDirectiveAPISpec.scala
@@ -22,7 +22,6 @@ import laika.ast.Path.Root
 import laika.ast._
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.bundle.{ BlockParserBuilder, ParserBundle }
-import laika.config.ConfigBuilder
 import laika.directive.std.StandardDirectives
 import laika.format.HTML
 import laika.parse.builders._
@@ -193,7 +192,7 @@ class BlockDirectiveAPISpec extends FunSuite
       blockParsers = Seq(paragraphParser),
       markupExtensions = directiveSupport.markupExtensions
     ).rootElement.evalMap { root =>
-      val doc = Document(Root, root, config = ConfigBuilder.empty.withValue("ref", "value").build)
+      val doc = Document(Root, root).modifyConfig(_.withValue("ref", "value"))
       rewrite(HTML)(doc).map(_.content).leftMap(_.message)
     }
 

--- a/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
@@ -23,7 +23,6 @@ import laika.ast.Path.Root
 import laika.ast._
 import laika.ast.sample.TestSourceBuilders
 import laika.bundle.ParserBundle
-import laika.config.ConfigBuilder
 import laika.format.{ HTML, Markdown }
 import laika.parse.markup.DocumentParser.TransformationError
 import laika.parse.markup.RootParserProvider
@@ -205,11 +204,12 @@ class SpanDirectiveAPISpec extends FunSuite with TestSourceBuilders with RenderP
       markupExtensions = directiveSupport.markupExtensions
     ).standaloneSpanParser.evalMap { spans =>
       val seq = SpanSequence(spans)
+
       val doc = Document(
         Root,
-        RootElement(seq),
-        config = ConfigBuilder.empty.withValue("ref", "value").build
-      )
+        RootElement(seq)
+      ).modifyConfig(_.withValue("ref", "value"))
+
       OperationConfig.default.rewriteRulesFor(doc, RewritePhase.Render(HTML))
         .map(_.rewriteSpan(seq))
         .leftMap(_.message)

--- a/core/shared/src/test/scala/laika/directive/TemplateDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/TemplateDirectiveAPISpec.scala
@@ -21,7 +21,6 @@ import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
 import laika.ast._
 import laika.ast.sample.TestSourceBuilders
-import laika.config.ConfigBuilder
 import laika.format.HTML
 import laika.parse.Parser
 import laika.parse.directive.TemplateParsers
@@ -174,9 +173,9 @@ class TemplateDirectiveAPISpec extends FunSuite with TestSourceBuilders {
       val root = TemplateRoot(spans)
       val doc  = Document(
         Root,
-        RootElement(root),
-        config = ConfigBuilder.empty.withValue("ref", "value").build
-      )
+        RootElement(root)
+      ).modifyConfig(_.withValue("ref", "value"))
+
       OperationConfig.default.rewriteRulesFor(doc, RewritePhase.Render(HTML))
         .map(_.rewriteBlock(root).asInstanceOf[TemplateRoot])
         .leftMap(_.message)

--- a/core/shared/src/test/scala/laika/directive/std/HTMLHeadDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/HTMLHeadDirectiveSpec.scala
@@ -66,7 +66,7 @@ class HTMLHeadDirectiveSpec extends FunSuite {
       )
       for {
         tree <- treeWithConfig.rewrite(resolveRules).leftMap(_.message)
-        treeRoot = DocumentTreeRoot(tree, staticDocuments = static)
+        treeRoot = DocumentTreeRoot(tree).addStaticDocuments(static)
         result <- treeRoot.applyTemplates(renderRules, ctx).leftMap(_.message)
       } yield result
     }

--- a/core/shared/src/test/scala/laika/directive/std/HTMLHeadDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/HTMLHeadDirectiveSpec.scala
@@ -16,21 +16,21 @@
 
 package laika.directive.std
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
-import laika.ast._
+import laika.ast.*
 import laika.rewrite.nav.TargetFormats
 import laika.rewrite.{ DefaultTemplatePath, OutputContext }
 import munit.FunSuite
-import RewriteSetup._
+import RewriteSetup.*
 import laika.config.{ ConfigBuilder, LaikaKeys }
 import laika.format.HTML
 
 class HTMLHeadDirectiveSpec extends FunSuite {
 
-  val staticDocs = Seq(
+  private val staticDocs = Seq(
     StaticDocument(Root / "doc-1.css", TargetFormats.Selected("html")),
     StaticDocument(Root / "doc-2.epub.css", TargetFormats.Selected("epub", "epub.xhtml")),
     StaticDocument(Root / "doc-3.shared.css", TargetFormats.Selected("epub", "epub.xhtml", "html")),
@@ -55,7 +55,7 @@ class HTMLHeadDirectiveSpec extends FunSuite {
     def applyTemplate(root: TemplateRoot): Either[String, DocumentTreeRoot] = {
       val inputTree      =
         buildTree(Some((templatePath.name, root.content)), docConfigUnderTest = docConfig)
-      val treeWithConfig = inputTree.copy(config = rootConfig(ConfigBuilder.empty).build)
+      val treeWithConfig = inputTree.withConfig(rootConfig(ConfigBuilder.empty).build)
       val resolveRules   = OperationConfig.default.rewriteRulesFor(
         DocumentTreeRoot(treeWithConfig),
         RewritePhase.Resolve

--- a/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
@@ -28,7 +28,7 @@ import laika.ast._
 import laika.rewrite.nav.TargetFormats
 import munit.FunSuite
 import RewriteSetup._
-import laika.config.{ ConfigBuilder, LaikaKeys }
+import laika.config.LaikaKeys
 
 class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts
     with TestSourceBuilders {
@@ -329,11 +329,8 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts
 
     implicit val options: NavOptions = NavOptions(additionalDocuments =
       Seq(
-        Document(
-          Root / "doc-3",
-          RootElement.empty,
-          config = ConfigBuilder.empty.withValue(LaikaKeys.excludeFromNavigation, true).build
-        )
+        Document(Root / "doc-3", RootElement.empty)
+          .modifyConfig(_.withValue(LaikaKeys.excludeFromNavigation, true))
       )
     )
 

--- a/core/shared/src/test/scala/laika/directive/std/SelectDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/SelectDirectiveSpec.scala
@@ -20,7 +20,6 @@ import laika.api.{ MarkupParser, RenderPhaseRewrite }
 import laika.ast.Path.Root
 import laika.ast._
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
-import laika.config.ConfigBuilder
 import laika.format.{ HTML, Markdown }
 import laika.rewrite.nav.{ ChoiceConfig, SelectionConfig, Selections }
 import munit.FunSuite
@@ -161,11 +160,9 @@ class SelectDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts
         ChoiceConfig("b", "label-b", selected = true)
       )
     )
-    val doc    = Document(
-      Root / "doc",
-      RootElement(group),
-      config = ConfigBuilder.empty.withValue(config).build
-    )
+    val doc    = Document(Root / "doc", RootElement(group))
+      .modifyConfig(_.withValue(config))
+
     assertEquals(
       rewrite(HTML)(doc).map(_.content),
       Right(RootElement(BlockSequence(List(p("common"), p("33\n44")))))

--- a/core/shared/src/test/scala/laika/directive/std/TemplateParserSetup.scala
+++ b/core/shared/src/test/scala/laika/directive/std/TemplateParserSetup.scala
@@ -54,9 +54,9 @@ trait TemplateParserSetup {
       val docPath  = Root / "docs" / "doc1.md"
       val template = TemplateDocument(Path.Root / "theme" / "test.template.html", tRoot)
       val doc      = Document(docPath, RootElement.empty, config = config)
-      val root  = DocumentTreeRoot(DocumentTree(Root, Seq(DocumentTree(Root / "docs", Seq(doc)))))
-      val rules = OperationConfig.default.rewriteRulesFor(root, RewritePhase.Render(HTML))
-      val res   = for {
+      val root     = DocumentTree.builder.addDocument(doc).buildRoot
+      val rules    = OperationConfig.default.rewriteRulesFor(root, RewritePhase.Render(HTML))
+      val res      = for {
         cursor <- RootCursor(root).flatMap(
           _.allDocuments.find(_.path == docPath).toRight(
             ValidationError("cursor under test missing")

--- a/core/shared/src/test/scala/laika/directive/std/TemplateParserSetup.scala
+++ b/core/shared/src/test/scala/laika/directive/std/TemplateParserSetup.scala
@@ -53,7 +53,7 @@ trait TemplateParserSetup {
     def rewriteTemplate(tRoot: TemplateRoot): Either[String, RootElement] = {
       val docPath  = Root / "docs" / "doc1.md"
       val template = TemplateDocument(Path.Root / "theme" / "test.template.html", tRoot)
-      val doc      = Document(docPath, RootElement.empty, config = config)
+      val doc      = Document(docPath, RootElement.empty).withConfig(config)
       val root     = DocumentTree.builder.addDocument(doc).buildRoot
       val rules    = OperationConfig.default.rewriteRulesFor(root, RewritePhase.Render(HTML))
       val res      = for {

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -41,7 +41,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
       if (withTitles)
         ConfigBuilder.empty.withValue(LaikaKeys.firstHeaderAsTitle, true).build
       else Config.empty
-    val doc    = Document(Path.Root / "doc", root, config = config)
+    val doc    = Document(Path.Root / "doc", root).withConfig(config)
     OperationConfig.default
       .rewriteRulesFor(doc, RewritePhase.Resolve)
       .flatMap(doc.rewrite(_).map(_.content))

--- a/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
@@ -17,10 +17,11 @@
 package laika.rewrite
 
 import laika.api.builder.OperationConfig
-import laika.ast._
+import laika.ast.*
+import laika.ast.Path.Root
 import laika.ast.sample.{ BuilderKey, DocumentTreeAssertions, SampleTrees }
 import laika.config.Config.ConfigResult
-import laika.config.ConfigParser
+import laika.config.{ ConfigParser, Origin }
 import laika.parse.GeneratedSource
 import munit.FunSuite
 
@@ -35,16 +36,26 @@ class SectionNumberSpec extends FunSuite with DocumentTreeAssertions {
 
     def isIncluded(level: Int): Boolean = depth.forall(_ >= level)
 
-    def header(level: Int, title: Int, style: String = "section") =
+    def header(level: Int, title: Int, style: String = "section"): Header =
       Header(level, List(Text(s"Title $title")), Id(s"title$title") + Styles(style))
 
     def tree(content: RootElement): DocumentTree = {
-      val autonumberConfig = ConfigParser.parse(config).resolve().toOption.get
-      SampleTrees.sixDocuments
+      val autonumberConfig = ConfigParser
+        .parse(config)
+        .resolve()
+        .toOption
+        .get
+        .withOrigin(Origin(Origin.TreeScope, Root))
+      val docs             = SampleTrees.sixDocuments
         .docContent(content.content)
-        .root.config(_.withFallback(autonumberConfig))
         .build
         .tree
+        .allDocuments
+        .toList
+      DocumentTree.builder
+        .addDocuments(docs)
+        .addConfig(autonumberConfig)
+        .build
     }
 
     def numberedHeader(
@@ -79,7 +90,7 @@ class SectionNumberSpec extends FunSuite with DocumentTreeAssertions {
     )
 
     lazy val expected: DocumentTree = {
-      val docNums = List(List(1), List(2), List(5, 1), List(5, 2), List(6, 1), List(6, 2))
+      val docNums = List(List(1), List(2), List(3, 1), List(3, 2), List(4, 1), List(4, 2))
       def contents(key: BuilderKey): Seq[Block] = {
         val docNum = if (!numberDocs) Nil else docNums(key.num - 1)
         resultContent(docNum)

--- a/core/shared/src/test/scala/laika/rst/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/RewriteRulesSpec.scala
@@ -35,7 +35,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
       if (withTitles)
         ConfigBuilder.empty.withValue(LaikaKeys.firstHeaderAsTitle, true).build
       else Config.empty
-    val doc    = Document(Path.Root / "doc", root, config = config)
+    val doc    = Document(Path.Root / "doc", root).withConfig(config)
     OperationConfig.default
       .rewriteRulesFor(doc, RewritePhase.Resolve)
       .flatMap(doc.rewrite(_).map(_.content))

--- a/core/shared/src/test/scala/laika/rst/std/StandardBlockDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/std/StandardBlockDirectivesSpec.scala
@@ -664,18 +664,21 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
                   | :prefix: (
                   | :suffix: )""".stripMargin
 
-    val expected = ObjectValue(
-      Seq(
-        Field("depth", StringValue("3")),
-        Field("start", StringValue("1")),
-        Field("prefix", StringValue("(")),
-        Field("suffix", StringValue(")"))
-      )
+    val expected = Set(
+      Field("depth", StringValue("3")),
+      Field("start", StringValue("1")),
+      Field("prefix", StringValue("(")),
+      Field("suffix", StringValue(")"))
     )
 
-    val res: Either[Any, ConfigValue] =
-      parser.parse(input).flatMap(_.config.get[ConfigValue](LaikaKeys.autonumbering))
-    assertEquals(res, Right(expected))
+    val res: Option[Set[Field]] = parser
+      .parse(input)
+      .flatMap(_.config.get[ConfigValue](LaikaKeys.autonumbering))
+      .toOption
+      .collect { case ObjectValue(fields) =>
+        fields.toSet
+      }
+    assertEquals(res, Some(expected))
   }
 
   test("contents - creates a placeholder in the document") {

--- a/core/shared/src/test/scala/laika/rst/std/StandardBlockDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/std/StandardBlockDirectivesSpec.scala
@@ -731,7 +731,7 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
         TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
       )
     )
-    val tree     = DocumentTree(Root, content = List(document), templates = List(template))
+    val tree     = DocumentTree.builder.addDocument(document).addTemplate(template).build
     val result   = for {
       rewrittenTree <- tree.rewrite(
         OperationConfig.default.withBundlesFor(ReStructuredText).rewriteRulesFor(

--- a/docs/src/04-customizing-laika/04-document-ast.md
+++ b/docs/src/04-customizing-laika/04-document-ast.md
@@ -416,48 +416,35 @@ The `DocumentStructure` mixin provides additional methods as shortcuts for selec
 ### The DocumentTree Type
 
 In a multi-input transformation all `Document` instances get assembled 
-into a recursive structure of `DocumentTree` instances:
+into a recursive structure of `DocumentTree` instances.
   
-```scala:reset
-import laika.ast.{Path, Document, TemplateDocument, Config, TreePosition, TreeStructure, TreeContent}
-
-case class DocumentTree (
-  path: Path,
-  content: Seq[TreeContent],
-  titleDocument: Option[Document] = None,
-  templates: Seq[TemplateDocument] = Nil,
-  config: Config = Config.empty,
-  position: TreePosition = TreePosition.root
-) extends TreeStructure with TreeContent
-```
-
-* Like with documents, the `path` property holds the absolute, virtual path of the document inside the tree.
+* Like with documents, the `path: Path` property holds the absolute, virtual path of the document inside the tree.
   For the root tree it will be `Root`.
   
-* The `content` property holds the child trees and documents of this tree.
+* The `content: Seq[TreeContent]` property holds the child trees and documents of this tree.
   Its type `TreeContent` is a trait implemented by both `Document` and `DocumentTree`.
   
-* The `titleDocument` property holds an optional title document for this tree.
+* The `titleDocument: Option[TitleDocument]` property holds an optional title document for this tree.
   A tree often represents a logical structure like a chapter.
   It is used as a section headline in auto-generated site navigation 
   as well as the first content of this tree in linearized e-book output (EPUB or PDF).
   See [Title Documents] for details.
   
-* The `templates` property holds the AST of all templates parsed inside this tree
+* The `templates: Seq[TemplateDocument]` property holds the AST of all templates parsed inside this tree
   (excluding templates from child trees).
   The AST nodes it can hold are described in [Template Spans] above.
   See [Creating Templates] for more details on the template engine.
   
-* The `config` property holds the configuration parsed from an optional HOCON document named `directory.conf`.
+* The `config: Config` property holds the configuration parsed from an optional HOCON document named `directory.conf`.
   It is an empty instance if there is no file.
   It can also be populated programmatically in cases where the content is generated and not loaded from the file system.
   See [Laika's HOCON API] for details.
 
-* The `position` property represents the position of the document in a tree.
+* The `position: TreePosition` property represents the position of the document in a tree.
   It can be used for functionality like auto-numbering.
   It is not populated if the transformation deals with a single document only.
   
-The `TreeStructure` mixin provides additional methods as shortcuts for selecting content from the tree:
+The API provides additional methods as shortcuts for selecting content from the tree:
 
 * `selectSubtree`, `selectTemplate` and `selectDocument` all accept a `RelativePath` argument to select
   content from the tree structure, including content from sub-trees.

--- a/docs/src/06-sub-modules/03-laikas-hocon-api.md
+++ b/docs/src/06-sub-modules/03-laikas-hocon-api.md
@@ -276,24 +276,21 @@ val config = ConfigBuilder.withFallback(parentConfig)
 
 The fallback will be used for resolving any values not present in the current instance.
 
-Finally, if you are building a `Config` instance that you want to assign to a `Document` instance in cases
-where you build an entire tree programmatically, you also have to provide a correct `Origin` instance:
+Finally, if you want to modify an existing `Config` instance of a particular `Document` instance
+you can use the `modifyConfig` method:
 
 ```scala mdoc:compile-only
 import laika.ast.Document
 
 def doc: Document = ???
-val docOrigin: Origin = Origin(Origin.DocumentScope, doc.path) 
 
-val config = ConfigBuilder.withOrigin(docOrigin)
+val finalDoc = doc.modifyConfig(_
   .withValue("laika.epub.coverImage", "/images/epub-cover.jpg")
   .withValue("laika.pdf.coverImage", "/images/pdf-cover.jpg")
-  .build
-  
-val finalDoc = doc.copy(config = config)
+)
 ```
 
-This is essential for resolving relative paths defined in that configuration correctly.
+This is more efficient than replacing the config and preserves the origin info in the existing config property which is essential for resolving relative paths defined in that configuration correctly.
 
 
 ### Parsing HOCON
@@ -340,7 +337,7 @@ val result: Either[ConfigError, Document] = ConfigParser
   .parse(hoconInput)
   .resolve(origin = docOrigin)
   .map { config =>
-    doc.copy(config = config)
+    doc.withConfig(config)
   }
 ```
 

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -187,10 +187,7 @@ case object EPUB extends TwoPhaseRenderFormat[HTMLFormatter, BinaryPostProcessor
               Root / "cover",
               RootElement(SpanSequence(Image(InternalTarget(image), alt = Some("cover"))))
             )
-              .withConfig(
-                ConfigBuilder.withFallback(root.config).withValue(LaikaKeys.title, "Cover").build
-              )
-              // TODO - M3 - after final changes manual application of fallback config should be obsolete
+              .modifyConfig(_.withValue(LaikaKeys.title, "Cover"))
           )
         )
       }

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -22,10 +22,10 @@ import java.util.{ Locale, UUID }
 import cats.effect.{ Async, Resource }
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.config.Config.ConfigResult
-import laika.config._
-import laika.factory._
+import laika.config.*
+import laika.factory.*
 import laika.io.model.{ BinaryOutput, RenderedTreeRoot }
 import laika.render.epub.{ ContainerWriter, XHTMLRenderer }
 import laika.render.{ HTMLFormatter, XHTMLFormatter }
@@ -182,14 +182,14 @@ case object EPUB extends TwoPhaseRenderFormat[HTMLFormatter, BinaryPostProcessor
     BookConfig.decodeWithDefaults(root.config).map { treeConfig =>
       treeConfig.coverImage.fold(root) { image =>
         root.modifyTree(
-          _.copy(
-            content = Document(
+          _.prependContent(
+            Document(
               path = Root / "cover",
               content =
                 RootElement(SpanSequence(Image(InternalTarget(image), alt = Some("cover")))),
               config =
                 ConfigBuilder.withFallback(root.config).withValue(LaikaKeys.title, "Cover").build
-            ) +: root.tree.content
+            )
           )
         )
       }

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -184,12 +184,13 @@ case object EPUB extends TwoPhaseRenderFormat[HTMLFormatter, BinaryPostProcessor
         root.modifyTree(
           _.prependContent(
             Document(
-              path = Root / "cover",
-              content =
-                RootElement(SpanSequence(Image(InternalTarget(image), alt = Some("cover")))),
-              config =
-                ConfigBuilder.withFallback(root.config).withValue(LaikaKeys.title, "Cover").build
+              Root / "cover",
+              RootElement(SpanSequence(Image(InternalTarget(image), alt = Some("cover"))))
             )
+              .withConfig(
+                ConfigBuilder.withFallback(root.config).withValue(LaikaKeys.title, "Cover").build
+              )
+              // TODO - M3 - after final changes manual application of fallback config should be obsolete
           )
         )
       }

--- a/io/src/main/scala/laika/helium/generate/DownloadPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/DownloadPageGenerator.scala
@@ -113,9 +113,7 @@ private[helium] object DownloadPageGenerator {
           Paragraph(_)
         ).toSeq ++: downloads
         val doc    = Document(Root / "downloads.gen", RootElement(blocks))
-          .withConfig(
-            tree.root.config.withValue("helium.markupEditLinks", false).build
-          ) // TODO - M3 - explicit parent wiring will become obsolete
+          .modifyConfig(_.withValue("helium.markupEditLinks", false))
         tree.modifyTree(_.prependContent(doc))
       }
 

--- a/io/src/main/scala/laika/helium/generate/DownloadPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/DownloadPageGenerator.scala
@@ -112,11 +112,10 @@ private[helium] object DownloadPageGenerator {
         val blocks = Title(pageConfig.title).withOptions(Style.title) +: pageConfig.description.map(
           Paragraph(_)
         ).toSeq ++: downloads
-        val doc    = Document(
-          Root / "downloads.gen",
-          RootElement(blocks),
-          config = tree.root.config.withValue("helium.markupEditLinks", false).build
-        )
+        val doc    = Document(Root / "downloads.gen", RootElement(blocks))
+          .withConfig(
+            tree.root.config.withValue("helium.markupEditLinks", false).build
+          ) // TODO - M3 - explicit parent wiring will become obsolete
         tree.modifyTree(_.prependContent(doc))
       }
 

--- a/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
@@ -72,8 +72,7 @@ private[helium] object LandingPageGenerator {
       tree.modifyTree { tree =>
         tree
           .withTitleDocument(titleDocWithTemplate)
-          .withContent(tree.content.filterNot(_.path.withoutSuffix.name == "landing-page"))
-        // TODO - M3 - this should ideally be .removeIfPresent(path) or .removeDocument
+          .removeContent(_.withoutSuffix.name == "landing-page")
       }
     }
 

--- a/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
@@ -17,7 +17,7 @@
 package laika.helium.generate
 
 import cats.data.Kleisli
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.effect.Sync
 import laika.ast.Path.Root
 import laika.ast.{ Document, Element, RootElement }
@@ -70,10 +70,10 @@ private[helium] object LandingPageGenerator {
       )
 
       tree.modifyTree { tree =>
-        tree.copy(
-          titleDocument = Some(titleDocWithTemplate),
-          content = tree.content.filterNot(_.path.withoutSuffix.name == "landing-page")
-        )
+        tree
+          .withTitleDocument(titleDocWithTemplate)
+          .withContent(tree.content.filterNot(_.path.withoutSuffix.name == "landing-page"))
+        // TODO - M3 - this should ideally be .removeIfPresent(path) or .removeDocument
       }
     }
 

--- a/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
@@ -75,11 +75,9 @@ private[helium] object TocPageGenerator {
           title,
           navList
         ) // TODO - Preamble should be inserted in PDF.prepareTree
-        val doc = Document(
-          Root / "table-of-content",
-          root,
-          config = tree.root.config.withValue("helium.site.pageNavigation.enabled", false).build
-        )
+        val doc = Document(Root / "table-of-content", root)
+          .withConfig(tree.root.config.withValue("helium.site.pageNavigation.enabled", false).build)
+        // TODO - M3 - explicit parent wiring will become obsolete
         tree.modifyTree(_.prependContent(doc))
       }
     Sync[F].pure(result)

--- a/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
@@ -76,8 +76,7 @@ private[helium] object TocPageGenerator {
           navList
         ) // TODO - Preamble should be inserted in PDF.prepareTree
         val doc = Document(Root / "table-of-content", root)
-          .withConfig(tree.root.config.withValue("helium.site.pageNavigation.enabled", false).build)
-        // TODO - M3 - explicit parent wiring will become obsolete
+          .modifyConfig(_.withValue("helium.site.pageNavigation.enabled", false))
         tree.modifyTree(_.prependContent(doc))
       }
     Sync[F].pure(result)

--- a/io/src/main/scala/laika/io/descriptor/TransformerDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/TransformerDescriptor.scala
@@ -18,9 +18,8 @@ package laika.io.descriptor
 
 import cats.data.NonEmptyList
 import cats.effect.Async
-import cats.implicits._
-import laika.ast.Path.Root
-import laika.ast.{ DocumentTree, DocumentTreeRoot }
+import cats.syntax.all.*
+import laika.ast.DocumentTree
 import laika.io.api.{
   BinaryTreeRenderer,
   BinaryTreeTransformer,
@@ -104,7 +103,7 @@ object TransformerDescriptor {
         new TreeRenderer.Op(
           op.renderer,
           op.theme,
-          DocumentTreeRoot(DocumentTree(Root, Nil)),
+          DocumentTree.builder.buildRoot,
           op.output,
           Nil
         )
@@ -119,7 +118,7 @@ object TransformerDescriptor {
       new BinaryTreeRenderer.Op(
         op.renderer,
         op.theme,
-        DocumentTreeRoot(DocumentTree(Root, Nil)),
+        DocumentTree.builder.buildRoot,
         op.output,
         Nil
       )

--- a/io/src/main/scala/laika/io/model/ParsedTree.scala
+++ b/io/src/main/scala/laika/io/model/ParsedTree.scala
@@ -44,7 +44,7 @@ class ParsedTree[F[_]](val root: DocumentTreeRoot, val staticDocuments: Seq[Bina
   /** Removes all static documents of this instance that match the specified filter.
     */
   def removeStaticDocuments(filter: Path => Boolean): ParsedTree[F] = new ParsedTree(
-    root = root.copy(staticDocuments = root.staticDocuments.filterNot(doc => filter(doc.path))),
+    root = root.replaceStaticDocuments(root.staticDocuments.filterNot(doc => filter(doc.path))),
     staticDocuments = staticDocuments.filterNot(doc => filter(doc.path))
   )
 
@@ -52,15 +52,15 @@ class ParsedTree[F[_]](val root: DocumentTreeRoot, val staticDocuments: Seq[Bina
     */
   def replaceStaticDocuments(newStaticDocs: Seq[BinaryInput[F]]): ParsedTree[F] = new ParsedTree(
     root =
-      root.copy(staticDocuments = newStaticDocs.map(doc => StaticDocument(doc.path, doc.formats))),
+      root.replaceStaticDocuments(newStaticDocs.map(doc => StaticDocument(doc.path, doc.formats))),
     staticDocuments = newStaticDocs
   )
 
   /** Adds the specified static documents to this instance.
     */
   def addStaticDocuments(newStaticDocs: Seq[BinaryInput[F]]): ParsedTree[F] = new ParsedTree(
-    root = root.copy(staticDocuments =
-      root.staticDocuments ++ newStaticDocs.map(doc => StaticDocument(doc.path, doc.formats))
+    root = root.addStaticDocuments(
+      newStaticDocs.map(doc => StaticDocument(doc.path, doc.formats))
     ),
     staticDocuments = staticDocuments ++ newStaticDocs
   )

--- a/io/src/main/scala/laika/io/ops/TreeMapperOps.scala
+++ b/io/src/main/scala/laika/io/ops/TreeMapperOps.scala
@@ -52,7 +52,7 @@ private[laika] abstract class TreeMapperOps[F[_]: Monad] {
         case tree: DocumentTree => mapTree(tree).widen[TreeContent]
       }
       newTitle   <- tree.titleDocument.traverse(f)
-    } yield tree.withContent(newContent).withTitleDocument(newTitle)
+    } yield tree.replaceContent(newContent).withTitleDocument(newTitle)
 
     for {
       mappedTree  <- mapTree(parsed.root.tree)

--- a/io/src/main/scala/laika/io/ops/TreeMapperOps.scala
+++ b/io/src/main/scala/laika/io/ops/TreeMapperOps.scala
@@ -57,7 +57,7 @@ private[laika] abstract class TreeMapperOps[F[_]: Monad] {
     for {
       mappedTree  <- mapTree(parsed.root.tree)
       mappedCover <- parsed.root.coverDocument.traverse(f)
-    } yield parsed.modifyRoot(_.copy(tree = mappedTree, coverDocument = mappedCover))
+    } yield parsed.modifyRoot(_.modifyTree(_ => mappedTree).withCoverDocument(mappedCover))
 
   }
 

--- a/io/src/main/scala/laika/io/ops/TreeMapperOps.scala
+++ b/io/src/main/scala/laika/io/ops/TreeMapperOps.scala
@@ -52,7 +52,7 @@ private[laika] abstract class TreeMapperOps[F[_]: Monad] {
         case tree: DocumentTree => mapTree(tree).widen[TreeContent]
       }
       newTitle   <- tree.titleDocument.traverse(f)
-    } yield tree.copy(content = newContent, titleDocument = newTitle)
+    } yield tree.withContent(newContent).withTitleDocument(newTitle)
 
     for {
       mappedTree  <- mapTree(parsed.root.tree)

--- a/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
@@ -18,10 +18,10 @@ package laika.io.runtime
 
 import cats.data.{ NonEmptyList, ValidatedNel }
 import cats.effect.{ Async, Sync }
-import cats.implicits._
+import cats.syntax.all.*
 import laika.api.MarkupParser
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.config.Config.IncludeMap
 import laika.config.{ ConfigBuilder, ConfigParser }
 import laika.io.api.TreeParser
@@ -110,8 +110,8 @@ private[io] object ParserRuntime {
       }.combineAll.toEither.leftMap(es => ParserErrors(es.toList.toSet))
 
       def rewriteTree(root: DocumentTreeRoot): Either[InvalidDocuments, ParsedTree[F]] = {
-        val rootToRewrite = root.copy(
-          staticDocuments = inputs.binaryInputs.map(doc =>
+        val rootToRewrite = root.replaceStaticDocuments(
+          inputs.binaryInputs.map(doc =>
             StaticDocument(doc.path, doc.formats)
           ) ++ inputs.providedPaths
         )

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -218,17 +218,16 @@ private[io] object RendererRuntime {
       }
 
     def applyTemplate(root: DocumentTreeRoot): Either[Throwable, DocumentTreeRoot] = {
-
-      val treeWithTpl: DocumentTree =
-        if (root.tree.getDefaultTemplate(context.fileSuffix).isEmpty)
-          root.tree.withDefaultTemplate(
+      val rootWithTpl = root.modifyTree { tree =>
+        if (tree.getDefaultTemplate(context.fileSuffix).isEmpty)
+          tree.withDefaultTemplate(
             getDefaultTemplate(themeInputs, context.fileSuffix),
             context.fileSuffix
           )
         else
-          root.tree
-      val rootWithTpl               = root.copy(tree = treeWithTpl)
-      val rules = op.config.rewriteRulesFor(rootWithTpl, RewritePhase.Render(context))
+          tree
+      }
+      val rules       = op.config.rewriteRulesFor(rootWithTpl, RewritePhase.Render(context))
       mapError(rootWithTpl.applyTemplates(rules, context))
         .flatMap(root => InvalidDocuments.from(root, op.config.failOnMessages).toLeft(root))
     }

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -17,16 +17,16 @@
 package laika.io.runtime
 
 import cats.effect.{ Async, Sync }
-import cats.implicits._
+import cats.syntax.all.*
 import fs2.io.file.Files
 import laika.api.Renderer
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.config.{ ConfigError, ConfigException, LaikaKeys }
 import laika.io.api.{ BinaryTreeRenderer, TreeRenderer }
-import laika.io.model._
+import laika.io.model.*
 import laika.parse.markup.DocumentParser.InvalidDocuments
-import laika.rewrite.nav._
+import laika.rewrite.nav.*
 import laika.rewrite.{ DefaultTemplatePath, OutputContext, Versions }
 
 /** Internal runtime for renderer operations, for text and binary output as well
@@ -35,8 +35,6 @@ import laika.rewrite.{ DefaultTemplatePath, OutputContext, Versions }
   *  @author Jens Halm
   */
 private[io] object RendererRuntime {
-
-  private[laika] case class RenderConfig()
 
   /** Process the specified render operation for an entire input tree and a character output format.
     */
@@ -108,7 +106,7 @@ private[io] object RendererRuntime {
           val renderer          = Renderer.of(op.renderer.format).withConfig(op.config).build
           val docPathTranslator = pathTranslator.forReferencePath(document.path)
           val outputPath        = docPathTranslator.translate(document.path)
-          val outputDoc         = document.copy(path = outputPath)
+          val outputDoc         = document.withPath(outputPath)
           for {
             renderResult <- Async[F].fromEither(
               renderer.render(outputDoc, docPathTranslator, styles)

--- a/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
@@ -190,8 +190,8 @@ class TreeParserFileIOSpec
     val path: Path         = Root / "tree-2" / "doc-7.md"
     val extraDoc: Document = Document(path, RootElement(p("Doc7")))
 
-    def customizeTree(sample: DocumentTreeRoot): DocumentTreeRoot = sample.copy(
-      tree = sample.tree.modifyContent {
+    def customizeTree(sample: DocumentTreeRoot): DocumentTreeRoot = sample.modifyTree(
+      _.modifyContent {
         case tree: DocumentTree if tree.path.name == "tree-2" => tree.appendContent(extraDoc)
         case other                                            => other
       }

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -339,7 +339,7 @@ class TreeParserSpec
       Root / "omg.js" -> Contents.name
     )
     val staticDoc  = StaticDocument(Root / "omg.js", TargetFormats.Selected("html"))
-    val treeResult = DocumentTreeRoot(DocumentTree.empty, staticDocuments = List(staticDoc))
+    val treeResult = DocumentTreeRoot(DocumentTree.empty).addStaticDocuments(List(staticDoc))
     parsedTree(inputs).assertEquals(treeResult)
   }
 
@@ -356,7 +356,7 @@ class TreeParserSpec
     val expectedResult = DocumentTree.builder
       .addDocument(expectedDoc)
       .buildRoot
-      .copy(staticDocuments = List(StaticDocument(providedPath)))
+      .addStaticDocuments(List(StaticDocument(providedPath)))
     parsedTree(inputs, _.addProvidedPath(providedPath)).assertEquals(expectedResult)
   }
 
@@ -427,9 +427,9 @@ class TreeParserSpec
       Root / "main2.bbb.css" -> Contents.name2,
       Root / "main3.aaa.css" -> Contents.name
     )
-    val treeResult                            = DocumentTreeRoot(
-      DocumentTree.empty,
-      styles = Map(
+
+    val treeResult = DocumentTreeRoot(DocumentTree.empty).addStyles(
+      Map(
         "aaa" -> StyleDeclarationSet(
           Set(Root / "main1.aaa.css", Root / "main3.aaa.css"),
           Set(styleDecl("foo"), styleDecl("foo", 1))

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -16,20 +16,20 @@
 
 package laika.io
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.data.{ Chain, NonEmptyChain }
 import cats.effect.IO
 import laika.api.MarkupParser
 import laika.api.builder.OperationConfig
-import laika.ast.DocumentType._
+import laika.ast.DocumentType.*
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, SampleTrees, TestSourceBuilders }
-import laika.bundle._
-import laika.config.ConfigException
+import laika.bundle.*
+import laika.config.{ ConfigBuilder, ConfigException, LaikaKeys }
 import laika.format.{ HTML, Markdown, ReStructuredText }
 import laika.io.helper.InputBuilder
-import laika.io.implicits._
+import laika.io.implicits.*
 import laika.io.model.{ InputTree, InputTreeBuilder, ParsedTree }
 import laika.io.runtime.ParserRuntime.{ DuplicatePath, ParserErrors }
 import laika.parse.Parser
@@ -276,14 +276,13 @@ class TreeParserSpec
       Root / "README.md" -> Contents.name,
       Root / "cover.md"  -> Contents.name
     )
-    val treeResult = DocumentTreeRoot(
-      DocumentTree(
-        Root,
-        List(docResult(1), docResult(2)),
-        titleDocument = Some(docResult("README.md"))
-      ),
-      coverDocument = Some(docResult("cover.md"))
-    )
+    val treeResult =
+      DocumentTree.builder
+        .addDocument(docResult(1))
+        .addDocument(docResult(2))
+        .addDocument(docResult("README.md"))
+        .addDocument(docResult("cover.md"))
+        .buildRoot
     parsedTree(inputs).assertEquals(treeResult)
   }
 
@@ -295,14 +294,19 @@ class TreeParserSpec
       Root / "alternative-title.md" -> Contents.name,
       Root / "cover.md"             -> Contents.name
     )
-    val treeResult = DocumentTreeRoot(
-      DocumentTree(
-        Root,
-        List(docResult(1), docResult(2)),
-        titleDocument = Some(docResult("alternative-title.md"))
-      ),
-      coverDocument = Some(docResult("cover.md"))
-    )
+    val treeResult =
+      DocumentTree.builder
+        .addDocument(docResult(1))
+        .addDocument(docResult(2))
+        .addDocument(docResult("alternative-title.md"))
+        .addDocument(docResult("cover.md"))
+        .addConfig(
+          ConfigBuilder.empty.withValue(
+            LaikaKeys.titleDocuments.inputName,
+            "alternative-title"
+          ).build
+        )
+        .buildRoot
     parsedTree(inputs).assertEquals(treeResult)
   }
 

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -163,9 +163,8 @@ class TreeRendererSpec extends CatsEffectSuite
       DocumentTree.builder.addDocument(Document(Root / "doc", content)).build
 
     def defaultRoot(input: DocumentTree): DocumentTreeRoot =
-      DocumentTreeRoot(
-        input,
-        styles = Map("fo" -> styles).withDefaultValue(StyleDeclarationSet.empty)
+      DocumentTreeRoot(input).addStyles(
+        Map("fo" -> styles).withDefaultValue(StyleDeclarationSet.empty)
       )
 
     def defaultRenderer: Resource[IO, TreeRenderer[IO]]
@@ -791,7 +790,7 @@ class TreeRendererSpec extends CatsEffectSuite
       s"""${title("_tree_subdoc_sub-title", "Sub Title")}
          |<fo:block $overriddenParagraphStyles>ccc</fo:block>""".stripMargin
     )
-    render(DocumentTreeRoot(input, styles = foStyles))
+    render(DocumentTreeRoot(input).addStyles(foStyles))
       .assertEquals(
         Results.root(
           List(
@@ -814,7 +813,7 @@ class TreeRendererSpec extends CatsEffectSuite
     val treeRoot = DocumentTree.builder
       .addConfig(ASTRenderer.fontConfig)
       .buildRoot
-      .copy(staticDocuments = Seq(StaticDocument(Inputs.staticDoc(1).path)))
+      .addStaticDocuments(Seq(StaticDocument(Inputs.staticDoc(1).path)))
 
     ASTRenderer.defaultRenderer
       .use(
@@ -837,7 +836,7 @@ class TreeRendererSpec extends CatsEffectSuite
   test("tree with a single static document from a theme") {
     val treeRoot = DocumentTree.builder
       .buildRoot
-      .copy(staticDocuments = Seq(StaticDocument(Inputs.staticDoc(1).path)))
+      .addStaticDocuments(Seq(StaticDocument(Inputs.staticDoc(1).path)))
 
     val inputs = new TestThemeBuilder.Inputs {
       def build[F[_]: Async] = InputTree[F].addString("...", Root / "static1.txt")
@@ -886,9 +885,8 @@ class TreeRendererSpec extends CatsEffectSuite
       Inputs.staticDoc(7, Root / "dir2", Some("zzz"))
     )
 
-    val treeRoot = DocumentTreeRoot(
-      finalInput,
-      staticDocuments = staticDocs.map(doc => StaticDocument(doc.path, doc.formats))
+    val treeRoot = DocumentTreeRoot(finalInput).addStaticDocuments(
+      staticDocs.map(doc => StaticDocument(doc.path, doc.formats))
     )
 
     val expectedStatic   = staticDocs.dropRight(1).map(_.path)
@@ -945,9 +943,8 @@ class TreeRendererSpec extends CatsEffectSuite
       Inputs.staticDoc(6, Root / "tree-2")
     )
 
-    val treeRoot = DocumentTreeRoot(
-      finalInput,
-      staticDocuments = staticDocs.map(doc => StaticDocument(doc.path, doc.formats))
+    val treeRoot = DocumentTreeRoot(finalInput).addStaticDocuments(
+      staticDocs.map(doc => StaticDocument(doc.path, doc.formats))
     )
 
     def docHTML(num: Int): String = s"<p>Text $num</p>"

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -192,13 +192,11 @@ class TreeRendererSpec extends CatsEffectSuite
           .render
       )
 
-    def addPosition(tree: DocumentTree, pos: Seq[Int] = Nil): DocumentTree = {
+    def addPosition(tree: DocumentTree): DocumentTree = {
       val nextNum = Iterator.from(1)
       tree.modifyContent {
-        case d: Document     => d.copy(position = TreePosition(pos :+ nextNum.next()))
-        case t: DocumentTree =>
-          val num = pos :+ nextNum.next()
-          addPosition(t.withPosition(num.last), num)
+        case d: Document     => d.withPosition(nextNum.next())
+        case t: DocumentTree => addPosition(t.withPosition(nextNum.next()))
       }
     }
 
@@ -780,7 +778,7 @@ class TreeRendererSpec extends CatsEffectSuite
   }
 
   test("tree with two documents to XSL-FO using a custom style sheet in the tree root") {
-    import FORenderer._
+    import FORenderer.*
 
     val input                                      = Inputs.twoDocs(defaultContent, subElem)
     val foStyles: Map[String, StyleDeclarationSet] =
@@ -1054,7 +1052,7 @@ class TreeRendererSpec extends CatsEffectSuite
   }
 
   object FileSystemTest {
-    import cats.implicits._
+    import cats.syntax.all.*
 
     val input: DocumentTreeRoot = SampleTrees.sixDocuments.build
 
@@ -1133,7 +1131,7 @@ class TreeRendererSpec extends CatsEffectSuite
   }
 
   test("render versioned documents with an existing versionInfo JSON file") {
-    import VersionInfoSetup._
+    import VersionInfoSetup.*
 
     val existingVersionInfo =
       """{
@@ -1177,7 +1175,7 @@ class TreeRendererSpec extends CatsEffectSuite
   }
 
   test("directory with existing versioned renderer output") {
-    import VersionInfoSetup._
+    import VersionInfoSetup.*
 
     def mkDirs(dir: FilePath): IO[Unit] =
       List(

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -410,7 +410,7 @@ class TreeRendererSpec extends CatsEffectSuite
         TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
       )
     )
-    val input    = HTMLRenderer.defaultTree.withTemplates(Seq(template))
+    val input    = HTMLRenderer.defaultTree.addTemplate(template)
     val expected = """[<h1 id="title" class="title">Title</h1>
                      |<p>bbb</p>]""".stripMargin
     HTMLRenderer
@@ -647,7 +647,7 @@ class TreeRendererSpec extends CatsEffectSuite
         TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
       )
     )
-    val input    = EPUB_XHTMLRenderer.defaultTree.withTemplates(Seq(template))
+    val input    = EPUB_XHTMLRenderer.defaultTree.addTemplate(template)
     val expected = """[<h1 id="title" class="title">Title</h1>
                      |<p>bbb</p>]""".stripMargin
     val path     = (Root / "doc").withSuffix("epub.xhtml")
@@ -740,7 +740,7 @@ class TreeRendererSpec extends CatsEffectSuite
         TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
       )
     )
-    val input    = FORenderer.defaultTree.withTemplates(Seq(template))
+    val input    = FORenderer.defaultTree.addTemplate(template)
     val expected = s"""[${FORenderer.title("_doc_title", "Title")}
                       |<fo:block ${FORenderer.defaultParagraphStyles}>bbb</fo:block>]""".stripMargin
     val path     = Root / "doc.fo"

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -200,12 +200,12 @@ class TreeRendererSpec extends CatsEffectSuite
 
     def addPosition(tree: DocumentTree, pos: Seq[Int] = Nil): DocumentTree = {
       val nextNum = Iterator.from(1)
-      tree.withContent(tree.content.map {
+      tree.modifyContent {
         case d: Document     => d.copy(position = TreePosition(pos :+ nextNum.next()))
         case t: DocumentTree =>
           val num = pos :+ nextNum.next()
           addPosition(t.withPosition(TreePosition(num)), num)
-      })
+      }
     }
 
   }

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -18,11 +18,11 @@ package laika.io
 
 import cats.data.{ Chain, NonEmptyChain }
 import cats.effect.{ Async, IO, Resource }
-import cats.syntax.all._
+import cats.syntax.all.*
 import fs2.io.file.Files
 import laika.api.Renderer
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.{
   BuilderKey,
   ParagraphCompanionShortcuts,
@@ -32,17 +32,17 @@ import laika.ast.sample.{
 }
 import laika.bundle.{ BundleOrigin, BundleProvider, ExtensionBundle }
 import laika.config.{ Config, ConfigBuilder, LaikaKeys }
-import laika.format._
+import laika.format.*
 import laika.helium.generate.FOStyles
 import laika.io.api.{ BinaryTreeRenderer, TreeRenderer }
 import laika.io.helper.{ InputBuilder, RenderResult, TestThemeBuilder }
-import laika.io.implicits._
-import laika.io.model._
+import laika.io.implicits.*
+import laika.io.model.*
 import laika.io.runtime.RendererRuntime.{ DuplicatePath, RendererErrors }
 import laika.io.runtime.VersionInfoGenerator
 import laika.parse.GeneratedSource
 import laika.parse.markup.DocumentParser.{ InvalidDocument, InvalidDocuments }
-import laika.render._
+import laika.render.*
 import laika.render.fo.TestTheme
 import laika.render.fo.TestTheme.staticHTMLPaths
 import laika.rewrite.ReferenceResolver.CursorKeys
@@ -146,10 +146,10 @@ class TreeRendererSpec extends CatsEffectSuite
 
   trait TreeRendererSetup[FMT] {
 
-    val fontConfigTree: DocumentTree = DocumentTree(
+    val fontConfigTree: DocumentTree = new DocumentTree(
       Root / "laika",
       List(
-        DocumentTree(
+        new DocumentTree(
           Root / "laika" / "fonts",
           Nil,
           config = ConfigBuilder
@@ -200,11 +200,11 @@ class TreeRendererSpec extends CatsEffectSuite
 
     def addPosition(tree: DocumentTree, pos: Seq[Int] = Nil): DocumentTree = {
       val nextNum = Iterator.from(1)
-      tree.copy(content = tree.content.map {
+      tree.withContent(tree.content.map {
         case d: Document     => d.copy(position = TreePosition(pos :+ nextNum.next()))
         case t: DocumentTree =>
           val num = pos :+ nextNum.next()
-          addPosition(t.copy(position = TreePosition(num)), num)
+          addPosition(t.withPosition(TreePosition(num)), num)
       })
     }
 
@@ -344,7 +344,7 @@ class TreeRendererSpec extends CatsEffectSuite
 
   test("fail with duplicate paths") {
     val root  = HTMLRenderer.defaultContent
-    val input = DocumentTree(
+    val input = new DocumentTree(
       Root,
       List(
         Document(Root / "doc1", root),
@@ -410,7 +410,7 @@ class TreeRendererSpec extends CatsEffectSuite
         TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
       )
     )
-    val input    = HTMLRenderer.defaultTree.copy(templates = Seq(template))
+    val input    = HTMLRenderer.defaultTree.withTemplates(Seq(template))
     val expected = """[<h1 id="title" class="title">Title</h1>
                      |<p>bbb</p>]""".stripMargin
     HTMLRenderer
@@ -534,7 +534,7 @@ class TreeRendererSpec extends CatsEffectSuite
   }
 
   test("tree with a cover and title document to HTML") {
-    val input    = DocumentTree(
+    val input    = new DocumentTree(
       Root,
       List(Document(Root / "doc", HTMLRenderer.defaultContent), HTMLRenderer.fontConfigTree),
       Some(Document(Root / "README", HTMLRenderer.defaultContent))
@@ -579,7 +579,7 @@ class TreeRendererSpec extends CatsEffectSuite
       Results.titleWithId("Title"),
       p(SpanLink.internal("doc-2.md")("Link Text"))
     )
-    val input                        = DocumentTree(
+    val input                        = new DocumentTree(
       Root,
       List(
         Document(Root / "doc-1.md", contentWithLink),
@@ -647,7 +647,7 @@ class TreeRendererSpec extends CatsEffectSuite
         TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
       )
     )
-    val input    = EPUB_XHTMLRenderer.defaultTree.copy(templates = Seq(template))
+    val input    = EPUB_XHTMLRenderer.defaultTree.withTemplates(Seq(template))
     val expected = """[<h1 id="title" class="title">Title</h1>
                      |<p>bbb</p>]""".stripMargin
     val path     = (Root / "doc").withSuffix("epub.xhtml")
@@ -740,7 +740,7 @@ class TreeRendererSpec extends CatsEffectSuite
         TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
       )
     )
-    val input    = FORenderer.defaultTree.copy(templates = Seq(template))
+    val input    = FORenderer.defaultTree.withTemplates(Seq(template))
     val expected = s"""[${FORenderer.title("_doc_title", "Title")}
                       |<fo:block ${FORenderer.defaultParagraphStyles}>bbb</fo:block>]""".stripMargin
     val path     = Root / "doc.fo"
@@ -752,7 +752,7 @@ class TreeRendererSpec extends CatsEffectSuite
   }
 
   test("tree with two documents to XSL-FO using a custom style sheet in a theme") {
-    import FORenderer._
+    import FORenderer.*
 
     val inputs       = new TestThemeBuilder.Inputs {
       def build[F[_]: Async] = InputTree[F]
@@ -827,7 +827,7 @@ class TreeRendererSpec extends CatsEffectSuite
   }
 
   test("tree with a single static document") {
-    val input = DocumentTree(Root, Seq(ASTRenderer.fontConfigTree))
+    val input = new DocumentTree(Root, Seq(ASTRenderer.fontConfigTree))
 
     val treeRoot =
       DocumentTreeRoot(input, staticDocuments = Seq(StaticDocument(Inputs.staticDoc(1).path)))

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -198,7 +198,7 @@ class TreeRendererSpec extends CatsEffectSuite
         case d: Document     => d.copy(position = TreePosition(pos :+ nextNum.next()))
         case t: DocumentTree =>
           val num = pos :+ nextNum.next()
-          addPosition(t.withPosition(TreePosition(num)), num)
+          addPosition(t.withPosition(num.last), num)
       }
     }
 

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -271,8 +271,7 @@ class TreeTransformerSpec extends CatsEffectSuite
     val mapperFunction: Document => Document = doc =>
       doc.withContent(doc.content.withContent(Seq(Paragraph("foo-bar"))))
 
-    val mapperFunctionExt: Document => Document = doc =>
-      doc.withContent(doc.content.withContent(doc.content.content :+ Paragraph("baz")))
+    val mapperFunctionExt: Document => Document = doc => doc.appendContent(Paragraph("baz"))
 
     def transformWithProcessor(theme: ThemeProvider): IO[RenderedTreeRoot[IO]] =
       transformWith(inputs, Transformer.from(Markdown).to(AST).parallel[IO].withTheme(theme).build)

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -21,15 +21,15 @@ import laika.api.builder.OperationConfig
 import laika.api.{ MarkupParser, Transformer }
 import laika.ast.DocumentType.Ignored
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.bundle.{ BundleProvider, ExtensionBundle }
 import laika.config.Config
 import laika.directive.Templates
-import laika.format._
+import laika.format.*
 import laika.io.api.{ BinaryTreeTransformer, TreeTransformer }
 import laika.io.descriptor.TransformerDescriptor
 import laika.io.helper.{ InputBuilder, RenderResult, RenderedTreeAssertions, TestThemeBuilder }
-import laika.io.implicits._
+import laika.io.implicits.*
 import laika.io.model.{
   FileFilter,
   FilePath,
@@ -246,7 +246,7 @@ class TreeTransformerSpec extends CatsEffectSuite
     )
     transformWithDocumentMapper(
       inputs,
-      doc => doc.copy(content = doc.content.withContent(Seq(Paragraph("foo-bar"))))
+      doc => doc.withContent(doc.content.withContent(Seq(Paragraph("foo-bar"))))
     )
       .assertEquals(
         renderedRoot(
@@ -269,10 +269,10 @@ class TreeTransformerSpec extends CatsEffectSuite
     )
 
     val mapperFunction: Document => Document = doc =>
-      doc.copy(content = doc.content.withContent(Seq(Paragraph("foo-bar"))))
+      doc.withContent(doc.content.withContent(Seq(Paragraph("foo-bar"))))
 
     val mapperFunctionExt: Document => Document = doc =>
-      doc.copy(content = doc.content.withContent(doc.content.content :+ Paragraph("baz")))
+      doc.withContent(doc.content.withContent(doc.content.content :+ Paragraph("baz")))
 
     def transformWithProcessor(theme: ThemeProvider): IO[RenderedTreeRoot[IO]] =
       transformWith(inputs, Transformer.from(Markdown).to(AST).parallel[IO].withTheme(theme).build)

--- a/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
@@ -140,8 +140,8 @@ class ThemeBundleSpec extends FunSuite {
     assertEquals(
       config(themeBundles, appBundles).rewriteRulesFor(doc, RewritePhase.Resolve).flatMap(
         doc.rewrite
-      ),
-      Right(expected)
+      ).map(_.content),
+      Right(expected.content)
     )
   }
 
@@ -161,8 +161,8 @@ class ThemeBundleSpec extends FunSuite {
     assertEquals(
       config(themeBundles, appBundles).rewriteRulesFor(doc, RewritePhase.Resolve).flatMap(
         doc.rewrite
-      ),
-      Right(expected)
+      ).map(_.content),
+      Right(expected.content)
     )
   }
 

--- a/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
@@ -22,8 +22,8 @@ import laika.api.Transformer
 import laika.api.builder.OperationConfig
 import laika.ast.DocumentType.{ Markup, Static, Template }
 import laika.ast.Path.Root
-import laika.ast._
-import laika.io.implicits._
+import laika.ast.*
+import laika.io.implicits.*
 import laika.bundle.{ BundleOrigin, BundleProvider, ExtensionBundle }
 import laika.format.{ HTML, Markdown }
 import laika.io.helper.TestThemeBuilder
@@ -118,7 +118,7 @@ class ThemeBundleSpec extends FunSuite {
       p.parent / p.withBasename(p.basename + "-app").relative
     })
     val testTree           =
-      DocumentTreeRoot(DocumentTree(Root, Seq(Document(Root / "doc.md", RootElement.empty))))
+      DocumentTree.builder.addDocument(Document(Root / "doc.md", RootElement.empty)).buildRoot
     val compoundTranslator = config(themeBundles, appBundles)
       .pathTranslatorFor(testTree, OutputContext("html"))
       .getOrElse(NoOpPathTranslator)

--- a/pdf/src/main/scala/laika/format/PDF.scala
+++ b/pdf/src/main/scala/laika/format/PDF.scala
@@ -78,7 +78,7 @@ object PDF extends TwoPhaseRenderFormat[FOFormatter, BinaryPostProcessorBuilder]
     Right(
       root
         .modifyTree(_.withDefaultTemplate(TemplateRoot.fallback, "fo"))
-        .mapDocuments { doc =>
+        .modifyDocumentsRecursively { doc =>
           val preamble = Preamble(doc.title.fold(doc.name)(_.extractText))
           doc.prependContent(preamble)
         }

--- a/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
@@ -61,12 +61,9 @@ private[laika] object FOConcatenation {
     def applyTemplate(foString: String, template: TemplateDocument): Either[Throwable, String] = {
       val finalConfig     = ensureAbsoluteCoverImagePath
       val virtualPath     = Path.Root / "merged.fo"
-      val finalDoc        = Document(
-        virtualPath,
-        RootElement(ContentWrapper(foString)),
-        fragments = PDFNavigation.generateBookmarks(result, config.navigationDepth),
-        config = finalConfig
-      )
+      val finalDoc        = Document(virtualPath, RootElement(ContentWrapper(foString)))
+        .withFragments(PDFNavigation.generateBookmarks(result, config.navigationDepth))
+        .withConfig(finalConfig)
       val renderer        = Renderer.of(XSLFO).withConfig(opConfig).build
       val templateApplied = for {
         rules <- opConfig.rewriteRulesFor(finalDoc, RewritePhase.Render(PDF))

--- a/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
@@ -17,7 +17,7 @@
 package laika.render
 
 import cats.effect.{ Async, IO, Resource }
-import cats.implicits._
+import cats.syntax.all.*
 import laika.api.Renderer
 import laika.api.builder.{ OperationConfig, TwoPhaseRendererBuilder }
 import laika.ast.{ DocumentTreeRoot, TemplateRoot }
@@ -32,7 +32,7 @@ import laika.format.{ Markdown, PDF, XSLFO }
 import laika.io.FileIO
 import laika.io.api.BinaryTreeRenderer
 import laika.io.helper.RenderResult
-import laika.io.implicits._
+import laika.io.implicits.*
 import laika.io.model.{ BinaryOutput, RenderedTreeRoot }
 import laika.render.FOFormatter.Preamble
 import laika.render.fo.TestTheme
@@ -167,7 +167,7 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
         TestTheme.foTemplate,
         "fo"
       )
-      val root = DocumentTreeRoot(tree, styles = Map("fo" -> TestTheme.foStyles))
+      val root = DocumentTreeRoot(tree).addStyles(Map("fo" -> TestTheme.foStyles))
       withByteArrayTextOutput { out =>
         r
           .from(root)

--- a/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
@@ -51,7 +51,7 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
         .modifyTree(_.withDefaultTemplate(TemplateRoot.fallback, "fo"))
         .mapDocuments { doc =>
           val preamble = Preamble(doc.title.fold(doc.name)(_.extractText))
-          doc.copy(content = doc.content.withContent(preamble +: doc.content.content))
+          doc.withContent(doc.content.withContent(preamble +: doc.content.content))
         }
     )
 

--- a/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
@@ -49,7 +49,7 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
     def prepareTree(root: DocumentTreeRoot): Either[Throwable, DocumentTreeRoot] = Right(
       root
         .modifyTree(_.withDefaultTemplate(TemplateRoot.fallback, "fo"))
-        .mapDocuments { doc =>
+        .modifyDocumentsRecursively { doc =>
           val preamble = Preamble(doc.title.fold(doc.name)(_.extractText))
           doc.prependContent(preamble)
         }

--- a/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
@@ -51,7 +51,7 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
         .modifyTree(_.withDefaultTemplate(TemplateRoot.fallback, "fo"))
         .mapDocuments { doc =>
           val preamble = Preamble(doc.title.fold(doc.name)(_.extractText))
-          doc.withContent(doc.content.withContent(preamble +: doc.content.content))
+          doc.prependContent(preamble)
         }
     )
 

--- a/pdf/src/test/scala/laika/render/PDFRendererSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFRendererSpec.scala
@@ -22,7 +22,7 @@ import laika.api.{ MarkupParser, Renderer }
 import laika.ast.{ DocumentTree, DocumentTreeRoot }
 import laika.format.{ Markdown, PDF }
 import laika.io.FileIO
-import laika.io.implicits._
+import laika.io.implicits.*
 import laika.io.model.{ InputTree, ParsedTree }
 import laika.rewrite.DefaultTemplatePath
 import munit.CatsEffectSuite
@@ -44,11 +44,11 @@ class PDFRendererSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
   private val emptyTreeWithTemplate = templateParser.use(_.fromInput(InputTree[IO]).parse)
 
   def buildInputTree(templateTree: ParsedTree[IO], inputTree: DocumentTree): DocumentTreeRoot = {
-    val treeWithTemplate = inputTree.copy(
-      templates =
-        Seq(templateTree.root.tree.selectTemplate(DefaultTemplatePath.forFO.relative).get),
-      config = templateTree.root.config
-    )
+    val treeWithTemplate = inputTree
+      .withTemplates(
+        Seq(templateTree.root.tree.selectTemplate(DefaultTemplatePath.forFO.relative).get)
+      )
+      .withConfig(templateTree.root.config)
     DocumentTreeRoot(treeWithTemplate)
   }
 

--- a/pdf/src/test/scala/laika/render/PDFRendererSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFRendererSpec.scala
@@ -45,8 +45,8 @@ class PDFRendererSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
 
   def buildInputTree(templateTree: ParsedTree[IO], inputTree: DocumentTree): DocumentTreeRoot = {
     val treeWithTemplate = inputTree
-      .withTemplates(
-        Seq(templateTree.root.tree.selectTemplate(DefaultTemplatePath.forFO.relative).get)
+      .addTemplate(
+        templateTree.root.tree.selectTemplate(DefaultTemplatePath.forFO.relative).get
       )
       .withConfig(templateTree.root.config)
     DocumentTreeRoot(treeWithTemplate)


### PR DESCRIPTION
This is the only PR for M3 where the removal of case classes is combined with a fairly big refactoring as it allows to remove some old limitations now that we do no longer have to support low-level copy operations on `DocumentTree`.

The `Document` instances added to such a tree have three properties which represent a hierarchical structure within the document tree: 

* `path: Path`, the virtual path of the document with the tree
* `config: Config`, the configuration instance which uses the config of the parent tree as a fallback
* `position: Position`, the value that is used for auto-numbering of documents

In the past these values could go out of sync due to the existence of low-level copy methods on both, `DocumentTree` and `Document`. Now that both are regular classes the correct parent association can be managed internally, creating a much more robust representation of the virtual tree on top of being easier to evolve in a binary compatible manner. A `Document` instance can now safely be taken from one `DocumentTree` and inserted into another where internally a copy with adjusted parent context will be added instead.

Types within the `laika.ast` package which cease to be case classes:

`TreeCursor`
`DocumentCursor`
`Document`
`DocumentTree`
`DocumentTreeRoot`
`TemplateDocument`

The removal of a `copy` method is balanced by the introduction of mutator methods, in the most simple case just the `withFoo` pattern, but in some cases with additional methods for convenience, e.g. `modifyConfig(ConfigBuilder => ConfigBuilder)` which helps with the common case of just adding to existing properties.