### PR TITLE
convert public case classes in laika.rewrite.link

### DIFF
--- a/core/shared/src/main/scala/laika/directive/std/LinkDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/LinkDirectives.scala
@@ -45,7 +45,7 @@ private[laika] object LinkDirectives {
   private def linkConfig[T](cursor: DocumentCursor): Either[String, LinkConfig] =
     cursor.config
       .getOpt[LinkConfig]
-      .map(_.getOrElse(LinkConfig()))
+      .map(_.getOrElse(LinkConfig.empty))
       .leftMap(_.message)
 
   /** Implementation of the `api` directive that creates links to API documentation based

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -170,7 +170,9 @@ sealed abstract class OutputContext {
 object OutputContext {
 
   private final case class Impl(fileSuffix: String, formatSelector: String)
-      extends OutputContext
+      extends OutputContext {
+    override def productPrefix: String = "OutputContext"
+  }
 
   private[laika] def apply(fileSuffix: String, formatSelector: String): OutputContext =
     Impl(fileSuffix, formatSelector)

--- a/core/shared/src/main/scala/laika/rewrite/link/IconRegistry.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/IconRegistry.scala
@@ -5,11 +5,15 @@ import laika.config.{ ConfigEncoder, DefaultKey, LaikaKeys }
 
 /** Registers Icon AST elements for use with the `@:icon` directive and the `IconReference` AST element.
   */
-case class IconRegistry private (icons: Map[String, Icon])
+class IconRegistry private (private val icons: Map[String, Icon]) {
+
+  def getIcon(id: String): Option[Icon] = icons.get(id)
+
+}
 
 object IconRegistry {
 
-  def apply(icons: (String, Icon)*): IconRegistry = IconRegistry(icons.toMap)
+  def apply(icons: (String, Icon)*): IconRegistry = new IconRegistry(icons.toMap)
 
   implicit val encoder: ConfigEncoder[IconRegistry] = ConfigEncoder.map[Element].contramap(_.icons)
 

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -317,13 +317,12 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
     private val linkTarget = RootElement(InternalLinkTarget(Id("ref")))
 
-    private val linkConfig = LinkConfig(targets =
-      Seq(
-        TargetDefinition("int", InternalTarget(RelativePath.parse("../doc-1.md#ref"))),
-        TargetDefinition("ext", ExternalTarget("https://www.foo.com/")),
-        TargetDefinition("inv", InternalTarget(RelativePath.parse("../doc-99.md#ref")))
+    private val linkConfig = LinkConfig.empty
+      .addTargets(
+        TargetDefinition.internal("int", RelativePath.parse("../doc-1.md#ref")),
+        TargetDefinition.external("ext", "https://www.foo.com/"),
+        TargetDefinition.internal("inv", RelativePath.parse("../doc-99.md#ref"))
       )
-    )
 
     def run(ref: LinkIdReference, expected: Block): Unit = {
       val root =

--- a/docs/src/03-preparing-content/02-navigation.md
+++ b/docs/src/03-preparing-content/02-navigation.md
@@ -127,20 +127,20 @@ Simply add them to the project's configuration:
 
 @:choice(sbt)
 ```scala mdoc:compile-only
-import laika.ast.ExternalTarget
 import laika.rewrite.link.{ LinkConfig, TargetDefinition }
 
 laikaConfig := LaikaConfig.defaults
-  .withConfigValue(LinkConfig(targets = Seq(
-    TargetDefinition("Example 1", ExternalTarget("https://example1.com/")),
-    TargetDefinition("Example 2", ExternalTarget("https://example2.com/"))
-  )))
+  .withConfigValue(LinkConfig.empty
+    .addTargets(
+      TargetDefinition.external("Example 1", "https://example1.com/"),
+      TargetDefinition.external("Example 2", "https://example2.com/")
+    )
+  )
 ```
 
 @:choice(library)
 ```scala mdoc:silent
 import laika.api._
-import laika.ast.ExternalTarget
 import laika.format._
 import laika.markdown.github.GitHubFlavor
 import laika.rewrite.link.{ LinkConfig, TargetDefinition }
@@ -149,10 +149,12 @@ val transformer = Transformer
   .from(Markdown)
   .to(HTML)
   .using(GitHubFlavor)
-  .withConfigValue(LinkConfig(targets = Seq(
-    TargetDefinition("Example 1", ExternalTarget("https://example1.com/")),
-    TargetDefinition("Example 2", ExternalTarget("https://example2.com/"))
-  )))
+  .withConfigValue(LinkConfig.empty
+    .addTargets(
+      TargetDefinition.external("Example 1", "https://example1.com/"),
+      TargetDefinition.external("Example 2", "https://example2.com/")
+    )
+  )
   .build
 ```
 @:@
@@ -251,9 +253,9 @@ This directive requires the base URI to be defined in the project's configuratio
 import laika.rewrite.link.{ LinkConfig, ApiLinks }
 
 laikaConfig := LaikaConfig.defaults
-  .withConfigValue(LinkConfig(apiLinks = Seq(
-    ApiLinks(baseUri = "https://example.com/api")
-  )))
+  .withConfigValue(LinkConfig.empty
+    .addApiLinks(ApiLinks(baseUri = "https://example.com/api"))
+  )
 ```
 
 @:choice(library)
@@ -267,9 +269,9 @@ val transformer = Transformer
   .from(Markdown)
   .to(HTML)
   .using(GitHubFlavor)
-  .withConfigValue(LinkConfig(apiLinks = Seq(
-    ApiLinks(baseUri = "https://example.com/api")
-  )))
+  .withConfigValue(LinkConfig.empty
+    .addApiLinks(ApiLinks(baseUri = "https://example.com/api"))
+  )
   .build
 ```
 @:@
@@ -284,10 +286,10 @@ while keeping one base URI as a default for all packages that do not match any p
 import laika.rewrite.link.{ LinkConfig, ApiLinks }
 
 laikaConfig := LaikaConfig.defaults
-  .withConfigValue(LinkConfig(apiLinks = Seq(
-    ApiLinks(baseUri = "https://example.com/api"),
-    ApiLinks(baseUri = "https://somewhere-else/", packagePrefix = "com.lib42")
-  )))
+  .withConfigValue(LinkConfig.empty
+    .addApiLinks(ApiLinks("https://example.com/api"))
+    .addApiLinks(ApiLinks("https://somewhere-else/").withPackagePrefix("com.lib42"))
+  )
 ```
 
 @:choice(library)
@@ -301,10 +303,10 @@ val transformer = Transformer
   .from(Markdown)
   .to(HTML)
   .using(GitHubFlavor)
-  .withConfigValue(LinkConfig(apiLinks = Seq(
-    ApiLinks(baseUri = "https://example.com/api"),
-    ApiLinks(baseUri = "https://somewhere-else/", packagePrefix = "com.lib42")
-  )))
+  .withConfigValue(LinkConfig.empty
+    .addApiLinks(ApiLinks("https://example.com/api"))
+    .addApiLinks(ApiLinks("https://somewhere-else/").withPackagePrefix("com.lib42"))
+  )
   .build
 ```
 
@@ -332,9 +334,11 @@ This directive requires the base URI and suffix to be defined in the project's c
 import laika.rewrite.link.{ LinkConfig, SourceLinks }
 
 laikaConfig := LaikaConfig.defaults
-  .withConfigValue(LinkConfig(sourceLinks = Seq(
-    SourceLinks(baseUri = "https://github.com/team/project", suffix = "scala")
-  )))
+  .withConfigValue(LinkConfig.empty
+    .addSourceLinks(
+      SourceLinks(baseUri = "https://github.com/team/project", suffix = "scala")
+    )
+  )
 ```
 
 @:choice(library)
@@ -348,9 +352,11 @@ val transformer = Transformer
   .from(Markdown)
   .to(HTML)
   .using(GitHubFlavor)
-  .withConfigValue(LinkConfig(sourceLinks = Seq(
-     SourceLinks(baseUri = "https://github.com/team/project", suffix = "scala")
-  )))
+  .withConfigValue(LinkConfig.empty
+    .addSourceLinks(
+      SourceLinks(baseUri = "https://github.com/team/project", suffix = "scala")
+    )
+  )
   .build
 ```
 @:@
@@ -365,17 +371,16 @@ while keeping one base URI as a default for all packages that do not match any p
 import laika.rewrite.link.{ LinkConfig, SourceLinks }
 
 laikaConfig := LaikaConfig.defaults
-  .withConfigValue(LinkConfig(sourceLinks = Seq(
-    SourceLinks(
+  .withConfigValue(LinkConfig.empty
+    .addSourceLinks(SourceLinks(
       baseUri = "https://github.com/team/project", 
       suffix = "scala"
-    ),
-    SourceLinks(
+    ))
+    .addSourceLinks(SourceLinks(
       baseUri = "https://github.com/elsewhere/project", 
-      suffix = "scala", 
-      packagePrefix = "com.lib42"
-    )
-  )))
+      suffix = "scala"
+    ).withPackagePrefix("com.lib42"))
+  )
 ```
 
 @:choice(library)
@@ -389,17 +394,16 @@ val transformer = Transformer
   .from(Markdown)
   .to(HTML)
   .using(GitHubFlavor)
-  .withConfigValue(LinkConfig(sourceLinks = Seq(
-    SourceLinks(
+  .withConfigValue(LinkConfig.empty
+    .addSourceLinks(SourceLinks(
       baseUri = "https://github.com/team/project", 
       suffix = "scala"
-    ),
-    SourceLinks(
+    ))
+    .addSourceLinks(SourceLinks(
       baseUri = "https://github.com/elsewhere/project", 
-      suffix = "scala", 
-      packagePrefix = "com.lib42"
-    )
-  )))
+      suffix = "scala"
+    ).withPackagePrefix("com.lib42"))
+  )
   .build
 ```
 


### PR DESCRIPTION
Applies the pattern described in #482 (section 2.) to public case classes in the package `laika.rewrite.link`:

* `LinkConfig`
* `ApiLinks`
* `SourceLinks`
* `TargetDefinition`

`apply` methods in the companions are reduced to arguments for all non-optional properties.
Since `LinkConfig` is heavily used in builds, deprecations for the old `apply` method will be introduced in 0.19.4 to ease the transition.

Finally, `IconRegistry` is no longer a case class (the above pattern has not been applied here).