### PR TITLE
convert public case classes in laika.rewrite.nav

### DIFF
--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -58,7 +58,7 @@ sealed trait TreeContent extends Navigatable {
     config.get[Traced[String]](LaikaKeys.title).toOption.flatMap { tracedTitle =>
       if (tracedTitle.origin.scope == configScope) {
         val title             = Seq(Text(tracedTitle.value))
-        val autonumberConfig  = config.get[AutonumberConfig].getOrElse(AutonumberConfig.defaults)
+        val autonumberConfig  = config.get[AutonumberConfig].getOrElse(AutonumberConfig.disabled)
         val autonumberEnabled =
           autonumberConfig.documents && position.depth < autonumberConfig.maxDepth
         if (autonumberEnabled) Some(SpanSequence(position.toSpan +: title))

--- a/core/shared/src/main/scala/laika/rewrite/nav/SectionBuilder.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/SectionBuilder.scala
@@ -17,7 +17,7 @@
 package laika.rewrite.nav
 
 import laika.ast.RewriteRules.RewriteRulesBuilder
-import laika.ast._
+import laika.ast.*
 import laika.collection.Stack
 import laika.config.Config.ConfigResult
 import laika.config.LaikaKeys
@@ -124,7 +124,7 @@ private[laika] object SectionBuilder extends RewriteRulesBuilder {
     */
   def apply(cursor: DocumentCursor): ConfigResult[RewriteRules] = for {
     autonumbering      <- cursor.config.getOpt[AutonumberConfig].map(
-      _.getOrElse(AutonumberConfig.defaults)
+      _.getOrElse(AutonumberConfig.disabled)
     )
     firstHeaderAsTitle <- cursor.config.get(
       LaikaKeys.firstHeaderAsTitle,

--- a/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
@@ -282,7 +282,7 @@ class ConfigCodecSpec extends FunSuite {
     val sample = Selections(
       SelectionConfig(
         "foo",
-        ChoiceConfig("foo-a", "foo-label-a", selected = true),
+        ChoiceConfig("foo-a", "foo-label-a").select,
         ChoiceConfig("foo-b", "foo-label-b")
       ).withSeparateEbooks,
       SelectionConfig(
@@ -325,11 +325,7 @@ class ConfigCodecSpec extends FunSuite {
 
   object autonumbering {
 
-    val fullyPopulatedInstance = AutonumberConfig(
-      documents = true,
-      sections = true,
-      maxDepth = 5
-    )
+    val fullyPopulatedInstance = AutonumberConfig.allEnabled.withMaxDepth(5)
 
   }
 

--- a/core/shared/src/test/scala/laika/directive/std/SelectDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/SelectDirectiveSpec.scala
@@ -18,7 +18,7 @@ package laika.directive.std
 
 import laika.api.{ MarkupParser, RenderPhaseRewrite }
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.format.{ HTML, Markdown }
 import laika.rewrite.nav.{ ChoiceConfig, SelectionConfig, Selections }
@@ -157,7 +157,7 @@ class SelectDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts
       SelectionConfig(
         "config",
         ChoiceConfig("a", "label-a"),
-        ChoiceConfig("b", "label-b", selected = true)
+        ChoiceConfig("b", "label-b").select
       )
     )
     val doc    = Document(Root / "doc", RootElement(group))

--- a/core/shared/src/test/scala/laika/rewrite/SelectionConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/SelectionConfigSpec.scala
@@ -16,8 +16,8 @@
 
 package laika.rewrite
 
-import cats.data.{ NonEmptyChain, NonEmptyVector }
-import cats.syntax.all._
+import cats.data.NonEmptyVector
+import cats.syntax.all.*
 import laika.ast.Path
 import laika.ast.Path.Root
 import laika.config.Config.ConfigResult
@@ -31,30 +31,24 @@ class SelectionConfigSpec extends FunSuite {
 
   val selectionFoo = SelectionConfig(
     "foo",
-    NonEmptyChain(
-      ChoiceConfig("foo-a", "foo-label-a"),
-      ChoiceConfig("foo-b", "foo-label-b")
-    )
+    ChoiceConfig("foo-a", "foo-label-a"),
+    ChoiceConfig("foo-b", "foo-label-b")
   )
 
   val selectionBar = SelectionConfig(
     "bar",
-    NonEmptyChain(
-      ChoiceConfig("bar-a", "bar-label-a"),
-      ChoiceConfig("bar-b", "bar-label-b")
-    )
+    ChoiceConfig("bar-a", "bar-label-a"),
+    ChoiceConfig("bar-b", "bar-label-b")
   )
 
   val selectionBaz = SelectionConfig(
     "baz",
-    NonEmptyChain(
-      ChoiceConfig("baz-a", "baz-label-a"),
-      ChoiceConfig("baz-b", "baz-label-b")
-    )
+    ChoiceConfig("baz-a", "baz-label-a"),
+    ChoiceConfig("baz-b", "baz-label-b")
   )
 
-  val selectionFooSeparate = selectionFoo.copy(separateEbooks = true)
-  val selectionBarSeparate = selectionBar.copy(separateEbooks = true)
+  val selectionFooSeparate = selectionFoo.withSeparateEbooks
+  val selectionBarSeparate = selectionBar.withSeparateEbooks
 
   private val epubCoverImgKey = LaikaKeys.root.child("epub").child(LaikaKeys.coverImage.local)
 
@@ -98,7 +92,7 @@ class SelectionConfigSpec extends FunSuite {
     val expectedGroup1 = Selections(
       SelectionConfig(
         "foo",
-        ChoiceConfig("foo-a", "foo-label-a", selected = true),
+        ChoiceConfig("foo-a", "foo-label-a").select,
         ChoiceConfig("foo-b", "foo-label-b")
       ).withSeparateEbooks
     )
@@ -106,7 +100,7 @@ class SelectionConfigSpec extends FunSuite {
       SelectionConfig(
         "foo",
         ChoiceConfig("foo-a", "foo-label-a"),
-        ChoiceConfig("foo-b", "foo-label-b", selected = true)
+        ChoiceConfig("foo-b", "foo-label-b").select
       ).withSeparateEbooks
     )
     val expected       = NonEmptyVector.of(expectedGroup1, expectedGroup2)

--- a/docs/src/03-preparing-content/02-navigation.md
+++ b/docs/src/03-preparing-content/02-navigation.md
@@ -602,7 +602,7 @@ Auto-numbering can be switched on per configuration:
 import laika.rewrite.nav.AutonumberConfig
 
 laikaConfig := LaikaConfig.defaults
-  .withConfigValue(AutonumberConfig(maxDepth = 3))
+  .withConfigValue(AutonumberConfig.allEnabled.withMaxDepth(3))
 ```
 
 @:choice(library)
@@ -616,7 +616,7 @@ val transformer = Transformer
   .from(Markdown)
   .to(HTML)
   .using(GitHubFlavor)
-  .withConfigValue(AutonumberConfig(maxDepth = 3))
+  .withConfigValue(AutonumberConfig.allEnabled.withMaxDepth(3))
   .build
 ```
 @:@

--- a/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
@@ -25,11 +25,11 @@ import laika.ast.Path.Root
 import laika.format.{ HTML, Markdown }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
-import laika.io.implicits._
+import laika.io.implicits.*
 import laika.io.model.StringTreeOutput
 import laika.render.HTMLFormatter
 import laika.rewrite.nav.{ ChoiceConfig, CoverImage, SelectionConfig, Selections }
-import laika.theme._
+import laika.theme.*
 import munit.CatsEffectSuite
 
 class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with ResultExtractor
@@ -239,12 +239,12 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
       )
       .site.landingPage()
       .pdf.coverImages(
-        CoverImage(Root / "cover-sbt.png", Some("sbt")),
-        CoverImage(Root / "cover-library.png", Some("library"))
+        CoverImage(Root / "cover-sbt.png", "sbt"),
+        CoverImage(Root / "cover-library.png", "library")
       )
       .epub.coverImages(
-        CoverImage(Root / "cover-sbt.png", Some("sbt")),
-        CoverImage(Root / "cover-library.png", Some("library"))
+        CoverImage(Root / "cover-sbt.png", "sbt"),
+        CoverImage(Root / "cover-library.png", "library")
       )
     val expected                        = """<h1 class="title">Downloads</h1>
                      |<p>EPUB &amp; PDF</p>


### PR DESCRIPTION
Applies the pattern described in #482 (section 2.) to public case classes in the package `laika.rewrite.nav`:

* `ChoiceConfig`
* `SelectionConfig`
* `Selections`
* `AutonumberConfig`
* `CoverImage`
* `PathAttributes`

`apply` methods in the companions are reduced to arguments for all non-optional properties.