### PR TITLE
convert public case classes for theme configuration

### DIFF
--- a/core/shared/src/main/scala/laika/ast/DocumentNavigation.scala
+++ b/core/shared/src/main/scala/laika/ast/DocumentNavigation.scala
@@ -44,7 +44,7 @@ trait DocumentNavigation extends Navigatable {
     * @return a navigation item that can be used as part of a bigger navigation structure comprising of trees, documents and their sections
     */
   def asNavigationItem(
-      context: NavigationBuilderContext = NavigationBuilderContext()
+      context: NavigationBuilderContext = NavigationBuilderContext.defaults
   ): NavigationItem = {
     val children =
       if (context.isComplete || context.excludeSections) Nil
@@ -64,26 +64,48 @@ trait DocumentNavigation extends Navigatable {
 
 /** The context of a navigation builder that can get passed down in recursive calls to the
   * various types that have an asNavigationItem method.
-  *
-  * @param refPath the path of document from which this document will be linked (for creating a corresponding relative path)
-  * @param itemStyles the styles to assign to each navigation item as a render hint
-  * @param maxLevels the number of levels of sub-trees, documents or sections to create navigation info for
-  * @param currentLevel the current level of the navigation tree being built
-  * @param excludeSections indicates whether the recursion should exclude sections of documents even when maxLevels
-  *                        has not been reached yet
   */
-case class NavigationBuilderContext(
-    refPath: Path = Root,
-    itemStyles: Set[String] = Set(),
-    maxLevels: Int = Int.MaxValue,
-    currentLevel: Int = 1,
-    excludeSections: Boolean = false,
-    excludeSelf: Boolean = false
-) {
+sealed abstract class NavigationBuilderContext {
 
-  lazy val nextLevel: NavigationBuilderContext = copy(currentLevel = currentLevel + 1)
+  /** The path of the document for which links will be created
+    * (meaning all generated links will be relative to this path).
+    */
+  def refPath: Path
 
+  /** The styles to assign to each navigation item as a render hint. */
+  def itemStyles: Set[String]
+
+  /** The number of levels of sub-trees, documents or sections to create navigation info for. */
+  def maxLevels: Int
+
+  /** The current level of the navigation tree being built. */
+  def currentLevel: Int
+
+  /** Indicates whether the recursion should exclude sections of documents
+    * even when maxLevels has not been reached yet.
+    */
+  def excludeSections: Boolean
+
+  /** Indicates that links pointing to the current document should be omitted.
+    */
+  def excludeSelf: Boolean
+
+  /** Creates a new instance for the next navigation level.
+    */
+  def nextLevel: NavigationBuilderContext
+
+  /** Indicates whether the final navigation level has been reached.
+    *
+    * True if `currentLevel >= maxLevels`.
+    */
   val isComplete: Boolean = currentLevel >= maxLevels
+
+  def withRefPath(path: Path): NavigationBuilderContext
+  def withItemStyles(styles: String*): NavigationBuilderContext
+  def withMaxLevels(max: Int): NavigationBuilderContext
+  def withExcludeSections(value: Boolean): NavigationBuilderContext
+  def withExcludeSelf(value: Boolean): NavigationBuilderContext
+  private[laika] def withCurrentLevel(value: Int): NavigationBuilderContext
 
   def newNavigationItem(
       title: SpanSequence,
@@ -117,6 +139,43 @@ case class NavigationBuilderContext(
       NavigationLink(InternalTarget(path).relativeTo(refPath), path == refPath, formats)
     }
     NavigationItem(title, children, link, targetFormats, styles)
+  }
+
+}
+
+object NavigationBuilderContext {
+
+  def defaults: NavigationBuilderContext =
+    Impl(Root, Set(), Int.MaxValue, 1, excludeSections = false, excludeSelf = false)
+
+  case class Impl(
+      refPath: Path,
+      itemStyles: Set[String],
+      maxLevels: Int,
+      currentLevel: Int,
+      excludeSections: Boolean,
+      excludeSelf: Boolean
+  ) extends NavigationBuilderContext {
+
+    override def productPrefix: String = "NavigationBuilderContext"
+
+    lazy val nextLevel: NavigationBuilderContext = copy(currentLevel = currentLevel + 1)
+
+    def withRefPath(path: Path): NavigationBuilderContext = copy(refPath = path)
+
+    def withItemStyles(itemStyles: String*): NavigationBuilderContext =
+      copy(itemStyles = itemStyles.toSet)
+
+    def withMaxLevels(max: Int): NavigationBuilderContext = copy(maxLevels = max)
+
+    def withExcludeSections(value: Boolean): NavigationBuilderContext =
+      copy(excludeSections = value)
+
+    def withExcludeSelf(value: Boolean): NavigationBuilderContext = copy(excludeSelf = value)
+
+    private[laika] def withCurrentLevel(value: Int): NavigationBuilderContext =
+      copy(currentLevel = value)
+
   }
 
 }

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -77,7 +77,7 @@ sealed trait TreeContent extends Navigatable {
     * @return a navigation item that can be used as part of a bigger navigation structure comprising of trees, documents and their sections
     */
   def asNavigationItem(
-      context: NavigationBuilderContext = NavigationBuilderContext()
+      context: NavigationBuilderContext = NavigationBuilderContext.defaults
   ): NavigationItem
 
   /** Extracts all runtime messages with the specified minimum level from this tree content.
@@ -164,7 +164,7 @@ case class SectionInfo(
     */
   def asNavigationItem(
       docPath: Path,
-      context: NavigationBuilderContext = NavigationBuilderContext()
+      context: NavigationBuilderContext = NavigationBuilderContext.defaults
   ): NavigationItem = {
     val children =
       if (context.isComplete) Nil else content.map(_.asNavigationItem(docPath, context.nextLevel))
@@ -672,7 +672,7 @@ class DocumentTree private[ast] (
     * @return a navigation item that can be used as part of a bigger navigation structure comprising of trees, documents and their sections
     */
   def asNavigationItem(
-      context: NavigationBuilderContext = NavigationBuilderContext()
+      context: NavigationBuilderContext = NavigationBuilderContext.defaults
   ): NavigationItem = {
     def hasLinks(item: NavigationItem): Boolean =
       item.link.nonEmpty || item.content.exists(hasLinks)

--- a/core/shared/src/main/scala/laika/directive/std/BreadcrumbDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/BreadcrumbDirectives.scala
@@ -47,10 +47,9 @@ private[laika] object BreadcrumbDirectives {
 
     def resolve(cursor: DocumentCursor): Block = {
 
-      val context = NavigationBuilderContext(
-        refPath = cursor.path,
-        itemStyles = Set(Style.breadcrumb.styles.head)
-      )
+      val context = NavigationBuilderContext.defaults
+        .withRefPath(cursor.path)
+        .withItemStyles(Style.breadcrumb.styles.head)
 
       @tailrec
       def entriesFor(tree: TreeCursor, items: List[NavigationItem] = Nil): List[NavigationItem] = {

--- a/core/shared/src/main/scala/laika/directive/std/NavigationTreeDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/NavigationTreeDirectives.scala
@@ -118,14 +118,14 @@ private[laika] object NavigationTreeDirectives {
             s"Unable to resolve document or tree with path: $targetPath".invalidNec
           ) { treeContent =>
             val noRoot  = optExcludeRoot.getOrElse(excludeRoot)
-            val context = NavigationBuilderContext(
-              refPath = cursor.path,
-              itemStyles = itemStyles,
-              maxLevels = depth.getOrElse(defaultDepth),
-              currentLevel = if (noRoot) currentLevel - 1 else currentLevel,
-              excludeSections = optExcludeSections.getOrElse(excludeSections),
-              excludeSelf = excludeSelf
-            )
+            val context = NavigationBuilderContext.defaults
+              .withRefPath(cursor.path)
+              .withItemStyles(itemStyles.toSeq *)
+              .withMaxLevels(depth.getOrElse(defaultDepth))
+              .withExcludeSections(optExcludeSections.getOrElse(excludeSections))
+              .withExcludeSelf(excludeSelf)
+              .withCurrentLevel(if (noRoot) currentLevel - 1 else currentLevel)
+
             val navItem = treeContent.asNavigationItem(context)
             if (noRoot) navItem.content.toList.validNec
             else List(title.fold(navItem)(t => navItem.copy(title = t))).validNec

--- a/core/shared/src/main/scala/laika/rst/ast/elements.scala
+++ b/core/shared/src/main/scala/laika/rst/ast/elements.scala
@@ -16,7 +16,7 @@
 
 package laika.rst.ast
 
-import laika.ast._
+import laika.ast.*
 import laika.parse.SourceFragment
 
 /** A two-column table-like structure used for bibliographic fields or directive options.
@@ -213,11 +213,10 @@ private[rst] case class Contents(
 
   def resolve(cursor: DocumentCursor): Block = {
     val nav = cursor.target.asNavigationItem(
-      NavigationBuilderContext(
-        refPath = cursor.target.path,
-        maxLevels = depth,
-        currentLevel = 0
-      )
+      NavigationBuilderContext.defaults
+        .withRefPath(cursor.target.path)
+        .withMaxLevels(depth)
+        .withCurrentLevel(0)
     ).content
     TitledBlock(List(Text(title)), Seq(NavigationList(nav)), options + Style.nav)
   }

--- a/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
@@ -91,17 +91,16 @@ class ConfigCodecSpec extends FunSuite {
       """.stripMargin
     decode[DocumentMetadata](
       input,
-      DocumentMetadata(
-        Some("Monkey Gone To Heaven"),
-        Some("It's indescribable"),
-        Some("XX-33-FF-01"),
-        Seq("Helen North", "Maria South"),
-        Some("en"),
-        Some(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get),
-        Some(PlatformDateTime.parse("2002-12-12T12:00:00").toOption.get),
-        Some("125"),
-        Some(new URI("http://foo.bar/baz"))
-      )
+      DocumentMetadata.empty
+        .withTitle("Monkey Gone To Heaven")
+        .withDescription("It's indescribable")
+        .withIdentifier("XX-33-FF-01")
+        .addAuthors("Helen North", "Maria South")
+        .withLanguage("en")
+        .withDatePublished(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
+        .withDateModified(PlatformDateTime.parse("2002-12-12T12:00:00").toOption.get)
+        .withVersion("125")
+        .withCanonicalLink(new URI("http://foo.bar/baz"))
     )
   }
 
@@ -117,29 +116,25 @@ class ConfigCodecSpec extends FunSuite {
       """.stripMargin
     decode[DocumentMetadata](
       input,
-      DocumentMetadata(
-        None,
-        None,
-        Some("XX-33-FF-01"),
-        Seq("Dorothea West"),
-        Some("en"),
-        Some(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
-      )
+      DocumentMetadata.empty
+        .withIdentifier("XX-33-FF-01")
+        .addAuthors("Dorothea West")
+        .withLanguage("en")
+        .withDatePublished(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
     )
   }
 
   test("DocumentMetadata - round-trip encode and decode") {
-    val input = DocumentMetadata(
-      Some("Monkey Gone To Heaven"),
-      Some("Rhubarb, Rhubarb, Rhubarb"),
-      Some("XX-33-FF-01"),
-      Seq("Helen North", "Maria South"),
-      Some("en"),
-      Some(PlatformDateTime.parse("2012-10-10T12:00:00").toOption.get),
-      Some(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get),
-      Some("125"),
-      Some(new URI("http://foo.bar/baz"))
-    )
+    val input = DocumentMetadata.empty
+      .withTitle("Monkey Gone To Heaven")
+      .withDescription("Rhubarb, Rhubarb, Rhubarb")
+      .withIdentifier("XX-33-FF-01")
+      .addAuthors("Helen North", "Maria South")
+      .withLanguage("en")
+      .withDatePublished(PlatformDateTime.parse("2012-10-10T12:00:00").toOption.get)
+      .withDateModified(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
+      .withVersion("125")
+      .withCanonicalLink(new URI("http://foo.bar/baz"))
     roundTrip(input)
   }
 

--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -153,7 +153,7 @@ val fontPath = "<file-path-to-your-fonts>"
 val latoURL = "http://fonts.googleapis.com/css?family=Lato:400,700"
 val firaURL = "https://fonts.googleapis.com/css?family=Fira+Mono:500"
 
-Helium.defaults.all.fontResources(
+Helium.defaults.all.addFontResources(
   FontDefinition(
     Font
       .embedResource(fontPath + "Lato/Lato-Regular.ttf")

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -92,7 +92,7 @@ case object EPUB extends TwoPhaseRenderFormat[HTMLFormatter, BinaryPostProcessor
     * @param coverImage the path to the cover image within the virtual document tree
     */
   case class BookConfig(
-      metadata: DocumentMetadata = DocumentMetadata(),
+      metadata: DocumentMetadata = DocumentMetadata.empty,
       navigationDepth: Option[Int] = None,
       fonts: Seq[FontDefinition] = Nil,
       coverImage: Option[Path] = None

--- a/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
+++ b/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
@@ -179,9 +179,8 @@ private[helium] object HeliumDefaults {
       defaultLineHeight = 1.5,
       anchorPlacement = AnchorPlacement.Left
     ),
-    metadata = DocumentMetadata(
-      language = Some(Locale.getDefault.toLanguageTag)
-    )
+    metadata = DocumentMetadata.empty
+      .withLanguage(Locale.getDefault.toLanguageTag)
   )
 
   private val defaultEPUBSettings = EPUBSettings(

--- a/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
+++ b/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 import laika.ast.DocumentMetadata
 import laika.ast.LengthUnit.{ cm, em, mm, pt, px }
 import laika.helium.Helium
-import laika.theme.config._
+import laika.theme.config.*
 
 private[helium] object HeliumDefaults {
 
@@ -184,12 +184,11 @@ private[helium] object HeliumDefaults {
   )
 
   private val defaultEPUBSettings = EPUBSettings(
-    bookConfig = BookConfig(
-      fonts = defaultFonts,
-      navigationDepth = Some(
-        2
-      ) // chosen as default as iBooks messes with the hierarchy of entries when using more than 2 levels
-    ),
+    bookConfig = BookConfig.empty
+      .addFonts(defaultFonts *)
+      .withNavigationDepth(
+        2 // chosen as default as iBooks messes with the hierarchy of entries when using more than 2 levels
+      ),
     themeFonts = defaultThemeFonts,
     fontSizes = FontSizes(
       body = em(1.0),
@@ -212,7 +211,7 @@ private[helium] object HeliumDefaults {
   )
 
   private val defaultPDFSettings = PDFSettings(
-    bookConfig = BookConfig(fonts = defaultFonts),
+    bookConfig = BookConfig.empty.addFonts(defaultFonts *),
     themeFonts = defaultThemeFonts,
     fontSizes = FontSizes(
       body = pt(10),

--- a/io/src/main/scala/laika/helium/config/ThemeLink.scala
+++ b/io/src/main/scala/laika/helium/config/ThemeLink.scala
@@ -321,11 +321,19 @@ object VersionMenu {
 
 }
 
-final case class ThemeNavigationSection(title: String, links: NonEmptyList[TextLink])
+sealed abstract class ThemeNavigationSection {
+  def title: String
+  def links: NonEmptyList[TextLink]
+}
 
 object ThemeNavigationSection {
 
+  private final case class Impl(title: String, links: NonEmptyList[TextLink])
+      extends ThemeNavigationSection {
+    override def productPrefix = "ThemeNavigationSection"
+  }
+
   def apply(title: String, link: TextLink, links: TextLink*): ThemeNavigationSection =
-    ThemeNavigationSection(title, NonEmptyList.of(link, links: _*))
+    Impl(title, NonEmptyList.of(link, links *))
 
 }

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -167,15 +167,25 @@ private[helium] case class GenericLinkGroup(links: Seq[ThemeLink], options: Opti
   *
   * The sizes string will be used in the corresponding `sizes` attribute of the generated `&lt;link&gt;` tag.
   */
-case class Favicon private (
-    target: Target,
-    sizes: Option[String],
-    mediaType: Option[String]
-)
+sealed abstract class Favicon private {
+  def target: Target
+
+  def sizes: Option[String]
+
+  def mediaType: Option[String]
+}
 
 /** Companion for creating Favicon configuration instances.
   */
 object Favicon {
+
+  private final case class Impl(
+      target: Target,
+      sizes: Option[String],
+      mediaType: Option[String]
+  ) extends Favicon {
+    override def productPrefix = "Favicon"
+  }
 
   private def mediaType(suffix: Option[String]): Option[String] = suffix.collect {
     case "ico"          => "image/x-icon"
@@ -190,12 +200,12 @@ object Favicon {
     * The sizes string will be used in the corresponding `sizes` attribute of the generated `&lt;link&gt;` tag.
     */
   def external(url: String, sizes: String, mediaType: String): Favicon =
-    Favicon(ExternalTarget(url), Some(sizes), Some(mediaType))
+    Impl(ExternalTarget(url), Some(sizes), Some(mediaType))
 
   /** Creates the configuration for a single favicon with an external URL.
     */
   def external(url: String, mediaType: String): Favicon =
-    Favicon(ExternalTarget(url), None, Some(mediaType))
+    Impl(ExternalTarget(url), None, Some(mediaType))
 
   /** Creates the configuration for a single favicon based on an internal resource and its virtual path.
     * This resource must be part of the inputs known to Laika.
@@ -203,13 +213,13 @@ object Favicon {
     * The sizes string will be used in the corresponding `sizes` attribute of the generated `&lt;link&gt;` tag.
     */
   def internal(path: Path, sizes: String): Favicon =
-    Favicon(InternalTarget(path), Some(sizes), mediaType(path.suffix))
+    Impl(InternalTarget(path), Some(sizes), mediaType(path.suffix))
 
   /** Creates the configuration for a single favicon based on an internal resource and its virtual path.
     * This resource must be part of the inputs known to Laika.
     */
   def internal(path: Path): Favicon =
-    Favicon(InternalTarget(path), None, mediaType(path.suffix))
+    Impl(InternalTarget(path), None, mediaType(path.suffix))
 
 }
 

--- a/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
@@ -53,12 +53,10 @@ private[helium] object TocPageGenerator {
     val result =
       if (tocConfig.depth < 1) tree
       else {
-        val navContext = NavigationBuilderContext(
-          refPath = Root,
-          itemStyles = Set("toc"),
-          maxLevels = tocConfig.depth,
-          currentLevel = 0
-        )
+        val navContext = NavigationBuilderContext.defaults
+          .withItemStyles("toc")
+          .withMaxLevels(tocConfig.depth)
+          .withCurrentLevel(0)
         val navItem    = tree.root.tree.asNavigationItem(navContext)
         val navContent = navItem.content.filter { item =>
           item.link match {

--- a/io/src/main/scala/laika/io/model/RenderedTree.scala
+++ b/io/src/main/scala/laika/io/model/RenderedTree.scala
@@ -36,7 +36,7 @@ sealed trait RenderContent extends Navigatable {
     * @return a navigation item that can be used as part of a bigger navigation structure comprising of trees, documents and their sections
     */
   def asNavigationItem(
-      context: NavigationBuilderContext = NavigationBuilderContext()
+      context: NavigationBuilderContext = NavigationBuilderContext.defaults
   ): NavigationItem
 
 }
@@ -83,7 +83,7 @@ class RenderedTree(
   }
 
   def asNavigationItem(
-      context: NavigationBuilderContext = NavigationBuilderContext()
+      context: NavigationBuilderContext = NavigationBuilderContext.defaults
   ): NavigationItem = {
     def hasLinks(item: NavigationItem): Boolean =
       item.link.nonEmpty || item.content.exists(hasLinks)

--- a/io/src/main/scala/laika/render/epub/ContainerWriter.scala
+++ b/io/src/main/scala/laika/render/epub/ContainerWriter.scala
@@ -17,13 +17,14 @@
 package laika.render.epub
 
 import cats.effect.{ Async, Sync }
-import cats.implicits._
+import cats.implicits.*
 import laika.ast.Path
 import laika.ast.Path.Root
 import laika.config.ConfigException
 import laika.format.EPUB
-import laika.io.model._
+import laika.io.model.*
 import laika.render.TagFormatter
+import laika.theme.config.BookConfig
 
 /** Creates the EPUB container based on a document tree and the HTML result
   * of a preceding render operation.
@@ -50,7 +51,7 @@ private[laika] class ContainerWriter {
     */
   def collectInputs[F[_]](
       result: RenderedTreeRoot[F],
-      config: EPUB.BookConfig
+      config: BookConfig
   ): Seq[BinaryInput[F]] = {
 
     val contentRoot = Root / "EPUB" / "content"
@@ -118,7 +119,7 @@ private[laika] class ContainerWriter {
 
     for {
       config <- Sync[F].fromEither(
-        EPUB.BookConfig.decodeWithDefaults(result.config).left.map(ConfigException.apply)
+        BookConfig.decodeWithDefaults(result.config, EPUB.configKey).left.map(ConfigException.apply)
       )
       inputs = collectInputs(result, config)
       _ <- ZipWriter.zipEPUB(inputs, output)

--- a/io/src/main/scala/laika/render/epub/NavigationBuilder.scala
+++ b/io/src/main/scala/laika/render/epub/NavigationBuilder.scala
@@ -49,7 +49,9 @@ private[epub] object NavigationBuilder {
     )
 
     tree.asNavigationItem(
-      NavigationBuilderContext(maxLevels = depth.getOrElse(Int.MaxValue), currentLevel = 0)
+      NavigationBuilderContext.defaults.withMaxLevels(
+        depth.getOrElse(Int.MaxValue)
+      ).withCurrentLevel(0)
     )
       .content.map(adjustPath)
   }

--- a/io/src/main/scala/laika/render/epub/OPFRenderer.scala
+++ b/io/src/main/scala/laika/render/epub/OPFRenderer.scala
@@ -16,11 +16,11 @@
 
 package laika.render.epub
 
-import laika.ast._
-import laika.format.EPUB
+import laika.ast.*
 import laika.format.EPUB.ScriptedTemplate
 import laika.io.model.{ RenderedDocument, RenderedTreeRoot }
 import laika.rewrite.link.SlugBuilder
+import laika.theme.config.BookConfig
 
 /** Renders the content of an EPUB Package document (OPF).
   *
@@ -110,7 +110,7 @@ private[epub] class OPFRenderer {
 
   /** Renders the content of an EPUB Package document (OPF) generated from the specified document tree.
     */
-  def render[F[_]](result: RenderedTreeRoot[F], title: String, config: EPUB.BookConfig): String = {
+  def render[F[_]](result: RenderedTreeRoot[F], title: String, config: BookConfig): String = {
 
     lazy val hasScriptDocuments: Boolean =
       result.staticDocuments.exists(_.path.suffix.exists(s => s == "epub.js" || s == "shared.js"))

--- a/io/src/main/scala/laika/theme/config/BookConfig.scala
+++ b/io/src/main/scala/laika/theme/config/BookConfig.scala
@@ -17,23 +17,94 @@
 package laika.theme.config
 
 import laika.ast.{ DocumentMetadata, Path }
-import laika.config.{ ConfigDecoder, ConfigEncoder, DefaultKey, LaikaKeys }
+import laika.config.Config.ConfigResult
+import laika.config.{ Config, ConfigDecoder, ConfigEncoder, Key, LaikaKeys }
+
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.{ Locale, UUID }
 
 /** Captures common configuration element of e-books, used by both EPUB and PDF renderers.
-  *
-  * @param metadata        metadata to be embedded in the document in a way that respective reader software can surface
-  * @param navigationDepth the number of levels to provide navigation structure for
-  * @param fonts           the fonts that should be embedded in the e-book output
-  * @param coverImage      the path to the cover image within the virtual document tree
   */
-case class BookConfig(
-    metadata: DocumentMetadata = DocumentMetadata.empty,
-    navigationDepth: Option[Int] = None,
-    fonts: Seq[FontDefinition] = Nil,
-    coverImage: Option[Path] = None
-)
+sealed abstract class BookConfig {
+
+  /** Metadata to be embedded in the document in a way that respective reader software can surface. */
+  def metadata: DocumentMetadata
+
+  /** The number of levels to provide navigation structure for. */
+  def navigationDepth: Option[Int]
+
+  /** The fonts that should be embedded in the e-book output. */
+  def fonts: Seq[FontDefinition]
+
+  /** The path to the cover image within the virtual document tree. */
+  def coverImage: Option[Path]
+
+  /** The identifier to be used for metadata in the book output,
+    * either taken from the provided metadata or, if that is empty, generated randomly.
+    */
+  def identifier: String
+
+  /** The language to be used for metadata in the book output,
+    * either taken from the provided metadata or, if that is empty, taken from the default locale
+    * of the running program.
+    */
+  def language: String
+
+  /** The publication date of the book,
+    * either taken from the provided metadata or, if that is empty, using the current time.
+    */
+  def date: OffsetDateTime
+
+  /** The publication date formatted as an ISO instant. */
+  def formattedDate: String
+
+  def withMetadata(value: DocumentMetadata): BookConfig
+  def withNavigationDepth(value: Int): BookConfig
+  def addFonts(values: FontDefinition*): BookConfig
+  def removeFonts(filter: FontDefinition => Boolean): BookConfig
+  def clearFonts: BookConfig
+  def withCoverImage(value: Path): BookConfig
+}
 
 object BookConfig {
+
+  val empty: BookConfig = Impl()
+
+  private final case class Impl(
+      metadata: DocumentMetadata = DocumentMetadata.empty,
+      navigationDepth: Option[Int] = None,
+      fonts: Seq[FontDefinition] = Nil,
+      coverImage: Option[Path] = None
+  ) extends BookConfig {
+
+    override def productPrefix: String = "BookConfig"
+
+    def withMetadata(value: DocumentMetadata): BookConfig = copy(metadata = value)
+
+    def withNavigationDepth(value: Int): BookConfig = copy(navigationDepth = Some(value))
+
+    def addFonts(values: FontDefinition*): BookConfig = copy(fonts = fonts ++ values)
+
+    def removeFonts(filter: FontDefinition => Boolean): BookConfig =
+      copy(fonts = fonts.filterNot(filter))
+
+    def clearFonts: BookConfig = copy(fonts = Nil)
+
+    def withCoverImage(value: Path): BookConfig = copy(coverImage = Some(value))
+
+    lazy val identifier: String =
+      metadata.identifier.getOrElse(s"urn:uuid:${UUID.randomUUID.toString}")
+
+    lazy val date: OffsetDateTime =
+      metadata.dateModified.orElse(metadata.datePublished).getOrElse(OffsetDateTime.now())
+
+    lazy val formattedDate: String =
+      DateTimeFormatter.ISO_INSTANT.format(date.toInstant.truncatedTo(ChronoUnit.SECONDS))
+
+    lazy val language: String = metadata.language.getOrElse(Locale.getDefault.toLanguageTag)
+  }
 
   implicit val decoder: ConfigDecoder[BookConfig] = ConfigDecoder.config.flatMap { config =>
     for {
@@ -42,7 +113,7 @@ object BookConfig {
       depth      <- config.getOpt[Int]("navigationDepth")
       coverImage <- config.getOpt[Path]("coverImage")
     } yield {
-      BookConfig(metadata, depth, fonts, coverImage)
+      Impl(metadata, depth, fonts, coverImage)
     }
   }
 
@@ -55,6 +126,23 @@ object BookConfig {
       .build
   }
 
-  implicit val defaultKey: DefaultKey[BookConfig] = DefaultKey(LaikaKeys.root)
+  /** Reads a `BookConfig` instance from the given instance using the specified key,
+    * while reading fallback values defined directly under the `laika` key.
+    *
+    * Empty optional values will be populated from the fallback instance,
+    * while properties of type `Seq` will accumulate values from the fallback and the value
+    * stored under the given key.
+    */
+  def decodeWithDefaults(config: Config, key: Key): ConfigResult[BookConfig] = for {
+    bookConfig <- config.getOpt[BookConfig](key).map(_.getOrElse(BookConfig.empty))
+    baseConfig <- config.getOpt[BookConfig](LaikaKeys.root).map(_.getOrElse(BookConfig.empty))
+  } yield {
+    Impl(
+      bookConfig.metadata.withDefaults(baseConfig.metadata),
+      bookConfig.navigationDepth.orElse(baseConfig.navigationDepth),
+      bookConfig.fonts ++ baseConfig.fonts,
+      bookConfig.coverImage.orElse(baseConfig.coverImage)
+    )
+  }
 
 }

--- a/io/src/main/scala/laika/theme/config/BookConfig.scala
+++ b/io/src/main/scala/laika/theme/config/BookConfig.scala
@@ -27,7 +27,7 @@ import laika.config.{ ConfigDecoder, ConfigEncoder, DefaultKey, LaikaKeys }
   * @param coverImage      the path to the cover image within the virtual document tree
   */
 case class BookConfig(
-    metadata: DocumentMetadata = DocumentMetadata(),
+    metadata: DocumentMetadata = DocumentMetadata.empty,
     navigationDepth: Option[Int] = None,
     fonts: Seq[FontDefinition] = Nil,
     coverImage: Option[Path] = None
@@ -37,7 +37,7 @@ object BookConfig {
 
   implicit val decoder: ConfigDecoder[BookConfig] = ConfigDecoder.config.flatMap { config =>
     for {
-      metadata   <- config.get[DocumentMetadata](LaikaKeys.metadata.local, DocumentMetadata())
+      metadata   <- config.get[DocumentMetadata](LaikaKeys.metadata.local, DocumentMetadata.empty)
       fonts      <- config.get[Seq[FontDefinition]]("fonts", Nil)
       depth      <- config.getOpt[Int]("navigationDepth")
       coverImage <- config.getOpt[Path]("coverImage")

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -327,7 +327,7 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
   }
 
   test("custom web fonts") {
-    val helium   = heliumBase.site.fontResources(
+    val helium   = heliumBase.site.addFontResources(
       FontDefinition(
         Font.webCSS("http://fonts.com/font-1.css"),
         "Font-1",

--- a/io/src/test/scala/laika/render/epub/BookConfigSpec.scala
+++ b/io/src/test/scala/laika/render/epub/BookConfigSpec.scala
@@ -72,14 +72,13 @@ class BookConfigSpec extends FunSuite {
       """.stripMargin
     val actual   = ConfigParser.parse(input).resolve().flatMap(BookConfig.decodeWithDefaults)
     val expected = BookConfig(
-      DocumentMetadata(
-        Some("Hell is around the corner"),
-        Some("Undescribable"),
-        Some("XX-33-FF-02"),
-        Seq("Maria South", "Helen North"),
-        Some("en"),
-        Some(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
-      ),
+      DocumentMetadata.empty
+        .withTitle("Hell is around the corner")
+        .withDescription("Undescribable")
+        .withIdentifier("XX-33-FF-02")
+        .addAuthors("Maria South", "Helen North")
+        .withLanguage("en")
+        .withDatePublished(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get),
       Some(4),
       TestTheme.fonts,
       Some(Root / "cover.jpg")
@@ -88,23 +87,15 @@ class BookConfigSpec extends FunSuite {
   }
 
   test("round-trip encode and decode") {
-    val input    = BookConfig(
-      DocumentMetadata(Some("XX-33-FF-01")),
+    val input   = BookConfig(
+      DocumentMetadata.empty.withIdentifier("XX-33-FF-01"),
       Some(3),
       TestTheme.fonts,
       Some(Root / "cover.jpg")
     )
-    val encoded  = ConfigBuilder.empty.withValue(testKey, input).build
-    val actual   = decode[BookConfig](encoded)
-    val expected = BookConfig(
-      DocumentMetadata(
-        Some("XX-33-FF-01")
-      ),
-      Some(3),
-      TestTheme.fonts,
-      Some(Root / "cover.jpg")
-    )
-    assertEquals(actual, Right(expected))
+    val encoded = ConfigBuilder.empty.withValue(testKey, input).build
+    val actual  = decode[BookConfig](encoded)
+    assertEquals(actual, Right(input))
   }
 
 }

--- a/io/src/test/scala/laika/render/epub/BookConfigSpec.scala
+++ b/io/src/test/scala/laika/render/epub/BookConfigSpec.scala
@@ -20,8 +20,9 @@ import laika.ast.DocumentMetadata
 import laika.ast.Path.Root
 import laika.config.Config.ConfigResult
 import laika.config.{ Config, ConfigBuilder, ConfigDecoder, ConfigParser, Key }
-import laika.format.EPUB.BookConfig
+import laika.format.EPUB
 import laika.render.fo.TestTheme
+import laika.theme.config.BookConfig
 import laika.time.PlatformDateTime
 import munit.FunSuite
 
@@ -37,7 +38,10 @@ class BookConfigSpec extends FunSuite {
   def decode[T: ConfigDecoder](config: Config): ConfigResult[T] = config.get[T](testKey)
 
   test("decode defaults with an empty config") {
-    assertEquals(BookConfig.decodeWithDefaults(Config.empty), Right(BookConfig()))
+    assertEquals(
+      BookConfig.decodeWithDefaults(Config.empty, EPUB.configKey),
+      Right(BookConfig.empty)
+    )
   }
 
   test("decode an instance with fallbacks") {
@@ -70,29 +74,30 @@ class BookConfigSpec extends FunSuite {
         |  }
         |}}
       """.stripMargin
-    val actual   = ConfigParser.parse(input).resolve().flatMap(BookConfig.decodeWithDefaults)
-    val expected = BookConfig(
-      DocumentMetadata.empty
-        .withTitle("Hell is around the corner")
-        .withDescription("Undescribable")
-        .withIdentifier("XX-33-FF-02")
-        .addAuthors("Maria South", "Helen North")
-        .withLanguage("en")
-        .withDatePublished(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get),
-      Some(4),
-      TestTheme.fonts,
-      Some(Root / "cover.jpg")
-    )
+    val actual   =
+      ConfigParser.parse(input).resolve().flatMap(BookConfig.decodeWithDefaults(_, EPUB.configKey))
+    val expected = BookConfig.empty
+      .withMetadata(
+        DocumentMetadata.empty
+          .withTitle("Hell is around the corner")
+          .withDescription("Undescribable")
+          .withIdentifier("XX-33-FF-02")
+          .addAuthors("Maria South", "Helen North")
+          .withLanguage("en")
+          .withDatePublished(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
+      )
+      .withNavigationDepth(4)
+      .addFonts(TestTheme.fonts *)
+      .withCoverImage(Root / "cover.jpg")
     assertEquals(actual, Right(expected))
   }
 
   test("round-trip encode and decode") {
-    val input   = BookConfig(
-      DocumentMetadata.empty.withIdentifier("XX-33-FF-01"),
-      Some(3),
-      TestTheme.fonts,
-      Some(Root / "cover.jpg")
-    )
+    val input   = BookConfig.empty
+      .withMetadata(DocumentMetadata.empty.withIdentifier("XX-33-FF-01"))
+      .withNavigationDepth(3)
+      .addFonts(TestTheme.fonts *)
+      .withCoverImage(Root / "cover.jpg")
     val encoded = ConfigBuilder.empty.withValue(testKey, input).build
     val actual  = decode[BookConfig](encoded)
     assertEquals(actual, Right(input))

--- a/io/src/test/scala/laika/render/epub/ContainerWriterSpec.scala
+++ b/io/src/test/scala/laika/render/epub/ContainerWriterSpec.scala
@@ -17,8 +17,8 @@
 package laika.render.epub
 
 import cats.effect.IO
-import laika.format.EPUB
 import laika.io.model.RenderedTreeRoot
+import laika.theme.config.BookConfig
 import munit.FunSuite
 
 class ContainerWriterSpec extends FunSuite {
@@ -36,7 +36,7 @@ class ContainerWriterSpec extends FunSuite {
 
   def collectInputs(renderResult: RenderedTreeRoot[IO]): Seq[String] =
     writer
-      .collectInputs(renderResult, EPUB.BookConfig())
+      .collectInputs(renderResult, BookConfig.empty)
       .map(_.path.toString)
 
   test("collect a single target document") {

--- a/io/src/test/scala/laika/theme/ThemeConfigCodecSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeConfigCodecSpec.scala
@@ -58,14 +58,13 @@ class ThemeConfigCodecSpec extends FunSuite {
         |}}
       """.stripMargin
     val expected = BookConfig(
-      DocumentMetadata(
-        Some("Hell is around the corner"),
-        Some("Undescribable"),
-        Some("XX-33-FF-01"),
-        Seq("Helen North", "Maria South"),
-        Some("en"),
-        Some(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
-      ),
+      DocumentMetadata.empty
+        .withTitle("Hell is around the corner")
+        .withDescription("Undescribable")
+        .withIdentifier("XX-33-FF-01")
+        .addAuthors("Helen North", "Maria South")
+        .withLanguage("en")
+        .withDatePublished(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get),
       Some(3),
       TestTheme.fonts,
       Some(Root / "cover.jpg")
@@ -84,9 +83,8 @@ class ThemeConfigCodecSpec extends FunSuite {
         |}}
       """.stripMargin
     val expected = BookConfig(
-      DocumentMetadata(
-        identifier = Some("XX-33-FF-01")
-      ),
+      DocumentMetadata.empty
+        .withIdentifier("XX-33-FF-01"),
       Some(3)
     )
     assertEquals(decode[BookConfig](input), Right(expected))
@@ -94,16 +92,16 @@ class ThemeConfigCodecSpec extends FunSuite {
 
   test("round-trip encode and decode") {
     val input    = BookConfig(
-      DocumentMetadata(Some("XX-33-FF-01")),
+      DocumentMetadata.empty
+        .withIdentifier("XX-33-FF-01"),
       Some(3),
       TestTheme.fonts,
       Some(Root / "cover.jpg")
     )
     val encoded  = ConfigBuilder.empty.withValue(testKey, input).build
     val expected = BookConfig(
-      DocumentMetadata(
-        Some("XX-33-FF-01")
-      ),
+      DocumentMetadata.empty
+        .withIdentifier("XX-33-FF-01"),
       Some(3),
       TestTheme.fonts,
       Some(Root / "cover.jpg")

--- a/pdf/src/main/scala/laika/format/PDF.scala
+++ b/pdf/src/main/scala/laika/format/PDF.scala
@@ -16,16 +16,12 @@
 
 package laika.format
 
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
-import java.util.{ Locale, UUID }
 import cats.effect.std.Dispatcher
 import cats.effect.{ Async, Resource }
-import cats.implicits._
+import cats.syntax.all.*
 import laika.api.builder.OperationConfig
-import laika.ast.{ DocumentMetadata, DocumentTreeRoot, Path, TemplateRoot }
-import laika.config.Config.ConfigResult
-import laika.config.{ Config, ConfigDecoder, ConfigEncoder, DefaultKey, Key }
+import laika.ast.{ DocumentTreeRoot, TemplateRoot }
+import laika.config.{ Config, Key }
 import laika.factory.{
   BinaryPostProcessor,
   BinaryPostProcessorBuilder,
@@ -37,9 +33,7 @@ import laika.theme.Theme
 import laika.render.FOFormatter
 import laika.render.FOFormatter.Preamble
 import laika.render.pdf.{ FOConcatenation, FopFactoryBuilder, PDFRenderer }
-import laika.theme.config.{ FontDefinition, BookConfig => CommonBookConfig }
-
-import java.time.OffsetDateTime
+import laika.theme.config.BookConfig
 
 /** A post processor for PDF output, based on an interim XSL-FO renderer.
   *  May be directly passed to the `Render` or `Transform` APIs:
@@ -69,6 +63,9 @@ object PDF extends TwoPhaseRenderFormat[FOFormatter, BinaryPostProcessorBuilder]
 
   val interimFormat: RenderFormat[FOFormatter] = XSLFO
 
+  /** The key to read `BookConfig` instance from for this PDF renderer. */
+  val configKey: Key = Key("laika", "pdf")
+
   /** Adds a preamble to each document for navigation and replaces the template with a fallback.
     * The modified tree will be used for rendering the interim XSL-FO result.
     * The original template will only be applied to the concatenated result of the XSL-FO renderer
@@ -90,7 +87,7 @@ object PDF extends TwoPhaseRenderFormat[FOFormatter, BinaryPostProcessorBuilder]
 
     def build[F[_]: Async](config: Config, theme: Theme[F]): Resource[F, BinaryPostProcessor[F]] =
       Dispatcher.parallel[F].evalMap { dispatcher =>
-        val pdfConfig = PDF.BookConfig.decodeWithDefaults(config).getOrElse(PDF.BookConfig())
+        val pdfConfig = BookConfig.decodeWithDefaults(config, configKey).getOrElse(BookConfig.empty)
         FopFactoryBuilder.build(pdfConfig, theme.inputs.binaryInputs, dispatcher).map {
           fopFactory =>
             new BinaryPostProcessor[F] {
@@ -107,66 +104,6 @@ object PDF extends TwoPhaseRenderFormat[FOFormatter, BinaryPostProcessorBuilder]
             }
         }
       }
-
-  }
-
-  /** Configuration options for the generated EPUB output.
-    *
-    * The duplication of the existing `BookConfig` instance from laika-core happens to have a different
-    * implicit key association with the EPUB-specific instance.
-    *
-    * @param metadata the metadata associated with the document
-    * @param navigationDepth the number of levels to generate a table of contents for
-    * @param fonts the fonts that should be embedded in the PDF output
-    * @param coverImage the path to the cover image within the virtual document tree
-    */
-  case class BookConfig(
-      metadata: DocumentMetadata = DocumentMetadata.empty,
-      navigationDepth: Option[Int] = None,
-      fonts: Seq[FontDefinition] = Nil,
-      coverImage: Option[Path] = None
-  ) {
-
-    lazy val identifier: String =
-      metadata.identifier.getOrElse(s"urn:uuid:${UUID.randomUUID.toString}")
-
-    lazy val date: OffsetDateTime =
-      metadata.dateModified.orElse(metadata.datePublished).getOrElse(OffsetDateTime.now())
-
-    lazy val formattedDate: String =
-      DateTimeFormatter.ISO_INSTANT.format(date.toInstant.truncatedTo(ChronoUnit.SECONDS))
-
-    lazy val language: String = metadata.language.getOrElse(Locale.getDefault.toLanguageTag)
-  }
-
-  object BookConfig {
-
-    implicit val decoder: ConfigDecoder[BookConfig] = CommonBookConfig.decoder.map(c =>
-      BookConfig(
-        c.metadata,
-        c.navigationDepth,
-        c.fonts,
-        c.coverImage
-      )
-    )
-
-    implicit val encoder: ConfigEncoder[BookConfig] = CommonBookConfig.encoder.contramap(c =>
-      CommonBookConfig(c.metadata, c.navigationDepth, c.fonts, c.coverImage)
-    )
-
-    implicit val defaultKey: DefaultKey[BookConfig] = DefaultKey(Key("laika", "pdf"))
-
-    def decodeWithDefaults(config: Config): ConfigResult[BookConfig] = for {
-      pdfConfig    <- config.getOpt[BookConfig].map(_.getOrElse(BookConfig()))
-      commonConfig <- config.getOpt[CommonBookConfig].map(_.getOrElse(CommonBookConfig()))
-    } yield {
-      BookConfig(
-        pdfConfig.metadata.withDefaults(commonConfig.metadata),
-        pdfConfig.navigationDepth.orElse(commonConfig.navigationDepth),
-        pdfConfig.fonts ++ commonConfig.fonts,
-        pdfConfig.coverImage.orElse(commonConfig.coverImage)
-      )
-    }
 
   }
 

--- a/pdf/src/main/scala/laika/format/PDF.scala
+++ b/pdf/src/main/scala/laika/format/PDF.scala
@@ -121,7 +121,7 @@ object PDF extends TwoPhaseRenderFormat[FOFormatter, BinaryPostProcessorBuilder]
     * @param coverImage the path to the cover image within the virtual document tree
     */
   case class BookConfig(
-      metadata: DocumentMetadata = DocumentMetadata(),
+      metadata: DocumentMetadata = DocumentMetadata.empty,
       navigationDepth: Option[Int] = None,
       fonts: Seq[FontDefinition] = Nil,
       coverImage: Option[Path] = None

--- a/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
@@ -16,16 +16,17 @@
 
 package laika.render.pdf
 
-import cats.implicits._
+import cats.syntax.all.*
 import laika.api.Renderer
 import laika.api.builder.OperationConfig
-import laika.ast._
+import laika.ast.*
 import laika.config.{ Config, ConfigException }
 import laika.format.{ PDF, XSLFO }
 import laika.io.model.RenderedTreeRoot
 import laika.parse.markup.DocumentParser.InvalidDocument
 import laika.render.FOFormatter.ContentWrapper
 import laika.rewrite.{ DefaultTemplatePath, OutputContext }
+import laika.theme.config.BookConfig
 
 /** Concatenates the XSL-FO that serves as a basis for producing the final PDF output
   * and applies the default XSL-FO template to the entire result.
@@ -44,7 +45,7 @@ private[laika] object FOConcatenation {
     */
   def apply[F[_]](
       result: RenderedTreeRoot[F],
-      config: PDF.BookConfig,
+      config: BookConfig,
       opConfig: OperationConfig
   ): Either[Throwable, String] = {
 

--- a/pdf/src/main/scala/laika/render/pdf/FopFactoryBuilder.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FopFactoryBuilder.scala
@@ -17,11 +17,10 @@
 package laika.render.pdf
 
 import java.io.{ ByteArrayInputStream, File }
-
 import cats.effect.Async
 import cats.effect.std.Dispatcher
-import laika.format.PDF
 import laika.io.model.BinaryInput
+import laika.theme.config.BookConfig
 import org.apache.fop.apps.{ FopConfParser, FopFactory }
 
 /** Creates a FopFactory instance based on user configuration, registering all fonts to be embedded into the PDF.
@@ -30,7 +29,7 @@ import org.apache.fop.apps.{ FopConfParser, FopFactory }
   */
 private[laika] object FopFactoryBuilder {
 
-  def generateXMLConfig(config: PDF.BookConfig): String = {
+  def generateXMLConfig(config: BookConfig): String = {
     // since there is no API to define fonts for Apache FOP we have to generate configuration XML here
     val fontDefs = config.fonts.flatMap { font =>
       font.resource.embedResource.map { res =>
@@ -54,7 +53,7 @@ private[laika] object FopFactoryBuilder {
   }
 
   def build[F[_]: Async](
-      config: PDF.BookConfig,
+      config: BookConfig,
       staticDocs: Seq[BinaryInput[F]],
       dispatcher: Dispatcher[F]
   ): F[FopFactory] = {

--- a/pdf/src/main/scala/laika/render/pdf/PDFNavigation.scala
+++ b/pdf/src/main/scala/laika/render/pdf/PDFNavigation.scala
@@ -40,11 +40,10 @@ private[pdf] object PDFNavigation {
       depth: Option[Int]
   ): Map[String, Element] = if (depth.contains(0)) Map()
   else {
-    val context = NavigationBuilderContext(
-      maxLevels = depth.getOrElse(Int.MaxValue),
-      currentLevel = 0,
-      itemStyles = Set("bookmark")
-    )
+    val context = NavigationBuilderContext.defaults
+      .withMaxLevels(depth.getOrElse(Int.MaxValue))
+      .withCurrentLevel(0)
+      .withItemStyles("bookmark")
     val toc     = result.tree.asNavigationItem(context).content
     Map("bookmarks" -> NavigationList(toc, Style.bookmark))
   }

--- a/pdf/src/test/scala/laika/render/BookConfigSpec.scala
+++ b/pdf/src/test/scala/laika/render/BookConfigSpec.scala
@@ -71,14 +71,13 @@ class BookConfigSpec extends FunSuite {
     val actual   = ConfigParser.parse(input).resolve().flatMap(BookConfig.decodeWithDefaults)
     val expected = Right(
       BookConfig(
-        DocumentMetadata(
-          Some("Hell is around the corner"),
-          Some("Undescribable"),
-          Some("XX-33-FF-02"),
-          Seq("Maria South", "Helen North"),
-          Some("en"),
-          Some(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
-        ),
+        DocumentMetadata.empty
+          .withTitle("Hell is around the corner")
+          .withDescription("Undescribable")
+          .withIdentifier("XX-33-FF-02")
+          .addAuthors("Maria South", "Helen North")
+          .withLanguage("en")
+          .withDatePublished(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get),
         Some(4),
         TestTheme.fonts,
         Some(Root / "cover.jpg")
@@ -89,7 +88,7 @@ class BookConfigSpec extends FunSuite {
 
   test("round-trip encode and decode") {
     val input    = BookConfig(
-      DocumentMetadata(Some("XX-33-FF-01")),
+      DocumentMetadata.empty.withIdentifier("XX-33-FF-01"),
       Some(3),
       TestTheme.fonts,
       Some(Root / "cover.jpg")
@@ -97,9 +96,7 @@ class BookConfigSpec extends FunSuite {
     val encoded  = ConfigBuilder.empty.withValue(testKey, input).build
     val expected = Right(
       BookConfig(
-        DocumentMetadata(
-          Some("XX-33-FF-01")
-        ),
+        DocumentMetadata.empty.withIdentifier("XX-33-FF-01"),
         Some(3),
         TestTheme.fonts,
         Some(Root / "cover.jpg")

--- a/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
+++ b/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
@@ -19,16 +19,17 @@ package laika.render
 import cats.effect.IO
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.TestSourceBuilders
 import laika.config.Config
-import laika.format.{ PDF, XSLFO }
+import laika.format.XSLFO
 import laika.io.model.{ RenderedDocument, RenderedTree, RenderedTreeRoot }
 import laika.parse.markup.DocumentParser.InvalidDocument
 import laika.render.fo.TestTheme
 import laika.render.pdf.FOConcatenation
 import laika.rewrite.OutputContext
 import laika.rewrite.nav.NoOpPathTranslator
+import laika.theme.config.BookConfig
 import munit.FunSuite
 
 /** @author Jens Halm
@@ -51,7 +52,7 @@ class FOConcatenationSpec extends FunSuite with TestSourceBuilders {
   )
 
   test("fail when there are invalid elements in the template result") {
-    val actual   = FOConcatenation(result, PDF.BookConfig(), OperationConfig.default)
+    val actual   = FOConcatenation(result, BookConfig.empty, OperationConfig.default)
     val expected = Left(InvalidDocument(Root / "merged.fo", invalidElement))
     assertEquals(actual, expected)
   }
@@ -64,7 +65,7 @@ class FOConcatenationSpec extends FunSuite with TestSourceBuilders {
       )
     val expected =
       """<fo:inline background-color="#ffe9e3" border="1pt solid #d83030" color="#d83030" padding="1pt 2pt">WRONG</fo:inline> <fo:inline font-family="monospaced" font-size="0.9em">faulty input</fo:inline>"""
-    assertEquals(FOConcatenation(result, PDF.BookConfig(), config), Right(expected))
+    assertEquals(FOConcatenation(result, BookConfig.empty, config), Right(expected))
   }
 
 }

--- a/pdf/src/test/scala/laika/render/FopFactoryConfigSpec.scala
+++ b/pdf/src/test/scala/laika/render/FopFactoryConfigSpec.scala
@@ -20,7 +20,7 @@ import laika.format.PDF
 import laika.helium.Helium
 import laika.helium.generate.ConfigGenerator
 import laika.render.pdf.FopFactoryBuilder
-import laika.theme.config.{ Font, FontDefinition, FontStyle, FontWeight }
+import laika.theme.config.{ BookConfig, Font, FontDefinition, FontStyle, FontWeight }
 import munit.FunSuite
 
 /** @author Jens Halm
@@ -29,7 +29,7 @@ class FopFactoryConfigSpec extends FunSuite {
 
   def renderXML(helium: Helium): String = {
     val config    = ConfigGenerator.populateConfig(helium)
-    val pdfConfig = PDF.BookConfig.decodeWithDefaults(config).getOrElse(PDF.BookConfig())
+    val pdfConfig = BookConfig.decodeWithDefaults(config, PDF.configKey).getOrElse(BookConfig.empty)
     FopFactoryBuilder.generateXMLConfig(pdfConfig)
   }
 
@@ -80,8 +80,8 @@ class FopFactoryConfigSpec extends FunSuite {
       |  </renderers>
       |</fop>""".stripMargin
 
-  test("custom fonts via 'pdf' selector") {
-    val helium = Helium.defaults.pdf.fontResources(
+  test("custom fonts via 'pdf' selector - removing default theme fonts") {
+    val helium = Helium.defaults.pdf.clearFontResources.pdf.addFontResources(
       FontDefinition(
         Font.embedFile("/projects/fonts/font-1.tff"),
         "Font-1",
@@ -98,8 +98,8 @@ class FopFactoryConfigSpec extends FunSuite {
     assertEquals(renderXML(helium), customXML)
   }
 
-  test("custom fonts via 'all' selector") {
-    val helium = Helium.defaults.all.fontResources(
+  test("custom fonts via 'all' selector - removing default theme fonts") {
+    val helium = Helium.defaults.all.clearFontResources.all.addFontResources(
       FontDefinition(
         Font.embedFile("/projects/fonts/font-1.tff"),
         "Font-1",

--- a/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
@@ -38,6 +38,7 @@ import laika.render.FOFormatter.Preamble
 import laika.render.fo.TestTheme
 import laika.render.pdf.FOConcatenation
 import laika.theme.Theme
+import laika.theme.config.BookConfig
 import munit.CatsEffectSuite
 
 class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
@@ -66,7 +67,7 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
               opConfig: OperationConfig
           ): F[Unit] = {
 
-            val pdfConfig = PDF.BookConfig.decodeWithDefaults(result.config)
+            val pdfConfig = BookConfig.decodeWithDefaults(result.config, PDF.configKey)
             output.resource.use { out =>
               for {
                 config <- Async[F].fromEither(pdfConfig.left.map(ConfigException.apply))

--- a/pdf/src/test/scala/laika/render/PDFTreeModel.scala
+++ b/pdf/src/test/scala/laika/render/PDFTreeModel.scala
@@ -16,7 +16,7 @@
 
 package laika.render
 
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.{ BuilderKey, SampleConfig, SampleSixDocuments, SampleTrees }
 import laika.format.PDF
 
@@ -41,7 +41,7 @@ trait PDFTreeModel {
       _.tree1.titleDoc.content(titleDocContent(2))
         .tree2.titleDoc.content(titleDocContent(3))
 
-  private val navConfigKey = PDF.BookConfig.defaultKey.value.child("navigationDepth")
+  private val navConfigKey = PDF.configKey.child("navigationDepth")
 
   def createTree(navigationDepth: Int = 23, useTitleDocuments: Boolean = false): DocumentTree =
     SampleTrees.sixDocuments

--- a/sbt/src/sbt-test/site/theme/build.sbt
+++ b/sbt/src/sbt-test/site/theme/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.12.6"
 
 enablePlugins(LaikaPlugin)
 
-laikaTheme := Helium.defaults.site.fontResources(
+laikaTheme := Helium.defaults.site.addFontResources(
   FontDefinition(
     Font.webCSS("http://home.com/myFont.css"),
     "MyFont",


### PR DESCRIPTION
Applies the pattern described in #482 (section 2.) to the following public case classes:

* `DocumentMetadata`, `NavigationBuilderContext` in `laika.ast`
* `BookConfig` in `laika.theme.config` (removes `PDF.BookConfig` and `EPUB.BookConfig`)
* `Font`, `FontDefinition` in `laika.theme.config`
* `Favicon`, `ThemeNavigationSection` in `laika.helium.config`

Packaging may change for some of these types in the final milestone.