### PR TITLE
convert case classes for plugin configuration

### DIFF
--- a/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
+++ b/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
@@ -308,7 +308,7 @@ trait RenderConfig {
   * @param strict indicates that text markup should be interpreted as defined by its specification, without any extensions
   * @param acceptRawContent indicates that the users accepts the inclusion of raw content in text markup
   */
-case class BundleFilter(strict: Boolean = false, acceptRawContent: Boolean = false) {
+private[laika] case class BundleFilter(strict: Boolean = false, acceptRawContent: Boolean = false) {
 
   def apply(bundles: Seq[ExtensionBundle]): Seq[ExtensionBundle] = {
     val strictApplied = if (!strict) bundles else bundles.flatMap(_.forStrictMode)

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -150,86 +150,122 @@ object ServerBuilder {
 }
 
 /** Additional configuration options for a preview server.
-  *
-  * @param port the port the server should run on (default 4242)
-  * @param pollInterval the interval at which input file resources are polled for changes (default 1 second)
-  * @param artifactBasename the base name for PDF and EPUB artifacts linked by the generated site (default "docs")
-  * @param includeEPUB indicates whether EPUB downloads should be included on a download page (default false)
-  * @param includePDF indicates whether PDF downloads should be included on a download page (default false)
-  * @param isVerbose whether each served page and each detected file change should be logged (default false)
-  * @param apiDir an optional API directory from which API documentation should be served (default None)
   */
-class ServerConfig private (
-    val port: Port,
-    val host: Host,
-    val pollInterval: FiniteDuration,
-    val artifactBasename: String,
-    val includeEPUB: Boolean,
-    val includePDF: Boolean,
-    val isVerbose: Boolean,
-    val apiDir: Option[FilePath]
-) {
+sealed abstract class ServerConfig private {
 
-  private def copy(
-      newPort: Port = port,
-      newHost: Host = host,
-      newPollInterval: FiniteDuration = pollInterval,
-      newArtifactBasename: String = artifactBasename,
-      newIncludeEPUB: Boolean = includeEPUB,
-      newIncludePDF: Boolean = includePDF,
-      newVerbose: Boolean = isVerbose,
-      newAPIDir: Option[FilePath] = apiDir
-  ): ServerConfig =
-    new ServerConfig(
-      newPort,
-      newHost,
-      newPollInterval,
-      newArtifactBasename,
-      newIncludeEPUB,
-      newIncludePDF,
-      newVerbose,
-      newAPIDir
-    )
+  /** The port the server should run on (default 4242). */
+  def port: Port
+
+  /** The host the server should run on (default localhost). */
+  def host: Host
+
+  /** The interval at which input file resources are polled for changes (default 1 second). */
+  def pollInterval: FiniteDuration
+
+  /** The base name for PDF and EPUB artifacts linked by the generated site (default "docs"). */
+  def artifactBasename: String
+
+  /** Indicates whether EPUB downloads should be included on a download page (default false). */
+  def includeEPUB: Boolean
+
+  /** Indicates whether PDF downloads should be included on a download page (default false). */
+  def includePDF: Boolean
+
+  /** Indicates whether each served page and each detected file change should be logged (default false). */
+  def isVerbose: Boolean
+
+  /** An optional API directory from which API documentation should be served (default None). */
+  def apiDir: Option[FilePath]
 
   /** Specifies the port the server should run on (default 4242).
     */
-  def withPort(port: Port): ServerConfig = copy(newPort = port)
+  def withPort(port: Port): ServerConfig
 
   /** Specifies the host the server should run on (default localhost).
     */
-  def withHost(host: Host): ServerConfig = copy(newHost = host)
+  def withHost(host: Host): ServerConfig
 
   /** Specifies the interval at which input file resources are polled for changes (default 1 second).
     */
-  def withPollInterval(interval: FiniteDuration): ServerConfig = copy(newPollInterval = interval)
+  def withPollInterval(interval: FiniteDuration): ServerConfig
 
   /** Indicates that EPUB downloads should be included on the download page.
     */
-  def withEPUBDownloads: ServerConfig = copy(newIncludeEPUB = true)
+  def withEPUBDownloads: ServerConfig
 
   /** Indicates that PDF downloads should be included on the download page.
     */
-  def withPDFDownloads: ServerConfig = copy(newIncludePDF = true)
+  def withPDFDownloads: ServerConfig
 
   /** Specifies the base name for PDF and EPUB artifacts linked by the generated site (default "docs").
     * Additional classifiers might be added to the base name (apart from the file suffix), depending on configuration.
     */
-  def withArtifactBasename(name: String): ServerConfig = copy(newArtifactBasename = name)
+  def withArtifactBasename(name: String): ServerConfig
 
   /** Specifies a directory from which API documentation of the site can be served.
     * This step is only necessary if you want to test links to API documentation with the preview server.
     */
-  def withAPIDirectory(dir: FilePath): ServerConfig = copy(newAPIDir = Some(dir))
+  def withAPIDirectory(dir: FilePath): ServerConfig
 
   /** Indicates that each served page and each detected file change should be logged to the console.
     */
-  def verbose: ServerConfig = copy(newVerbose = true)
+  def verbose: ServerConfig
 
 }
 
 /** Companion for preview server configuration instances.
   */
 object ServerConfig {
+
+  private final case class Impl(
+      port: Port,
+      host: Host,
+      pollInterval: FiniteDuration,
+      artifactBasename: String,
+      includeEPUB: Boolean,
+      includePDF: Boolean,
+      isVerbose: Boolean,
+      apiDir: Option[FilePath]
+  ) extends ServerConfig {
+    override def productPrefix = "ServerConfig"
+
+    private def copy(
+        newPort: Port = port,
+        newHost: Host = host,
+        newPollInterval: FiniteDuration = pollInterval,
+        newArtifactBasename: String = artifactBasename,
+        newIncludeEPUB: Boolean = includeEPUB,
+        newIncludePDF: Boolean = includePDF,
+        newVerbose: Boolean = isVerbose,
+        newAPIDir: Option[FilePath] = apiDir
+    ): ServerConfig =
+      Impl(
+        newPort,
+        newHost,
+        newPollInterval,
+        newArtifactBasename,
+        newIncludeEPUB,
+        newIncludePDF,
+        newVerbose,
+        newAPIDir
+      )
+
+    def withPort(port: Port): ServerConfig = copy(newPort = port)
+
+    def withHost(host: Host): ServerConfig = copy(newHost = host)
+
+    def withPollInterval(interval: FiniteDuration): ServerConfig = copy(newPollInterval = interval)
+
+    def withEPUBDownloads: ServerConfig = copy(newIncludeEPUB = true)
+
+    def withPDFDownloads: ServerConfig = copy(newIncludePDF = true)
+
+    def withArtifactBasename(name: String): ServerConfig = copy(newArtifactBasename = name)
+
+    def withAPIDirectory(dir: FilePath): ServerConfig = copy(newAPIDir = Some(dir))
+
+    def verbose: ServerConfig = copy(newVerbose = true)
+  }
 
   val defaultPort: Port = port"4242"
 
@@ -240,15 +276,15 @@ object ServerConfig {
   val defaultArtifactBasename: String = "docs"
 
   /** A ServerConfig instance populated with default values. */
-  val defaults = new ServerConfig(
+  val defaults: ServerConfig = Impl(
     defaultPort,
     defaultHost,
     defaultPollInterval,
     defaultArtifactBasename,
-    false,
-    false,
-    false,
-    None
+    includeEPUB = false,
+    includePDF = false,
+    isVerbose = false,
+    apiDir = None
   )
 
 }

--- a/sbt/src/main/scala/laika/sbt/LaikaConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaConfig.scala
@@ -29,48 +29,80 @@ import scala.io.Codec
   *
   * @author Jens Halm
   */
-case class LaikaConfig private (
-    encoding: Codec = Codec.UTF8,
-    bundleFilter: BundleFilter = BundleFilter(),
-    configBuilder: ConfigBuilder = ConfigBuilder.empty,
-    failOnMessages: MessageFilter = MessageFilter.Error,
-    renderMessages: MessageFilter = MessageFilter.None,
-    logMessages: MessageFilter = MessageFilter.Warning
-) {
+sealed abstract class LaikaConfig private {
 
   /** The file encoding to use for input and output files.
     */
-  def encoding(codec: Codec): LaikaConfig = copy(encoding = codec)
+  def encoding: Codec
+
+  /** Indicates whether strict mode has been turned on for the target parser,
+    * switching off any features not part of the original markup syntax.
+    * This includes the registration of markup directives (custom tags)
+    * as well as configuration sections at the start of the document.
+    */
+  def isStrict: Boolean
+
+  /** Indicates whether all extensions that process raw content embedded into the host markup language should be enabled.
+    * These are disabled by default as Laika is designed to render to multiple output formats from a single input document.
+    * With raw content embedded the markup document is tied to a specific output format.
+    */
+  def acceptsRawContent: Boolean
+
+  /** The configuration builder, populated with all values passed via `withConfigValue`.
+    */
+  def configBuilder: ConfigBuilder
+
+  /** Indicates the filter to apply to runtime messages that should cause a transformation to fail.
+    *
+    * The default is to fail transformations on messages of level `Error` or higher.
+    */
+  def failOnMessages: MessageFilter
+
+  /** Indicates the filter to apply to runtime messages that should get rendered to the output.
+    *
+    * The default is not to render any messages to the output.
+    */
+  def renderMessages: MessageFilter
+
+  /** Indicates the filter to apply to runtime messages that should be logged to the console when running transformation tasks.
+    *
+    * The default is to log messages of level `Warning` or higher.
+    */
+  def logMessages: MessageFilter
+
+  /** The file encoding to use for input and output files.
+    */
+  def encoding(codec: Codec): LaikaConfig
 
   /**  Turns strict mode on for the target parser, switching off any features not part of the original markup syntax.
     *  This includes the registration of markup directives (custom tags)
     *  as well as configuration sections at the start of the document.
     */
-  def strict: LaikaConfig = copy(bundleFilter = bundleFilter.copy(strict = true))
+  def strict: LaikaConfig
 
   /**  Enables all extensions that process raw content embedded into the host markup language.
     *  These are disabled by default as Laika is designed to render to multiple output formats from a single input document.
     *  With raw content embedded the markup document is tied to a specific output format.
     */
-  def withRawContent: LaikaConfig = copy(bundleFilter = bundleFilter.copy(acceptRawContent = true))
+  def withRawContent: LaikaConfig
 
   /** Specifies the filter to apply to runtime messages that should cause a transformation to fail.
     *
     * The default is to fail transformations on messages of level `Error` or higher.
     */
-  def failOnMessages(filter: MessageFilter): LaikaConfig = copy(failOnMessages = filter)
+  def failOnMessages(filter: MessageFilter): LaikaConfig
 
   /** Specifies the filter to apply to runtime messages that should get rendered to the output.
     *
     * The default is not to render any messages to the output.
     */
-  def renderMessages(filter: MessageFilter): LaikaConfig = copy(renderMessages = filter)
+  def renderMessages(filter: MessageFilter): LaikaConfig
 
   /** Specifies the filter to apply to runtime messages that should be logged to the console when running transformation tasks.
     *
     * The default is to log messages of level `Warning` or higher.
     */
-  def logMessages(filter: MessageFilter): LaikaConfig = copy(logMessages = filter)
+  def logMessages(filter: MessageFilter): LaikaConfig
 
   /** Returns a new instance with the specified configuration value added.
     *
@@ -78,8 +110,7 @@ case class LaikaConfig private (
     * but lower precedence than any value with the same key specified in a configuration file for a directory
     * or a configuration header in a markup document.
     */
-  def withConfigValue[T: ConfigEncoder: DefaultKey](value: T): LaikaConfig =
-    copy(configBuilder = configBuilder.withValue(value))
+  def withConfigValue[T: ConfigEncoder: DefaultKey](value: T): LaikaConfig
 
   /** Returns a new instance with the specified configuration value added.
     *
@@ -87,8 +118,7 @@ case class LaikaConfig private (
     * but lower precedence than any value with the same key specified in a configuration file for a directory
     * or a configuration header in a markup document.
     */
-  def withConfigValue[T: ConfigEncoder](key: String, value: T): LaikaConfig =
-    copy(configBuilder = configBuilder.withValue(key, value))
+  def withConfigValue[T: ConfigEncoder](key: String, value: T): LaikaConfig
 
   /** Returns a new instance with the specified configuration value added.
     *
@@ -96,16 +126,76 @@ case class LaikaConfig private (
     * but lower precedence than any value with the same key specified in a configuration file for a directory
     * or a configuration header in a markup document.
     */
-  def withConfigValue[T: ConfigEncoder](key: Key, value: T): LaikaConfig =
-    copy(configBuilder = configBuilder.withValue(key, value))
+  def withConfigValue[T: ConfigEncoder](key: Key, value: T): LaikaConfig
+
+  private[sbt] def bundleFilter: BundleFilter
 
 }
 
 object LaikaConfig {
 
+  private final case class Impl(
+      encoding: Codec,
+      private[sbt] val bundleFilter: BundleFilter,
+      configBuilder: ConfigBuilder,
+      failOnMessages: MessageFilter,
+      renderMessages: MessageFilter,
+      logMessages: MessageFilter
+  ) extends LaikaConfig {
+    override def productPrefix = "LaikaConfig"
+
+    private def copy(
+        newEncoding: Codec = encoding,
+        newBundleFilter: BundleFilter = bundleFilter,
+        newConfigBuilder: ConfigBuilder = configBuilder,
+        newFailOnMessages: MessageFilter = failOnMessages,
+        newRenderMessages: MessageFilter = renderMessages,
+        newLogMessages: MessageFilter = logMessages
+    ): LaikaConfig = Impl(
+      newEncoding,
+      newBundleFilter,
+      newConfigBuilder,
+      newFailOnMessages,
+      newRenderMessages,
+      newLogMessages
+    )
+
+    val acceptsRawContent: Boolean = bundleFilter.acceptRawContent
+    val isStrict: Boolean          = bundleFilter.strict
+
+    def encoding(codec: Codec): LaikaConfig = copy(newEncoding = codec)
+    def strict: LaikaConfig = copy(newBundleFilter = bundleFilter.copy(strict = true))
+
+    def withRawContent: LaikaConfig =
+      copy(newBundleFilter = bundleFilter.copy(acceptRawContent = true))
+
+    def failOnMessages(filter: MessageFilter): LaikaConfig = copy(newFailOnMessages = filter)
+
+    def renderMessages(filter: MessageFilter): LaikaConfig = copy(newRenderMessages = filter)
+
+    def logMessages(filter: MessageFilter): LaikaConfig = copy(newLogMessages = filter)
+
+    def withConfigValue[T: ConfigEncoder: DefaultKey](value: T): LaikaConfig =
+      copy(newConfigBuilder = configBuilder.withValue(value))
+
+    def withConfigValue[T: ConfigEncoder](key: String, value: T): LaikaConfig =
+      copy(newConfigBuilder = configBuilder.withValue(key, value))
+
+    def withConfigValue[T: ConfigEncoder](key: Key, value: T): LaikaConfig =
+      copy(newConfigBuilder = configBuilder.withValue(key, value))
+
+  }
+
   /** The default settings for the Laika plugin that can be modified with the methods of the returned instance.
     */
-  def defaults: LaikaConfig = LaikaConfig()
+  def defaults: LaikaConfig = Impl(
+    encoding = Codec.UTF8,
+    bundleFilter = BundleFilter(),
+    configBuilder = ConfigBuilder.empty,
+    failOnMessages = MessageFilter.Error,
+    renderMessages = MessageFilter.None,
+    logMessages = MessageFilter.Warning
+  )
 
   private def unapply(conf: LaikaConfig) = conf
 

--- a/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
@@ -20,8 +20,8 @@ import cats.effect.IO
 import laika.bundle.ExtensionBundle
 import laika.helium.Helium
 import laika.theme.ThemeProvider
-import sbt.Keys._
-import sbt._
+import sbt.Keys.*
+import sbt.*
 
 /** Plugin that adapts the features of the Laika library for use from within sbt.
   *
@@ -154,7 +154,7 @@ object LaikaPlugin extends AutoPlugin {
     laikaXSLFO / target         := (Laika / target).value / "fo",
     laikaAST / target           := (Laika / target).value / "ast",
     laikaExtensions             := Nil,
-    laikaConfig                 := LaikaConfig(),
+    laikaConfig                 := LaikaConfig.defaults,
     laikaPreviewConfig          := LaikaPreviewConfig.defaults,
     laikaTheme                  := Helium.defaults.build,
     laikaDescribe               := Tasks.describe.value,

--- a/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
@@ -16,48 +16,42 @@
 
 package laika.sbt
 
-import com.comcast.ip4s._
+import com.comcast.ip4s.*
 import laika.preview.ServerConfig
 
 import scala.concurrent.duration.FiniteDuration
 
 /** Plugin configuration options specific to the preview server.
-  *
-  * @param port the port the server should run on (default 4242)
-  * @param pollInterval the interval at which input file resources are polled for changes (default 3 seconds)
-  * @param isVerbose whether each served page and each detected file change should be logged (default false)
   */
-case class LaikaPreviewConfig private (
-    port: Port,
-    host: Host,
-    pollInterval: FiniteDuration,
-    isVerbose: Boolean
-) {
+sealed abstract class LaikaPreviewConfig private {
 
-  private def copy(
-      newPort: Port = port,
-      newHost: Host = host,
-      newPollInterval: FiniteDuration = pollInterval,
-      newVerbose: Boolean = isVerbose
-  ): LaikaPreviewConfig =
-    new LaikaPreviewConfig(newPort, newHost, newPollInterval, newVerbose)
+  /** The port the server should run on (default 4242). */
+  def port: Port
+
+  /** The host the server should run on (default localhost). */
+  def host: Host
+
+  /** The interval at which input file resources are polled for changes (default 3 seconds). */
+  def pollInterval: FiniteDuration
+
+  /** Indicates whether each served page and each detected file change should be logged (default false). */
+  def isVerbose: Boolean
 
   /** Specifies the port the server should run on (default 4242).
     */
-  def withPort(port: Port): LaikaPreviewConfig = copy(newPort = port)
+  def withPort(port: Port): LaikaPreviewConfig
 
   /** Specifies the host the server should run on (default localhost).
     */
-  def withHost(host: Host): LaikaPreviewConfig = copy(newHost = host)
+  def withHost(host: Host): LaikaPreviewConfig
 
   /** Specifies the interval at which input file resources are polled for changes (default 3 seconds).
     */
-  def withPollInterval(interval: FiniteDuration): LaikaPreviewConfig =
-    copy(newPollInterval = interval)
+  def withPollInterval(interval: FiniteDuration): LaikaPreviewConfig
 
   /** Indicates that each served page and each detected file change should be logged to the console.
     */
-  def verbose: LaikaPreviewConfig = copy(newVerbose = true)
+  def verbose: LaikaPreviewConfig
 
 }
 
@@ -65,14 +59,37 @@ case class LaikaPreviewConfig private (
   */
 object LaikaPreviewConfig {
 
+  private final case class Impl(
+      port: Port,
+      host: Host,
+      pollInterval: FiniteDuration,
+      isVerbose: Boolean
+  ) extends LaikaPreviewConfig {
+    override def productPrefix = "LaikaPreviewConfig"
+
+    private def copy(
+        newPort: Port = port,
+        newHost: Host = host,
+        newPollInterval: FiniteDuration = pollInterval,
+        newVerbose: Boolean = isVerbose
+    ): LaikaPreviewConfig =
+      Impl(newPort, newHost, newPollInterval, newVerbose)
+
+    def withPort(port: Port): LaikaPreviewConfig = copy(newPort = port)
+    def withHost(host: Host): LaikaPreviewConfig = copy(newHost = host)
+
+    def withPollInterval(interval: FiniteDuration): LaikaPreviewConfig =
+      copy(newPollInterval = interval)
+
+    def verbose: LaikaPreviewConfig = copy(newVerbose = true)
+  }
+
   /** A config instance populated with default values. */
-  val defaults = new LaikaPreviewConfig(
+  val defaults: LaikaPreviewConfig = Impl(
     ServerConfig.defaultPort,
     ServerConfig.defaultHost,
     ServerConfig.defaultPollInterval,
-    false
+    isVerbose = false
   )
-
-  private def unapply(conf: LaikaPreviewConfig) = conf
 
 }

--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -18,7 +18,7 @@ package laika.sbt
 
 import cats.effect.{ IO, Resource }
 import cats.effect.unsafe.implicits.global
-import cats.implicits.*
+import cats.syntax.all.*
 import laika.api.{ MarkupParser, Renderer, Transformer }
 import laika.factory.{
   BinaryPostProcessorBuilder,
@@ -50,7 +50,7 @@ import scala.annotation.tailrec
   */
 object Tasks {
 
-  import Def._
+  import Def.*
 
   /** Generates and copies the API documentation to the target directory of the site task.
     * Does nothing if the `laikaIncludeAPI` setting is set to false (the default).


### PR DESCRIPTION
Applies the pattern described in #482 (section 2.) to the following public case classes:

* `ServerConfig` in `laika.preview`
* `LaikaConfig`, `LaikaPreviewConfig` in `laika.sbt`

These changes also allowed removing `BundleFilter` from the public API.

This is the final PR in the series of case class conversions.

