### PR TITLE
plugin: print full URL in preview server boot message

### DIFF
--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -247,7 +247,7 @@ object Tasks {
     val (_, cancel) = buildPreviewServer.value.allocated.unsafeRunSync()
 
     streams.value.log.info(
-      s"Preview server started on port ${laikaPreviewConfig.value.port}. Press return/enter to exit."
+      s"Preview server started at http://${laikaPreviewConfig.value.host}:${laikaPreviewConfig.value.port}. Press return/enter to exit."
     )
 
     try {


### PR DESCRIPTION
Changes the boot message of the preview server of the sbt plugin from

`Preview server started on port 4242. Press return/enter to exit.`

to

`Preview server started at http://localhost:4242. Press return/enter to exit.`

Closes #494