### PR TITLE
manual: add missing info for running separate parsers and renderers

### DIFF
--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -507,23 +507,29 @@ it is mostly trivial: delegating to the underlying `Parser` and `Renderer` and j
 
 The following code example demonstrates the third scenario listed above: Rendering the same input to multiple output formats.
 
-First we create a parser that reads from a directory:
+First we set up a parser and its configuration.
+We create a parallel parser that is capable of reading from a directory:
 
 ```scala mdoc:silent
-val parser = MarkupParser
-  .of(Markdown)
-  .using(GitHubFlavor)
-  .parallel[IO]
-  .build
+val parserBuilder = MarkupParser.of(Markdown).using(GitHubFlavor)
+
+val parser = parserBuilder.parallel[IO].build
+
+val config = parserBuilder.config
 ```
 
 Next we create the renderers for the three output formats:
 
 ```scala mdoc:silent
-val htmlRenderer = Renderer.of(HTML).parallel[IO].build
-val epubRenderer = Renderer.of(EPUB).parallel[IO].build
-val pdfRenderer  = Renderer.of(PDF).parallel[IO].build
+val htmlRenderer = Renderer.of(HTML).withConfig(config).parallel[IO].build
+val epubRenderer = Renderer.of(EPUB).withConfig(config).parallel[IO].build
+val pdfRenderer  = Renderer.of(PDF).withConfig(config).parallel[IO].build
 ```
+
+Notice that we pass the `config` value obtained from the parser to all renderers.
+First, this simplifies the code as any custom configuration you define for the parser
+will be automatically shared, and secondly, it ensures that any extensions added
+by the parser itself are known to the renderers.
 
 Since all four processors are a cats-effect `Resource`, we combine them into one:
 
@@ -557,6 +563,32 @@ We are using cats' `parMapN` here to run the three renderers in parallel.
 The `tree` instance passed to all renderers is of type `DocumentTreeRoot`. 
 If necessary you can use its API to inspect or transform the tree before rendering.
 See [The Document AST] for details.
+
+Our little sample setup will run with the Helium theme and all its defaults applied.
+In the (very common) case that you customize the theme (colors, fonts, landing page content, etc.),
+you need to pass it to all parsers and renderers.
+
+```scala mdoc:silent
+import laika.helium.Helium
+
+val helium = Helium.defaults
+  .site.baseURL("https://foo.com")
+  .build
+
+val customParser = parserBuilder
+  .parallel[IO]
+  .withTheme(helium)
+  .build
+  
+val customHTML = Renderer
+  .of(HTML)
+  .withConfig(config)
+  .parallel[IO]
+  .withTheme(helium)
+  .build
+  
+// ... repeat for all other renderers
+```
 
 The sample code in this scenario showed the effectful variant of the `Parser` and `Renderer` types,
 but just as the `Transformer` they exist in the other flavor as well: a pure variant as part of the `laika-core` module.


### PR DESCRIPTION
This addresses the lack of crucial details in the manual that surfaced in this discussion: #489 

Affected section: https://typelevel.org/Laika/latest/02-running-laika/02-library-api.html#separate-parsing-and-rendering

Changes:

* Mentions that the `OperationConfig` should be shared between parsers and renderers.
* Explains that theme configuration needs to be passed to both, parsers and renderers.

FYI @hmf