### PR TITLE
Markdown spec compliance: bullet lists do no longer require preceding empty lines

### DIFF
--- a/core/jvm/src/test/resources/markdownTestSuite/Hard-wrapped paragraphs with list-like lines.html
+++ b/core/jvm/src/test/resources/markdownTestSuite/Hard-wrapped paragraphs with list-like lines.html
@@ -4,5 +4,7 @@ Because a hard-wrapped line in the
 middle of a paragraph looked like a
 list item.</p>
 
-<p>Here's one with a bullet.
-* criminey.</p>
+<p>Here's one with a bullet.</p>
+<ul>
+  <li>criminey.</li>
+</ul>

--- a/core/shared/src/main/scala/laika/format/Markdown.scala
+++ b/core/shared/src/main/scala/laika/format/Markdown.scala
@@ -68,8 +68,7 @@ case object Markdown extends MarkupFormat {
     BlockParsers.rules,
     ListParsers.enumLists.rootOnly,
     ListParsers.enumLists.nestedOnly.interruptsParagraphWith(TextParsers.oneOf(CharGroup.digit)),
-    ListParsers.bulletLists.rootOnly,
-    ListParsers.bulletLists.nestedOnly.interruptsParagraphWith(TextParsers.oneOf('+', '*', '-'))
+    ListParsers.bulletLists.interruptsParagraphWith(TextParsers.oneOf('+', '*', '-'))
   )
 
   val spanParsers: Seq[SpanParserBuilder] = Seq(


### PR DESCRIPTION
The following test case shows examples of potential enum lists and bullet lists interrupting a paragraph without a preceding empty line (taken from an actual test suite of a classic Markdown parser):

```
In Markdown 1.0.0 and earlier. Version
8. This line turns into a list item.
Because a hard-wrapped line in the
middle of a paragraph looked like a
list item.

Here's one with a bullet.
* criminey.
```

Markdown parser handle the above cases differently. (See [here](https://babelmark.github.io/?text=In+Markdown+1.0.0+and+earlier.+Version%0A8.+This+line+turns+into+a+list+item.%0ABecause+a+hard-wrapped+line+in+the%0Amiddle+of+a+paragraph+looked+like+a%0Alist+item.%0A%0AHere%27s+one+with+a+bullet.%0A*+criminey.%0A) for example output from various parsers)

1. Some ignore both lists
2. Some support bullet lists without preceding blank line, but not enum lists.
3. Some support both list types without preceding blank line

However, all newer parsers marked as CommonMark compliant behave as in 2.

For this reason Laika's Markdown parser changes the behaviour to allow bullet lists without preceding blank lines, while still preventing the same for enum list.

One example file from the test suite taken from a classic Markdown parser which behaves differently had to be adjusted accordingly.

Closes #454