### PR TITLE
introduce substitution variable `cursor.currentDocument.rawTitle`

### DIFF
--- a/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
@@ -78,6 +78,7 @@ object ReferenceResolver {
   ): ReferenceResolver = {
 
     val rootKey = Key("cursor")
+    val title   = document.title.getOrElse(emptyTitle)
 
     val baseBuilder = ConfigBuilder
       .withFallback(config)
@@ -88,7 +89,8 @@ object ReferenceResolver {
             Field("path", StringValue(document.path.toString)), // deprecated since 0.19.0
             Field("sourcePath", StringValue(document.path.toString)),
             Field("content", ASTValue(document.content), config.origin),
-            Field("title", ASTValue(document.title.getOrElse(emptyTitle)), config.origin),
+            Field("title", ASTValue(title), config.origin),
+            Field("rawTitle", StringValue(title.extractText), config.origin),
             Field(
               "fragments",
               ObjectValue(document.fragments.toSeq.map { case (name, element) =>

--- a/docs/src/07-reference/02-substitution-variables.md
+++ b/docs/src/07-reference/02-substitution-variables.md
@@ -66,6 +66,8 @@ This is a complete list of values exposed in the `cursor` namespace:
 
     * `title`: the AST of the title of this document - including formatting.
 
+    * `rawTitle`: the raw string of the title of this document - stripping all formatting.
+
     * `sourcePath`: the absolute (virtual) path of the document in the input tree.
 
     * `path` (deprecated since 0.19.0): use `sourcePath`.

--- a/io/src/main/resources/laika/helium/templates/includes/head.template.html
+++ b/io/src/main/resources/laika/helium/templates/includes/head.template.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="Typelevel Laika + Helium Theme" />
-  <title>${cursor.currentDocument.title}</title>
+  <title>${cursor.currentDocument.rawTitle}</title>
   @:for(laika.site.metadata.authors)
   <meta name="author" content="${_}"/>
   @:@

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -418,11 +418,11 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
     transformAndExtractHead(singleDoc, helium).assertEquals(expected)
   }
 
-  test("title") {
+  test("title - ignoring markup") {
     val markup =
       """
-        |Title
-        |=====
+        |Title **1**
+        |===========
         |
         |Text
       """.stripMargin
@@ -430,7 +430,7 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
       Root / "name.md" -> markup
     )
     transformAndExtractHead(inputs, heliumBase).map(_.extractTag("title")).assertEquals(
-      Some("Title")
+      Some("Title 1")
     )
   }
 


### PR DESCRIPTION
This is a fairly simple enhancement that introduces a new substitution variable `cursor.currentDocument.rawTitle`.
In contrast to the existing `cursor.currentDocument.title` it strips all formatting so that it can be used in templates where formatting is not permitted. Also adjusts the Helium default template to use the new variable for the `<title>` tag.

fyi @j-mie6