### PR TITLE
preview server - render document AST under /ast path postfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val basicSettings = Seq(
     (if (priorTo2_13(scalaVersion.value)) Seq("-Ypartial-unification") else Nil)
 )
 
-val mimaPreviousVersions = Set("0.19.0", "0.19.1", "0.19.2")
+val mimaPreviousVersions = Set("0.19.0", "0.19.1", "0.19.2", "0.19.3")
 
 val previousArtifacts = Seq(
   mimaPreviousArtifacts := mimaPreviousVersions

--- a/core/shared/src/main/scala/laika/render/ASTRenderer.scala
+++ b/core/shared/src/main/scala/laika/render/ASTRenderer.scala
@@ -51,7 +51,11 @@ object ASTRenderer extends ((TextFormatter, Element) => String) {
     }
 
     def attributes(attr: Iterator[Any], exclude: AnyRef = NoRef): String = {
-      def prep(value: Any) = value match { case opt: Options => options(opt); case other => other }
+      def prep(value: Any) = value match {
+        case opt: Options              => options(opt)
+        case t: ResolvedInternalTarget => s"InternalTarget(${t.relativePath},${t.internalFormats})"
+        case other                     => other
+      }
       val it               = attr.asInstanceOf[Iterator[AnyRef]]
       val res              = it
         .filter(_ ne exclude)

--- a/docs/src/01-about-laika/01-features.md
+++ b/docs/src/01-about-laika/01-features.md
@@ -71,7 +71,8 @@ Content Organization
 * Produce [Versioned Documentation] based on simple configuration steps and an integrated version switcher
   dropdown in the default Helium theme.
   
-* Use the integrated [Preview Server](../02-running-laika/01-sbt-plugin.md#using-the-preview-server) with live updates to preview your site while editing.
+* Use the integrated [Preview Server](../02-running-laika/01-sbt-plugin.md#using-the-preview-server) 
+  with live updates to preview your site while editing.
 
 
 Library API

--- a/docs/src/02-running-laika/01-sbt-plugin.md
+++ b/docs/src/02-running-laika/01-sbt-plugin.md
@@ -175,7 +175,20 @@ If you are using an IDE with auto-save you might need to tweak its preferences
 for seeing changes while editing the Markdown sources. 
 IntelliJ, for example, only auto-saves when you run or compile an application or when you switch to a
 different application in the OS. 
-You can either use `cmd-S` to manually force saving or change the preferences to auto-save in fixed time intervals. 
+You can either use `cmd-S` to manually force saving or change the preferences to auto-save in fixed time intervals.
+
+
+### Preview of the Document AST
+
+Introduced in version 0.19.4 the preview server can now also render the document AST for any markup source document.
+Simply append the `/ast` path element to your URL, e.g. `localhost:4242/my-docs/intro.md/ast`. 
+Note that this does not prevent you from using `/ast` as an actual path segment in your site,
+the server will be able to distinguish those.
+
+The AST shown is equivalent to the AST passed to the actual renderer after the final rewrite phase.
+In case of writing custom render overrides it is the most accurate representation of the nodes you can match on.
+When writing rewrite rules for earlier phases the actual nodes to match on might differ 
+(e.g. directives and links might still be unresolved).
 
 
 Plugin Settings

--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -735,3 +735,16 @@ ServerBuilder[IO](parser, inputs)
 By default, the port is 4242, the poll interval is 3 seconds, and EPUB or PDF downloads will not be included
 in the generated site.
 
+
+### Preview of the Document AST
+
+Introduced in version 0.19.4 the preview server can now also render the document AST for any markup source document.
+Simply append the `/ast` path element to your URL, e.g. `localhost:4242/my-docs/intro.md/ast`.
+Note that this does not prevent you from using `/ast` as an actual path segment in your site,
+the server will be able to distinguish those.
+
+The AST shown is equivalent to the AST passed to the actual renderer after the final rewrite phase.
+In case of writing custom render overrides it is the most accurate representation of the nodes you can match on.
+When writing rewrite rules for earlier phases the actual nodes to match on might differ
+(e.g. directives and links might still be unresolved).
+

--- a/preview/src/main/scala/laika/preview/ASTPageTransformer.scala
+++ b/preview/src/main/scala/laika/preview/ASTPageTransformer.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.preview
+
+import laika.api.Renderer
+import laika.api.builder.OperationConfig
+import laika.ast.{
+  Block,
+  BlockContainer,
+  BlockSequence,
+  CodeBlock,
+  Document,
+  DocumentTree,
+  DocumentTreeRoot,
+  Path,
+  RewritePhase,
+  RootElement,
+  Section,
+  Title
+}
+import laika.format.{ AST, HTML }
+import laika.parse.{ Failure, Success }
+import laika.parse.code.languages.LaikaASTSyntax
+import laika.rewrite.OutputContext
+
+import scala.annotation.tailrec
+
+object ASTPageTransformer {
+
+  private val renderer = Renderer.of(AST).build
+
+  private val highlighter = LaikaASTSyntax.rootParser
+
+  private val messagePrefix = "Rendering of AST failed: "
+
+  private def callout(message: String): Block =
+    BlockSequence(messagePrefix + message).withStyles("callout", "error")
+
+  private def sequenceToASTBlock(bs: BlockContainer): Block = {
+    renderer.render(bs) match {
+      case Left(error) => callout(error.message)
+      case Right(ast)  =>
+        highlighter.parse(ast) match {
+          case Success(spans, _) => CodeBlock("laika-ast", spans)
+          case f: Failure        => callout(f.message)
+        }
+
+    }
+  }
+
+  private def splitAtFirstSection(blocks: Seq[Block]): (Seq[Block], Seq[Block]) =
+    blocks.span(b => !b.isInstanceOf[Section])
+
+  @tailrec
+  private def transformBlocks(blocks: Seq[Block], acc: Seq[Block] = Nil): Seq[Block] = {
+
+    val (start, end) = splitAtFirstSection(blocks)
+
+    // due to the nature of Laika's internal section builder start is expected to always be empty,
+    // but there is no need to fail on unexpected content
+    val noSection       =
+      if (start.isEmpty) None
+      else Some(sequenceToASTBlock(BlockSequence(start)))
+    val (section, rest) =
+      if (end.isEmpty) (None, Nil)
+      else (Some(transformSection(end.head.asInstanceOf[Section])), end.tail)
+
+    val newAcc = acc ++ noSection.toSeq ++ section.toSeq
+    if (rest.isEmpty) newAcc
+    else transformBlocks(rest, newAcc)
+  }
+
+  private def transformSection(section: Section): Section = {
+    val (first, remaining) = splitAtFirstSection(section.content)
+
+    val firstBlock = sequenceToASTBlock(section.withContent(first))
+
+    section.withContent(firstBlock +: transformBlocks(remaining))
+  }
+
+  private def transformRoot(root: RootElement): RootElement = {
+
+    val (first, remaining) = splitAtFirstSection(root.content)
+
+    val title      = first.collectFirst { case title: Title => title }
+    val firstBlock = sequenceToASTBlock(root.withContent(first))
+    val rest       = firstBlock +: transformBlocks(remaining)
+
+    root.withContent(title.toSeq ++ rest)
+  }
+
+  private def transformDocument(doc: Document, treePath: Path): Document =
+    doc.copy(
+      path = treePath / "ast",
+      content = transformRoot(doc.content)
+    )
+
+  private def transformTree(tree: DocumentTree): DocumentTree = tree.copy(
+    content = tree.content.map {
+      case t: DocumentTree => transformTree(t)
+      case d: Document     =>
+        val treePath = d.path.withSuffix("html")
+        DocumentTree(treePath, Seq(transformDocument(d, treePath)))
+    }
+  )
+
+  def transform(tree: DocumentTreeRoot, config: OperationConfig): DocumentTreeRoot = {
+    val rules = config.rewriteRulesFor(tree, RewritePhase.Render(OutputContext(HTML)))
+    tree.rewrite(rules) match {
+      case Right(rewritten) => rewritten.modifyTree(transformTree)
+      case Left(error) => tree.mapDocuments(_.copy(content = RootElement(callout(error.message))))
+    }
+  }
+
+}

--- a/preview/src/test/scala/laika/preview/PreviewRouteSpec.scala
+++ b/preview/src/test/scala/laika/preview/PreviewRouteSpec.scala
@@ -92,6 +92,13 @@ class PreviewRouteSpec extends CatsEffectSuite with InputBuilder {
     run(uri"/dir", Status.Ok, Some(MediaType.text.html), stringBody("<p>foo</p>"))
   }
 
+  test("serve the AST of a rendered document") {
+    val expected = """<pre><code class="nohighlight"><span class="type-name">RootElement</span><span> - </span><span class="keyword">Blocks</span><span>: </span><span class="number-literal">1</span><span>
+                     |</span><span class="tag-punctuation">. </span><span class="type-name">Paragraph</span><span> - </span><span class="keyword">Spans</span><span>: </span><span class="number-literal">1</span><span>
+                     |</span><span class="tag-punctuation">. . </span><span class="type-name">Text</span><span> - </span><span class="string-literal">&#39;foo&#39;</span></code></pre>""".stripMargin
+    run(uri"/doc.html/ast", Status.Ok, Some(MediaType.text.html), stringBody(expected))
+  }
+
   test("serve a static document") {
     run(uri"/dir/image.jpg", Status.Ok, Some(MediaType.image.jpeg), stringBody("img"))
   }

--- a/preview/src/test/scala/laika/preview/PreviewRouteSpec.scala
+++ b/preview/src/test/scala/laika/preview/PreviewRouteSpec.scala
@@ -93,9 +93,10 @@ class PreviewRouteSpec extends CatsEffectSuite with InputBuilder {
   }
 
   test("serve the AST of a rendered document") {
-    val expected = """<pre><code class="nohighlight"><span class="type-name">RootElement</span><span> - </span><span class="keyword">Blocks</span><span>: </span><span class="number-literal">1</span><span>
-                     |</span><span class="tag-punctuation">. </span><span class="type-name">Paragraph</span><span> - </span><span class="keyword">Spans</span><span>: </span><span class="number-literal">1</span><span>
-                     |</span><span class="tag-punctuation">. . </span><span class="type-name">Text</span><span> - </span><span class="string-literal">&#39;foo&#39;</span></code></pre>""".stripMargin
+    val expected =
+      """<pre><code class="nohighlight"><span class="type-name">RootElement</span><span> - </span><span class="keyword">Blocks</span><span>: </span><span class="number-literal">1</span><span>
+        |</span><span class="tag-punctuation">. </span><span class="type-name">Paragraph</span><span> - </span><span class="keyword">Spans</span><span>: </span><span class="number-literal">1</span><span>
+        |</span><span class="tag-punctuation">. . </span><span class="type-name">Text</span><span> - </span><span class="string-literal">&#39;foo&#39;</span></code></pre>""".stripMargin
     run(uri"/doc.html/ast", Status.Ok, Some(MediaType.text.html), stringBody(expected))
   }
 


### PR DESCRIPTION
This is the penultimate feature PR for 0.19.

It adds the capability to render the document AST in the preview server when adding the `/ast` postfix to the page's URL.

This is particularly helpful when a developer intends to implement render overrides or rewrite rules and is not sure which nodes to match on.

The server goes beyond just putting the AST out as a huge blob of text as that would not be very helpful:

* The AST is rendered separately for each section, with original headers rendered between them.
* It receives proper syntax highlighting.
* It's rendered in the same page template, with all page navigation and site navigation intact.
* The site navigation also links to the AST, not the HTML of other pages.
* To get out of AST mode, the `/ast` postfix simply has to be removed from the URL again.

The AST shown is equivalent to the AST passed to the actual renderer after the final rewrite phase.
In case of writing custom render overrides it is the most accurate representation of the nodes you can match on.
When writing rewrite rules for earlier phases the actual nodes to match on might differ 
(e.g. directives and links might still be unresolved).

This functionality finally makes the old demo app obsolete. The code for the app has already been removed some time ago, but once this feature is released as part of version 0.19.4, the running demo app will be decommissioned and the links to it removed from Laika's manual and README.
