### PR TITLE
Markdown: allow URLs with nested parenthesis in links

### DIFF
--- a/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
@@ -197,9 +197,12 @@ object InlineParsers {
     def enclosedIn(delim: String): Parser[String] =
       delim ~> delimitedBy(delim <~ lookAhead(titleEnd))
     val title                                     = ws.void ~> (enclosedIn("\"") | enclosedIn("'"))
+    val nestedParens                              = ("(" ~ delimitedBy(')')).source
 
     val url = ("<" ~> text(delimitedBy('>')).embed(recParsers.escapeSequence)) |
-      text(delimitedBy(')', ' ', '\t').keepDelimiter).embed(recParsers.escapeSequence)
+      text(delimitedBy(')', ' ', '\t').keepDelimiter).embedAll(
+        Seq(recParsers.escapeSequence, nestedParens)
+      )
 
     val urlWithTitle =
       ("(" ~> url ~ opt(title) <~ ws ~ ")").mapN(TargetUrl.apply).withCursor.map(t =>

--- a/core/shared/src/test/scala/laika/markdown/InlineParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/InlineParsersSpec.scala
@@ -171,6 +171,13 @@ class InlineParsersSpec extends FunSuite with TestSourceBuilders {
     runEnclosed("some [link](http://foo) here", SpanLink.external("http://foo")("link"))
   }
 
+  test("links - inline link with nested parenthesis") {
+    runEnclosed(
+      "some [link](http://foo?param=foo(bar)baz) here",
+      SpanLink.external("http://foo?param=foo(bar)baz")("link")
+    )
+  }
+
   test("links - recognize email link as external link") {
     runEnclosed(
       "some [link](mailto:nobody@nowhere.com) here",


### PR DESCRIPTION
The following syntax is supported by most parsers:
```markdown
This is a [link](https://foo.com/bar?param=some(parens)here).
```
Laika did not previously support this and cut the URL at the first closing parenthesis.
This improvement is a prerequisite for fixing #506 properly.