### PR TITLE
link directives - properly support custom link text as documented

### DIFF
--- a/core/shared/src/main/scala/laika/directive/DirectiveSupport.scala
+++ b/core/shared/src/main/scala/laika/directive/DirectiveSupport.scala
@@ -20,7 +20,7 @@ import laika.ast.RewriteRules.RewritePhaseBuilder
 import laika.ast.{
   DocumentCursor,
   InvalidSpan,
-  LinkIdReference,
+  LinkPathReference,
   NoOpt,
   Options,
   Replace,
@@ -97,7 +97,7 @@ class DirectiveSupport(
   ))
 
   case class LinkDirectiveResolver(
-      ref: LinkIdReference,
+      ref: LinkPathReference,
       directiveName: String,
       typeName: String,
       source: SourceFragment,
@@ -124,8 +124,8 @@ class DirectiveSupport(
     if (strictMode) Nil
     else
       Seq(RewriteRules.forSpans {
-        case ref: LinkIdReference if ref.ref.startsWith("@:") =>
-          linkParser.parse(ref.ref.drop(2)).toEither.fold(
+        case ref: LinkPathReference if ref.path.toString.startsWith("@:") =>
+          linkParser.parse(ref.path.toString.drop(2)).toEither.fold(
             err => Replace(InvalidSpan(s"Invalid link directive: $err", ref.source)),
             res => Replace(LinkDirectiveResolver(ref, res._1, res._2, ref.source, ref.options))
           )

--- a/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
@@ -528,7 +528,7 @@ class SpanDirectiveAPISpec extends FunSuite with TestSourceBuilders with RenderP
 
   test("link directive inside a native link expression") {
     new LinkParser with LinkDirectiveSetup {
-      val input = "aa [RFC-222][@:rfc(222)] bb"
+      val input = "aa [RFC-222](@:rfc(222)) bb"
       assertEquals(
         parseAsMarkdown(input),
         Right(
@@ -544,13 +544,13 @@ class SpanDirectiveAPISpec extends FunSuite with TestSourceBuilders with RenderP
 
   test("unknown link directive") {
     new LinkParser with LinkDirectiveSetup {
-      val input = "aa [RFC-222][@:rfx(222)] bb"
+      val input = "aa [RFC-222](@:rfx(222)) bb"
       assertEquals(
         parseAsMarkdown(input),
         Right(
           Paragraph(
             Text("aa "),
-            invalid("[RFC-222][@:rfx(222)]", "Unknown link directive: rfx", defaultPath),
+            invalid("[RFC-222](@:rfx(222))", "Unknown link directive: rfx", defaultPath),
             Text(" bb")
           )
         )
@@ -560,14 +560,14 @@ class SpanDirectiveAPISpec extends FunSuite with TestSourceBuilders with RenderP
 
   test("invalid link directive") {
     new LinkParser with LinkDirectiveSetup {
-      val input = "aa [RFC-222][@:rfc(foo)] bb"
+      val input = "aa [RFC-222](@:rfc(foo)) bb"
       assertEquals(
         parseAsMarkdown(input),
         Right(
           Paragraph(
             Text("aa "),
             invalid(
-              "[RFC-222][@:rfc(foo)]",
+              "[RFC-222](@:rfc(foo))",
               "Invalid link directive: Not a valid RFC id: foo",
               defaultPath
             ),
@@ -580,15 +580,15 @@ class SpanDirectiveAPISpec extends FunSuite with TestSourceBuilders with RenderP
 
   test("invalid link directive syntax") {
     new LinkParser with LinkDirectiveSetup {
-      val input = "aa [RFC-222][@:rfc foo] bb"
+      val input = "aa [RFC-222](@:rfc!foo) bb"
       assertEquals(
         parseAsMarkdown(input),
         Right(
           Paragraph(
             Text("aa "),
             invalid(
-              "[RFC-222][@:rfc foo]",
-              "Invalid link directive: `(' expected but `f` found",
+              "[RFC-222](@:rfc!foo)",
+              "Invalid link directive: `(' expected but `!` found",
               defaultPath
             ),
             Text(" bb")

--- a/core/shared/src/test/scala/laika/directive/std/LinkDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/LinkDirectiveSpec.scala
@@ -47,6 +47,19 @@ class LinkDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts with T
         Right(RootElement(p(Text("aa "), expected, Text(" bb"))))
       )
 
+    def runCustom(
+        directiveInput: String,
+        expected: Span,
+        withoutConfig: Boolean = false
+    ): Unit = {
+      val input =
+        if (withoutConfig) lineInput(directiveInput) else configInput(lineInput(directiveInput))
+      assertEquals(
+        parse(input).map(_.content),
+        Right(RootElement(p(Text("aa "), expected, Text(" bb"))))
+      )
+    }
+
     def runTypeBlock(block: String, expected: Span*): Unit = {
       val input = s"""aa
                      |
@@ -85,6 +98,14 @@ class LinkDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts with T
     Api.runType(
       "def.bar.Baz",
       SpanLink.external("https://default.api/def/bar/Baz.html")("Baz").withStyles("api")
+    )
+  }
+
+  test("api directive - with custom link text in native Markdown link syntax") {
+    Api.runCustom(
+      "[Custom link text](@:api(def.bar.Baz))",
+      SpanLink.external("https://default.api/def/bar/Baz.html")("Custom link text")
+        .withStyles("api")
     )
   }
 
@@ -200,12 +221,33 @@ class LinkDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts with T
         Right(RootElement(p(Text("aa "), expected, Text(" bb"))))
       )
 
+    def runCustom(
+        directiveInput: String,
+        expected: Span,
+        withoutConfig: Boolean = false
+    ): Unit = {
+      val input =
+        if (withoutConfig) lineInput(directiveInput) else configInput(lineInput(directiveInput))
+      assertEquals(
+        parse(input).map(_.content),
+        Right(RootElement(p(Text("aa "), expected, Text(" bb"))))
+      )
+    }
+
   }
 
   test("source directive - span link based on the default base URI") {
     Source.runType(
       "def.bar.Baz",
       SpanLink.external("https://default.source/def/bar/Baz.scala")("Baz").withStyles("source")
+    )
+  }
+
+  test("source directive - with custom link text in native Markdown link syntax") {
+    Source.runCustom(
+      "[Custom link text](@:source(def.bar.Baz))",
+      SpanLink.external("https://default.source/def/bar/Baz.scala")("Custom link text")
+        .withStyles("source")
     )
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,4 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.2")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
-addSbtPlugin("org.planet42" % "laika-sbt" % "0.19.2")
+addSbtPlugin("org.planet42" % "laika-sbt" % "0.19.3")


### PR DESCRIPTION
Addresses the issue reported in #506, but not with the reported syntax, but instead the one actually originally documented.

The reported syntax did piggy-back on exiting id-based linking: `[text][@:api(foo.Bar)]`.
But the reported undesired lower-case transformation of the type name is based on the fact that link ids are normalized early and deferring that step comes with a high risk of regressions for standard links.

Instead this PR implements custom link texts for link directives based on the literal URL syntax of native text markup as these do not undergo any transformations before rendering: `[text](@:api(foo.Bar))`. The syntax is not ideal, due to the double closing parenthesis, but it's the most robust option for now for a feature that is not heavily used.

The third option, using standard directive syntax with nested bodies `@:api(foo.Bar) link text @:@` had to be discarded due to the fact that directives do not support optional bodies for avoiding potentially significant parsing inefficiencies. The only way this syntax could be supported would be with different directive names for links with and without custom link text which feels even less intuitive than the approach chosen now.

Closes #506.