### PR TITLE
introduce some deprecations to help with migrating to 1.x

### DIFF
--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -459,7 +459,7 @@ object DocumentCursor {
       document: Document,
       outputContext: Option[OutputContext] = None
   ): Either[TreeConfigErrors, DocumentCursor] =
-    TreeCursor(DocumentTree(Root, Seq(document)), outputContext)
+    TreeCursor(new DocumentTree(Root, Seq(document)), outputContext)
       .map(apply(document, _, document.config, document.position))
 
   /** Creates a cursor for a document and full context information:

--- a/core/shared/src/main/scala/laika/ast/DocumentTreeBuilder.scala
+++ b/core/shared/src/main/scala/laika/ast/DocumentTreeBuilder.scala
@@ -110,7 +110,7 @@ class DocumentTreeBuilder private[laika] (parts: List[BuilderPart] = Nil) {
       }
     } yield {
       val (title, content) = extract(resolvedContent, titleName)
-      DocumentTree(result.path, content, title, result.templates, treeConfig)
+      new DocumentTree(result.path, content, title, result.templates, treeConfig)
     }
   }
 
@@ -128,7 +128,7 @@ class DocumentTreeBuilder private[laika] (parts: List[BuilderPart] = Nil) {
       case _: MarkupPart     => None
     }
     val (title, content) = extract(allContent, titleName)
-    DocumentTree(result.path, content, title, result.templates, treeConfig)
+    new DocumentTree(result.path, content, title, result.templates, treeConfig)
   }
 
   private def collectStyles(parts: Seq[BuilderPart]): Map[String, StyleDeclarationSet] = parts

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -543,12 +543,22 @@ object DocumentTree
     ] {
   // TODO - simplify for 1.x - signature is required to satisfy mima (companion introduced in 0.19.3)
 
+  @deprecated("use DocumentTree.builder to construct instances", "0.19.4")
+  def apply(
+      path: Path,
+      content: Seq[TreeContent],
+      titleDocument: Option[Document] = None,
+      templates: Seq[TemplateDocument] = Nil,
+      config: Config = Config.empty,
+      position: TreePosition = TreePosition.root
+  ) = new DocumentTree(path, content, titleDocument, templates, config, position)
+
   /** A new, empty builder for constructing a new `DocumentTree`.
     */
   val builder = new DocumentTreeBuilder()
 
   /** An empty `DocumentTree` without any documents, templates or configurations. */
-  val empty: DocumentTree = DocumentTree(Root, Nil)
+  val empty: DocumentTree = new DocumentTree(Root, Nil)
 }
 
 /** Represents the root of a tree of documents. In addition to the recursive structure of documents,

--- a/core/shared/src/main/scala/laika/directive/std/LinkDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/LinkDirectives.scala
@@ -45,7 +45,7 @@ object LinkDirectives {
   private def linkConfig[T](cursor: DocumentCursor): Either[String, LinkConfig] =
     cursor.config
       .getOpt[LinkConfig]
-      .map(_.getOrElse(LinkConfig()))
+      .map(_.getOrElse(LinkConfig.empty))
       .leftMap(_.message)
 
   /** Implementation of the `api` directive that creates links to API documentation based

--- a/core/shared/src/main/scala/laika/rewrite/link/LinkConfig.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/LinkConfig.scala
@@ -26,11 +26,29 @@ case class LinkConfig(
     excludeFromValidation: Seq[Path] = Nil,
     apiLinks: Seq[ApiLinks] = Nil,
     sourceLinks: Seq[SourceLinks] = Nil
-)
+) {
+
+  def addTargets(newTargets: TargetDefinition*): LinkConfig =
+    copy(targets = targets ++ newTargets)
+
+  def addApiLinks(newLinks: ApiLinks*): LinkConfig = copy(apiLinks = apiLinks ++ newLinks)
+
+  def addSourceLinks(newLinks: SourceLinks*): LinkConfig =
+    copy(sourceLinks = sourceLinks ++ newLinks)
+
+}
 
 object LinkConfig {
 
-  val empty: LinkConfig = LinkConfig(Nil, Nil, Nil)
+  @deprecated("use LinkConfig.empty.addXXX(...).addYYY(...)", "0.19.4")
+  def apply(
+      targets: Seq[TargetDefinition] = Nil,
+      excludeFromValidation: Seq[Path] = Nil,
+      apiLinks: Seq[ApiLinks] = Nil,
+      sourceLinks: Seq[SourceLinks] = Nil
+  ) = new LinkConfig(targets, excludeFromValidation, apiLinks, sourceLinks)
+
+  val empty: LinkConfig = new LinkConfig()
 
   implicit val key: DefaultKey[LinkConfig] = DefaultKey(LaikaKeys.links)
 
@@ -44,7 +62,7 @@ object LinkConfig {
       val mappedTargets = targets.map { case (id, targetURL) =>
         TargetDefinition(id, Target.parse(targetURL))
       }
-      LinkConfig(mappedTargets.toSeq, exclude, apiLinks, sourceLinks)
+      new LinkConfig(mappedTargets.toSeq, exclude, apiLinks, sourceLinks)
     }
   }
 

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -46,6 +46,9 @@ import laika.parse.GeneratedSource
 import laika.rewrite.{ OutputContext, TemplateRewriter }
 import munit.FunSuite
 
+import scala.annotation.nowarn
+
+@nowarn("cat=deprecation")
 class DocumentTreeAPISpec extends FunSuite
     with ParagraphCompanionShortcuts
     with MunitDocumentTreeAssertions

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeBuilderSpec.scala
@@ -5,6 +5,9 @@ import laika.config.Origin.TreeScope
 import laika.config.{ ConfigBuilder, Origin }
 import munit.FunSuite
 
+import scala.annotation.nowarn
+
+@nowarn("cat=deprecation")
 class DocumentTreeBuilderSpec extends FunSuite {
 
   test("empty tree") {

--- a/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
@@ -34,6 +34,7 @@ import laika.time.PlatformDateTime
 import munit.FunSuite
 
 import java.net.URI
+import scala.annotation.nowarn
 
 /** @author Jens Halm
   */
@@ -178,7 +179,7 @@ class ConfigCodecSpec extends FunSuite {
 
     def sort(config: LinkConfig): LinkConfig = config.copy(targets = config.targets.sortBy(_.id))
 
-    val fullyPopulatedInstance = LinkConfig(
+    val fullyPopulatedInstance = new LinkConfig(
       Seq(
         TargetDefinition("bar", InternalTarget(CurrentTree / "bar")),
         TargetDefinition("ext", ExternalTarget("http://ext.com")),
@@ -239,10 +240,9 @@ class ConfigCodecSpec extends FunSuite {
       """.stripMargin
     decode[LinkConfig](
       input,
-      LinkConfig(
-        targets = Seq(TargetDefinition("foo", InternalTarget(CurrentTree / "foo"))),
-        apiLinks = Seq(ApiLinks("https://bar.api/"))
-      ),
+      LinkConfig.empty
+        .addTargets(TargetDefinition("foo", InternalTarget(CurrentTree / "foo")))
+        .addApiLinks(ApiLinks("https://bar.api/")),
       links.sort
     )
   }

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -333,12 +333,10 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
     private val linkTarget = RootElement(InternalLinkTarget(Id("ref")))
 
-    private val linkConfig = LinkConfig(targets =
-      Seq(
-        TargetDefinition("int", InternalTarget(RelativePath.parse("../doc-1.md#ref"))),
-        TargetDefinition("ext", ExternalTarget("https://www.foo.com/")),
-        TargetDefinition("inv", InternalTarget(RelativePath.parse("../doc-99.md#ref")))
-      )
+    private val linkConfig = LinkConfig.empty.addTargets(
+      TargetDefinition("int", InternalTarget(RelativePath.parse("../doc-1.md#ref"))),
+      TargetDefinition("ext", ExternalTarget("https://www.foo.com/")),
+      TargetDefinition("inv", InternalTarget(RelativePath.parse("../doc-99.md#ref")))
     )
 
     def run(ref: LinkIdReference, expected: Block): Unit = {

--- a/docs/src/02-running-laika/01-sbt-plugin.md
+++ b/docs/src/02-running-laika/01-sbt-plugin.md
@@ -181,7 +181,7 @@ You can either use `cmd-S` to manually force saving or change the preferences to
 ### Preview of the Document AST
 
 Introduced in version 0.19.4 the preview server can now also render the document AST for any markup source document.
-Simply append the `/ast` path element to your URL, e.g. `localhost:4242/my-docs/intro.md/ast`. 
+Simply append the `/ast` path element to your URL, e.g. `localhost:4242/my-docs/intro.html/ast`. 
 Note that this does not prevent you from using `/ast` as an actual path segment in your site,
 the server will be able to distinguish those.
 

--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -739,7 +739,7 @@ in the generated site.
 ### Preview of the Document AST
 
 Introduced in version 0.19.4 the preview server can now also render the document AST for any markup source document.
-Simply append the `/ast` path element to your URL, e.g. `localhost:4242/my-docs/intro.md/ast`.
+Simply append the `/ast` path element to your URL, e.g. `localhost:4242/my-docs/intro.html/ast`.
 Note that this does not prevent you from using `/ast` as an actual path segment in your site,
 the server will be able to distinguish those.
 

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -96,6 +96,9 @@ private[helium] trait CommonConfigOps {
     *
     * When using this method, all default fonts of the Helium theme will be de-registered.
     */
+  def addFontResources(defn: FontDefinition*): Helium = fontResources(defn: _*)
+
+  @deprecated("use addFontResources", "0.19.4")
   def fontResources(defn: FontDefinition*): Helium
 
   /** Specifies which font family to use for the body text, for headlines

--- a/io/src/main/scala/laika/io/descriptor/TransformerDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/TransformerDescriptor.scala
@@ -90,7 +90,7 @@ object TransformerDescriptor {
       TreeRenderer.Op(
         op.renderer,
         op.theme,
-        DocumentTreeRoot(DocumentTree(Root, Nil)),
+        DocumentTreeRoot(DocumentTree.empty),
         op.output,
         Nil
       )
@@ -103,7 +103,7 @@ object TransformerDescriptor {
       BinaryTreeRenderer.Op(
         op.renderer,
         op.theme,
-        DocumentTreeRoot(DocumentTree(Root, Nil)),
+        DocumentTreeRoot(DocumentTree.empty),
         op.output,
         Nil
       )

--- a/io/src/main/scala/laika/io/runtime/TreeResultBuilder.scala
+++ b/io/src/main/scala/laika/io/runtime/TreeResultBuilder.scala
@@ -158,7 +158,7 @@ object TreeResultBuilder {
       }
       title = resolvedContent.collectFirst { case d: Document if isTitleDoc(titleName)(d) => d }
     } yield {
-      DocumentTree(
+      new DocumentTree(
         result.path,
         resolvedContent.filterNot(isTitleDoc(titleName)),
         title,

--- a/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
@@ -42,7 +42,9 @@ import laika.io.model.{ FileFilter, FilePath, InputTree, InputTreeBuilder }
 import munit.CatsEffectSuite
 
 import java.io.ByteArrayInputStream
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 class TreeParserFileIOSpec
     extends CatsEffectSuite
     with ParserSetup

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -41,6 +41,9 @@ import laika.rewrite.{ DefaultTemplatePath, OutputContext, Version, Versions }
 import laika.theme.Theme
 import munit.CatsEffectSuite
 
+import scala.annotation.nowarn
+
+@nowarn("cat=deprecation")
 class TreeParserSpec
     extends CatsEffectSuite
     with ParagraphCompanionShortcuts

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -51,8 +51,10 @@ import laika.rewrite.nav.{ NoOpPathTranslator, PrettyURLs, TargetFormats }
 import laika.rewrite.{ DefaultTemplatePath, OutputContext, Version, VersionScannerConfig, Versions }
 import munit.CatsEffectSuite
 
+import scala.annotation.nowarn
 import scala.io.Codec
 
+@nowarn("cat=deprecation")
 class TreeRendererSpec extends CatsEffectSuite
     with ParagraphCompanionShortcuts
     with FileIO

--- a/sbt/src/main/scala/laika/sbt/LaikaConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaConfig.scala
@@ -40,6 +40,9 @@ case class LaikaConfig(
 
   /** The file encoding to use for input and output files.
     */
+  def withEncoding(codec: Codec): LaikaConfig = copy(encoding = codec)
+
+  @deprecated("use withEncoding", "0.19.4")
   def encoding(codec: Codec): LaikaConfig = copy(encoding = codec)
 
   /**  Turns strict mode on for the target parser, switching off any features not part of the original markup syntax.


### PR DESCRIPTION
This PR only covers a small subset of the most commonly used APIs which tend to be used in basic build configuration, 1.x changes in lower-level APIs are too much effort to cover. In other words, this PR helps end users, but not so much extension developers.

List of new deprecations (all other deprecations introduced during the 0.19 lifespan should be addressed, too, before attempting to migrate to 1.x):

* `LaikaConfig.encoding` -> `.withEncoding`
* `Helium.site/all/epub/pdf.fontResources` -> `.addFontResources`
* `LinkConfig.apply` -> `LinkConfig.empty.addXXX(...).addYYY(...)`
* `DocumentTree.apply` -> `DocumentTree.builder.addXXX(...).addYYY(...)`