### PR TITLE
fix perfomance regression in preview server bootstrapping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import com.typesafe.tools.mima.core.{ ProblemFilters, DirectMissingMethodProblem
 import Dependencies._
 
 lazy val basicSettings = Seq(
-  version              := "0.19.4",
+  version              := "0.19.5-SNAPSHOT",
   homepage             := Some(new URL("https://typelevel.org/Laika/")),
   organization         := "org.planet42",
   organizationHomepage := Some(new URL("http://typelevel.org")),

--- a/preview/src/main/scala/laika/preview/ASTPageTransformer.scala
+++ b/preview/src/main/scala/laika/preview/ASTPageTransformer.scala
@@ -25,6 +25,7 @@ import laika.ast.{
   CodeBlock,
   Document,
   DocumentTreeRoot,
+  Path,
   RewritePhase,
   RootElement,
   Section,
@@ -47,14 +48,16 @@ private[preview] object ASTPageTransformer {
     val description: String           = "AST URL extension for preview server"
     private val outputName            = "ast"
 
+    def translateASTPath(path: Path): Path = {
+      val base = path.withoutFragment / outputName
+      path.fragment.fold(base)(base.withFragment)
+    }
+
     override def extendPathTranslator
         : PartialFunction[ExtensionBundle.PathTranslatorExtensionContext, PathTranslator] = {
       case context =>
         PathTranslator.postTranslate(context.baseTranslator) { path =>
-          if (path.suffix.contains("html")) {
-            val base = path.withoutFragment / outputName
-            path.fragment.fold(base)(base.withFragment)
-          }
+          if (path.suffix.contains("html")) translateASTPath(path)
           else path
         }
     }

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -18,6 +18,7 @@ package laika.preview
 
 import cats.effect.{ Async, Resource }
 import cats.syntax.all._
+import cats.effect.syntax.all._
 import fs2.Chunk
 import laika.api.Renderer
 import laika.api.builder.OperationConfig
@@ -96,13 +97,27 @@ private[preview] class SiteTransformer[F[_]: Async](
       }
   }
 
+  private def buildLazyMap(
+      htmlMap: ResultMap[F],
+      delegate: F[ResultMap[F]]
+  ): ResultMap[F] = {
+    htmlMap.keySet
+      .map(ASTPageTransformer.ASTPathTranslator.translateASTPath)
+      .map { astPath =>
+        val result = LazyResult(delegate.map(_.get(astPath)))
+        (astPath, result: SiteResult[F])
+      }
+      .toMap
+  }
+
   val transform: F[SiteResults[F]] = for {
-    tree   <- parse
-    html   <- transformHTML(tree, htmlRenderer)
-    ast    <- transformHTML(
+    tree    <- parse
+    html    <- transformHTML(tree, htmlRenderer)
+    lazyAST <- transformHTML(
       tree.modifyRoot(ASTPageTransformer.transform(_, parser.config)),
       astRenderer
-    )
+    ).memoize
+    ast = buildLazyMap(html, lazyAST)
     ebooks <- Async[F].fromEither(transformBinaries(tree).leftMap(ConfigException.apply))
   } yield {
     new SiteResults(staticFiles ++ ast ++ html ++ ebooks)
@@ -197,3 +212,6 @@ class SiteResults[F[_]: Async](map: Map[Path, SiteResult[F]]) {
 sealed abstract class SiteResult[F[_]: Async]                      extends Product with Serializable
 case class RenderedResult[F[_]: Async](content: String)            extends SiteResult[F]
 case class StaticResult[F[_]: Async](content: fs2.Stream[F, Byte]) extends SiteResult[F]
+
+private[preview] case class LazyResult[F[_]: Async](result: F[Option[SiteResult[F]]])
+    extends SiteResult[F]


### PR DESCRIPTION
The AST rendering capability introduced in 0.19.4 triggered the initialisation of the new feature eagerly during bootstrap causing significantly longer boot times, depending on input size. 

This PR makes AST rendering lazy, so that the speed tax is only payed (once) when actually accessing an AST page for the first time. Given that many users will probably not use this functionality, it's essential that it does not affect boot times.