### PR TITLE
tweak MarkupFormat API to encourage public declarations for top-level parsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -76,7 +76,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
@@ -134,7 +134,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -162,7 +162,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Download target directories (2.12, rootJS)
         uses: actions/download-artifact@v3
@@ -263,10 +263,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (fast)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup Java (temurin@11)
+        id: setup-java-temurin-11
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
 
       - uses: coursier/setup-action@v1
         with:

--- a/core/shared/src/main/scala/laika/factory/MarkupFormat.scala
+++ b/core/shared/src/main/scala/laika/factory/MarkupFormat.scala
@@ -98,6 +98,8 @@ object MarkupFormat {
     * private and only offer high level entry points for extension authors.
     */
   trait MarkupParsers[E] {
+
+    /** List of parsers to register with the runtime for a specific markup format. */
     def all: Seq[E]
   }
 

--- a/core/shared/src/main/scala/laika/factory/MarkupFormat.scala
+++ b/core/shared/src/main/scala/laika/factory/MarkupFormat.scala
@@ -99,7 +99,11 @@ object MarkupFormat {
     */
   trait MarkupParsers[E] {
 
-    /** List of parsers to register with the runtime for a specific markup format. */
+    /** List of parsers to register with the runtime for a specific markup format.
+      *
+      * The order of parsers in this sequence is significant and determines
+      * the precedence in which parsers are tried on blocks or spans.
+      */
     def all: Seq[E]
   }
 

--- a/core/shared/src/main/scala/laika/factory/MarkupFormat.scala
+++ b/core/shared/src/main/scala/laika/factory/MarkupFormat.scala
@@ -18,6 +18,7 @@ package laika.factory
 
 import laika.ast.Block
 import laika.bundle.{ BlockParserBuilder, ExtensionBundle, SpanParserBuilder }
+import laika.factory.MarkupFormat.MarkupParsers
 import laika.parse.Parser
 import laika.parse.combinator.Parsers
 import laika.parse.text.TextParsers
@@ -42,11 +43,11 @@ trait MarkupFormat extends Format {
 
   /** All block parsers for the markup language this parser processes.
     */
-  def blockParsers: Seq[BlockParserBuilder]
+  def blockParsers: MarkupParsers[BlockParserBuilder]
 
   /** All span parsers for the markup language this parser processes.
     */
-  def spanParsers: Seq[SpanParserBuilder]
+  def spanParsers: MarkupParsers[SpanParserBuilder]
 
   /** Parses the character after the one that started the escape sequence (usually a backslash).
     *
@@ -78,5 +79,26 @@ trait MarkupFormat extends Format {
     */
   def createBlockListParser(parser: Parser[Block]): Parser[Seq[Block]] =
     (parser <~ Parsers.opt(TextParsers.blankLines)).rep
+
+}
+
+object MarkupFormat {
+
+  /** API for registering parsers for a specific markup format.
+    *
+    * The only abstract method is `all` that specifies the list of parsers
+    * to register with Laika's parser runtime.
+    *
+    * But parser authors are encouraged to use this type for also creating
+    * public properties for each of their individual parsers so that users
+    * can compose them for custom formats or parser extensions.
+    *
+    * The type of these properties should be either `BlockParserBuilder` or
+    * `SpanParserBuilder` which allows to keep all parser implementation details
+    * private and only offer high level entry points for extension authors.
+    */
+  trait MarkupParsers[E] {
+    def all: Seq[E]
+  }
 
 }

--- a/core/shared/src/main/scala/laika/format/Markdown.scala
+++ b/core/shared/src/main/scala/laika/format/Markdown.scala
@@ -26,7 +26,7 @@ import laika.parse.Parser
 import laika.parse.text.{ CharGroup, TextParsers }
 
 /** A parser for Markdown text. Instances of this class may be passed directly
-  *  to the `Parser` or `Transformer` APIs:
+  * to the `Parser` or `Transformer` APIs:
   *
   *  {{{
   *  val document = MarkupParser.of(Markdown).build.parse(inputString)
@@ -58,34 +58,111 @@ case object Markdown extends MarkupFormat {
 
   val fileSuffixes: Set[String] = Set("md", "markdown")
 
-  val blockParsers: MarkupParsers[BlockParserBuilder] = new MarkupParsers[BlockParserBuilder] {
+  object blockParsers extends MarkupParsers[BlockParserBuilder] {
 
-    val all = Seq(
-      BlockParsers.atxHeader.interruptsParagraphWith(TextParsers.oneOf('#')),
-      BlockParsers.linkTarget,
-      BlockParsers.quotedBlock,
-      BlockParsers.rootHeaderOrParagraph,
-      BlockParsers.nestedHeaderOrParagraph,
+    /** Parses an ATX header, a line that starts with 1 to 6 `'#'` characters,
+      * with the number of hash characters corresponding to the level of the header.
+      * Markdown also allows to decorate the line with trailing `'#'` characters which
+      * this parser will remove.
+      */
+    val atxHeader: BlockParserBuilder = BlockParsers.atxHeader
+
+    /** Parses either a setext header, or a plain paragraph if the second line of the block
+      * is not a setext header decoration.
+      * Only used for root level blocks where lists starting in the middle of a paragraph are not allowed.
+      */
+    lazy val rootHeaderOrParagraph: BlockParserBuilder = BlockParsers.rootHeaderOrParagraph
+
+    /** Parses either a setext header, or a plain paragraph if the second line of the block
+      * is not a setext header decoration.
+      * Only used for nested blocks where lists starting in the middle of a paragraph are allowed.
+      */
+    lazy val nestedHeaderOrParagraph: BlockParserBuilder = BlockParsers.nestedHeaderOrParagraph
+
+    /** Parses a bullet list, called "unordered list" in the Markdown syntax description.
+      */
+    val bulletList: BlockParserBuilder = ListParsers.bulletLists
+
+    /** Parses an enumerated list, called "ordered list" in the Markdown syntax description.
+      */
+    val enumList: BlockParserBuilder = ListParsers.enumLists
+
+    /** Parses a quoted block, a paragraph starting with a `'>'` character,
+      * with subsequent lines optionally starting with a `'>'`, too.
+      */
+    val quotedBlock: BlockParserBuilder = BlockParsers.quotedBlock
+
+    /** Parses a literal block, text indented by a tab or 4 spaces.
+      */
+    val literalBlock: BlockParserBuilder = BlockParsers.literalBlocks
+
+    /** Parses a link definition in the form `[id]: <url> "title"`.
+      * The title is optional as well as the quotes around it and the angle brackets around the url.
+      */
+    val linkTarget: BlockParserBuilder = BlockParsers.linkTarget
+
+    /** Parses a horizontal rule, a line only decorated with three or more `'*'`, `'-'` or `'_'`
+      * characters with optional spaces between them
+      */
+    val rule: BlockParserBuilder = BlockParsers.rules
+
+    val all: Seq[BlockParserBuilder] = Seq(
+      atxHeader.interruptsParagraphWith(TextParsers.oneOf('#')),
+      linkTarget,
+      quotedBlock,
+      rootHeaderOrParagraph,
+      nestedHeaderOrParagraph,
       BlockParsers.fallbackParagraph,
-      BlockParsers.literalBlocks,
-      BlockParsers.rules,
-      ListParsers.enumLists.rootOnly,
-      ListParsers.enumLists.nestedOnly.interruptsParagraphWith(TextParsers.oneOf(CharGroup.digit)),
-      ListParsers.bulletLists.interruptsParagraphWith(TextParsers.oneOf('+', '*', '-'))
+      literalBlock,
+      rule,
+      enumList.rootOnly,
+      enumList.nestedOnly.interruptsParagraphWith(TextParsers.oneOf(CharGroup.digit)),
+      bulletList.interruptsParagraphWith(TextParsers.oneOf('+', '*', '-'))
     )
 
   }
 
-  val spanParsers: MarkupParsers[SpanParserBuilder] = new MarkupParsers[SpanParserBuilder] {
+  object spanParsers extends MarkupParsers[SpanParserBuilder] {
 
-    val all = Seq(
-      InlineParsers.enclosedByAsterisk,
-      InlineParsers.enclosedByUnderscore,
-      InlineParsers.literalSpan,
-      InlineParsers.image,
-      InlineParsers.link,
-      InlineParsers.simpleLink,
-      InlineParsers.lineBreak
+    /** Parses either strong spans enclosed in double asterisks or emphasized spans enclosed in single asterisks.
+      */
+    val enclosedByAsterisk: SpanParserBuilder = InlineParsers.enclosedByAsterisk
+
+    /** Parses either strong spans enclosed in double underscores or emphasized spans enclosed in single underscores.
+      */
+    val enclosedByUnderscore: SpanParserBuilder = InlineParsers.enclosedByUnderscore
+
+    /** Parses a link, including nested spans in the link text.
+      * Recognizes both, an inline link `[text](url)` and a link reference `[text][id]`.
+      */
+    lazy val link: SpanParserBuilder = InlineParsers.link
+
+    /** Parses a simple inline link in the form of &lt;http://someURL/&gt;
+      */
+    val simpleLink: SpanParserBuilder = InlineParsers.simpleLink
+
+    /** Parses a literal span enclosed by one or more backticks.
+      * Does neither parse nested spans nor Markdown escapes.
+      */
+    val literalSpan: SpanParserBuilder = InlineParsers.literalSpan
+
+    /** Parses an inline image.
+      * Recognizes both, an inline image `![text](url)` and an image reference `![text][id]`.
+      */
+    val image: SpanParserBuilder = InlineParsers.image
+
+    /** Parses an explicit hard line break.
+      */
+    val lineBreak: SpanParserBuilder = InlineParsers.lineBreak
+
+    val all: Seq[SpanParserBuilder] = Seq(
+      enclosedByAsterisk,
+      enclosedByUnderscore,
+      literalSpan,
+      image,
+      link,
+      simpleLink,
+      lineBreak
     )
 
   }

--- a/core/shared/src/main/scala/laika/format/Markdown.scala
+++ b/core/shared/src/main/scala/laika/format/Markdown.scala
@@ -19,6 +19,7 @@ package laika.format
 import laika.ast.Block
 import laika.bundle.{ BlockParserBuilder, ExtensionBundle, SpanParserBuilder }
 import laika.factory.MarkupFormat
+import laika.factory.MarkupFormat.MarkupParsers
 import laika.markdown.bundle.VerbatimHTML
 import laika.markdown.{ BlockParsers, InlineParsers, ListParsers }
 import laika.parse.Parser
@@ -57,29 +58,37 @@ case object Markdown extends MarkupFormat {
 
   val fileSuffixes: Set[String] = Set("md", "markdown")
 
-  val blockParsers: Seq[BlockParserBuilder] = Seq(
-    BlockParsers.atxHeader.interruptsParagraphWith(TextParsers.oneOf('#')),
-    BlockParsers.linkTarget,
-    BlockParsers.quotedBlock,
-    BlockParsers.rootHeaderOrParagraph,
-    BlockParsers.nestedHeaderOrParagraph,
-    BlockParsers.fallbackParagraph,
-    BlockParsers.literalBlocks,
-    BlockParsers.rules,
-    ListParsers.enumLists.rootOnly,
-    ListParsers.enumLists.nestedOnly.interruptsParagraphWith(TextParsers.oneOf(CharGroup.digit)),
-    ListParsers.bulletLists.interruptsParagraphWith(TextParsers.oneOf('+', '*', '-'))
-  )
+  val blockParsers: MarkupParsers[BlockParserBuilder] = new MarkupParsers[BlockParserBuilder] {
 
-  val spanParsers: Seq[SpanParserBuilder] = Seq(
-    InlineParsers.enclosedByAsterisk,
-    InlineParsers.enclosedByUnderscore,
-    InlineParsers.literalSpan,
-    InlineParsers.image,
-    InlineParsers.link,
-    InlineParsers.simpleLink,
-    InlineParsers.lineBreak
-  )
+    val all = Seq(
+      BlockParsers.atxHeader.interruptsParagraphWith(TextParsers.oneOf('#')),
+      BlockParsers.linkTarget,
+      BlockParsers.quotedBlock,
+      BlockParsers.rootHeaderOrParagraph,
+      BlockParsers.nestedHeaderOrParagraph,
+      BlockParsers.fallbackParagraph,
+      BlockParsers.literalBlocks,
+      BlockParsers.rules,
+      ListParsers.enumLists.rootOnly,
+      ListParsers.enumLists.nestedOnly.interruptsParagraphWith(TextParsers.oneOf(CharGroup.digit)),
+      ListParsers.bulletLists.interruptsParagraphWith(TextParsers.oneOf('+', '*', '-'))
+    )
+
+  }
+
+  val spanParsers: MarkupParsers[SpanParserBuilder] = new MarkupParsers[SpanParserBuilder] {
+
+    val all = Seq(
+      InlineParsers.enclosedByAsterisk,
+      InlineParsers.enclosedByUnderscore,
+      InlineParsers.literalSpan,
+      InlineParsers.image,
+      InlineParsers.link,
+      InlineParsers.simpleLink,
+      InlineParsers.lineBreak
+    )
+
+  }
 
   override lazy val escapedChar: Parser[String] = InlineParsers.escapedChar
 

--- a/core/shared/src/main/scala/laika/format/ReStructuredText.scala
+++ b/core/shared/src/main/scala/laika/format/ReStructuredText.scala
@@ -56,44 +56,216 @@ case object ReStructuredText extends MarkupFormat { self =>
 
   val fileSuffixes: Set[String] = Set("rest", "rst")
 
-  val blockParsers: MarkupParsers[BlockParserBuilder] = new MarkupParsers[BlockParserBuilder] {
+  object blockParsers extends MarkupParsers[BlockParserBuilder] {
 
-    val all = Seq(
-      ListParsers.bulletList,
-      ListParsers.enumList,
-      ListParsers.fieldList,
-      ListParsers.lineBlock,
-      ListParsers.optionList,
-      ExplicitBlockParsers.allBlocks,
-      ExplicitBlockParsers.shortAnonymousLinkTarget,
-      TableParsers.gridTable,
-      TableParsers.simpleTable,
-      BlockParsers.doctest,
-      BlockParsers.blockQuote,
-      BlockParsers.headerWithOverline,
-      BlockParsers.transition,
-      BlockParsers.headerWithUnderline,
-      ListParsers.definitionList,
-      BlockParsers.paragraph
+    /** Parses a bullet list with any of the supported bullet characters.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#bullet-lists]].
+      */
+    lazy val bulletList: BlockParserBuilder = ListParsers.bulletList
+
+    /** Parses an enumerated list in any of the supported combinations of enumeration style and formatting.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#enumerated-lists]].
+      */
+    lazy val enumList: BlockParserBuilder = ListParsers.enumList
+
+    /** Parses a field list.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists]].
+      */
+    lazy val fieldList: BlockParserBuilder = ListParsers.fieldList
+
+    /** Parses a definition list.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#definition-lists]].
+      */
+    lazy val definitionList: BlockParserBuilder = ListParsers.definitionList
+
+    /** Parses an option list.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#option-lists]].
+      */
+    lazy val optionList: BlockParserBuilder = ListParsers.optionList
+
+    /** Parses a block of lines with line breaks preserved.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#line-blocks]].
+      */
+    lazy val lineBlock: BlockParserBuilder = ListParsers.lineBlock
+
+    /** Parses a grid table.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables]].
+      */
+    lazy val gridTable: BlockParserBuilder = TableParsers.gridTable
+
+    /** Parses a simple table.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables]].
+      */
+    lazy val simpleTable: BlockParserBuilder = TableParsers.simpleTable
+
+    /** Parses a block quote with an optional attribution.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#block-quotes]]
+      */
+    lazy val blockQuote: BlockParserBuilder = BlockParsers.blockQuote
+
+    /** Parses a section header with both overline and underline.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections]].
+      */
+    lazy val headerWithOverline: BlockParserBuilder = BlockParsers.headerWithOverline
+
+    /** Parses a section header with an underline, but no overline.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections]].
+      */
+    lazy val headerWithUnderline: BlockParserBuilder = BlockParsers.headerWithUnderline
+
+    /** Parses a transition (rule).
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#transitions]].
+      */
+    val transition: BlockParserBuilder = BlockParsers.transition
+
+    /** Parses a doctest block.
+      * This is a feature which is very specific to the world of Python where reStructuredText originates.
+      * Therefore the resulting `DoctestBlock` tree element is not part of the standard Laika AST model.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#doctest-blocks]]
+      */
+    val doctest: BlockParserBuilder = BlockParsers.doctest
+
+    /** The parser builder for all explicit block items that start with `..` except
+      * for directives which are provided by an extension.
+      */
+    val explicitBlocks: BlockParserBuilder = ExplicitBlockParsers.allBlocks
+
+    /** Parses the short variant of an anonymous link definition
+      * (that starts with `__` instead of `.. __:`)
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks]].
+      */
+    lazy val shortAnonymousLinkTarget: BlockParserBuilder =
+      ExplicitBlockParsers.shortAnonymousLinkTarget
+
+    /** Parses a single paragraph.
+      * Everything between two blank lines that is not recognized
+      * as a special reStructuredText block type will be parsed as a regular paragraph.
+      */
+    lazy val paragraph: BlockParserBuilder = BlockParsers.paragraph
+
+    val all: Seq[BlockParserBuilder] = Seq(
+      bulletList,
+      enumList,
+      fieldList,
+      lineBlock,
+      optionList,
+      explicitBlocks,
+      shortAnonymousLinkTarget,
+      gridTable,
+      simpleTable,
+      doctest,
+      blockQuote,
+      headerWithOverline,
+      transition,
+      headerWithUnderline,
+      definitionList,
+      paragraph
     )
 
   }
 
-  val spanParsers: MarkupParsers[SpanParserBuilder] = new MarkupParsers[SpanParserBuilder] {
+  object spanParsers extends MarkupParsers[SpanParserBuilder] {
 
-    val all = Seq(
-      InlineParsers.strong,
-      InlineParsers.em,
-      InlineParsers.inlineLiteral,
-      InlineParsers.phraseLinkRef,
-      InlineParsers.simpleLinkRef,
-      InlineParsers.footnoteRef,
-      InlineParsers.citationRef,
-      InlineParsers.substitutionRef,
-      InlineParsers.internalTarget,
-      InlineParsers.interpretedTextWithRolePrefix,
-      InlineParsers.uri,
-      InlineParsers.email
+    /** Parses a span of text with strong emphasis.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#strong-emphasis]]
+      */
+    lazy val strong: SpanParserBuilder = InlineParsers.strong
+
+    /** Parses a span of emphasized text.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#emphasis]]
+      */
+    lazy val em: SpanParserBuilder = InlineParsers.em
+
+    /** Parses an inline literal element.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-literals]].
+      */
+    lazy val inlineLiteral: SpanParserBuilder = InlineParsers.inlineLiteral
+
+    /** Parses a phrase link reference (enclosed in back ticks).
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-references]]
+      */
+    lazy val phraseLinkRef: SpanParserBuilder = InlineParsers.phraseLinkRef
+
+    /** Parses a simple link reference.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-references]]
+      */
+    lazy val simpleLinkRef: SpanParserBuilder = InlineParsers.simpleLinkRef
+
+    /** Parses a footnote reference.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#footnote-references]].
+      */
+    lazy val footnoteRef: SpanParserBuilder = InlineParsers.footnoteRef
+
+    /** Parses a citation reference.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#citation-references]].
+      */
+    lazy val citationRef: SpanParserBuilder = InlineParsers.citationRef
+
+    /** Parses a substitution reference.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#substitution-references]].
+      */
+    lazy val substitutionRef: SpanParserBuilder = InlineParsers.substitutionRef
+
+    /** Parses an inline internal link target.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-internal-targets]]
+      */
+    lazy val internalTarget: SpanParserBuilder = InlineParsers.internalTarget
+
+    /** Parses an interpreted text element with the role name as a prefix.
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#interpreted-text]]
+      */
+    lazy val interpretedTextWithRolePrefix: SpanParserBuilder =
+      InlineParsers.interpretedTextWithRolePrefix
+
+    /** Parses a standalone HTTP or HTTPS hyperlink (with no surrounding markup).
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks]]
+      */
+    lazy val uri: SpanParserBuilder = InlineParsers.uri
+
+    /** Parses a standalone email address (with no surrounding markup).
+      *
+      * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks]]
+      */
+    lazy val email: SpanParserBuilder = InlineParsers.email
+
+    val all: Seq[SpanParserBuilder] = Seq(
+      strong,
+      em,
+      inlineLiteral,
+      phraseLinkRef,
+      simpleLinkRef,
+      footnoteRef,
+      citationRef,
+      substitutionRef,
+      internalTarget,
+      interpretedTextWithRolePrefix,
+      uri,
+      email
     )
 
   }

--- a/core/shared/src/main/scala/laika/format/ReStructuredText.scala
+++ b/core/shared/src/main/scala/laika/format/ReStructuredText.scala
@@ -17,12 +17,20 @@
 package laika.format
 
 import laika.ast.Block
-import laika.bundle.{ BundleOrigin, ExtensionBundle, ParserBundle, ParserHooks }
+import laika.bundle.{
+  BlockParserBuilder,
+  BundleOrigin,
+  ExtensionBundle,
+  ParserBundle,
+  ParserHooks,
+  SpanParserBuilder
+}
 import laika.factory.MarkupFormat
+import laika.factory.MarkupFormat.MarkupParsers
 import laika.parse.Parser
 import laika.parse.text.WhitespacePreprocessor
-import laika.rst._
-import laika.rst.bundle._
+import laika.rst.*
+import laika.rst.bundle.*
 
 /** A parser for text written in reStructuredText markup. Instances of this class may be passed directly
   * to the `Parseer` or `Transformer` APIs:
@@ -48,39 +56,47 @@ case object ReStructuredText extends MarkupFormat { self =>
 
   val fileSuffixes: Set[String] = Set("rest", "rst")
 
-  val blockParsers = Seq(
-    ListParsers.bulletList,
-    ListParsers.enumList,
-    ListParsers.fieldList,
-    ListParsers.lineBlock,
-    ListParsers.optionList,
-    ExplicitBlockParsers.allBlocks,
-    ExplicitBlockParsers.shortAnonymousLinkTarget,
-    TableParsers.gridTable,
-    TableParsers.simpleTable,
-    BlockParsers.doctest,
-    BlockParsers.blockQuote,
-    BlockParsers.headerWithOverline,
-    BlockParsers.transition,
-    BlockParsers.headerWithUnderline,
-    ListParsers.definitionList,
-    BlockParsers.paragraph
-  )
+  val blockParsers: MarkupParsers[BlockParserBuilder] = new MarkupParsers[BlockParserBuilder] {
 
-  val spanParsers = Seq(
-    InlineParsers.strong,
-    InlineParsers.em,
-    InlineParsers.inlineLiteral,
-    InlineParsers.phraseLinkRef,
-    InlineParsers.simpleLinkRef,
-    InlineParsers.footnoteRef,
-    InlineParsers.citationRef,
-    InlineParsers.substitutionRef,
-    InlineParsers.internalTarget,
-    InlineParsers.interpretedTextWithRolePrefix,
-    InlineParsers.uri,
-    InlineParsers.email
-  )
+    val all = Seq(
+      ListParsers.bulletList,
+      ListParsers.enumList,
+      ListParsers.fieldList,
+      ListParsers.lineBlock,
+      ListParsers.optionList,
+      ExplicitBlockParsers.allBlocks,
+      ExplicitBlockParsers.shortAnonymousLinkTarget,
+      TableParsers.gridTable,
+      TableParsers.simpleTable,
+      BlockParsers.doctest,
+      BlockParsers.blockQuote,
+      BlockParsers.headerWithOverline,
+      BlockParsers.transition,
+      BlockParsers.headerWithUnderline,
+      ListParsers.definitionList,
+      BlockParsers.paragraph
+    )
+
+  }
+
+  val spanParsers: MarkupParsers[SpanParserBuilder] = new MarkupParsers[SpanParserBuilder] {
+
+    val all = Seq(
+      InlineParsers.strong,
+      InlineParsers.em,
+      InlineParsers.inlineLiteral,
+      InlineParsers.phraseLinkRef,
+      InlineParsers.simpleLinkRef,
+      InlineParsers.footnoteRef,
+      InlineParsers.citationRef,
+      InlineParsers.substitutionRef,
+      InlineParsers.internalTarget,
+      InlineParsers.interpretedTextWithRolePrefix,
+      InlineParsers.uri,
+      InlineParsers.email
+    )
+
+  }
 
   override lazy val escapedChar: Parser[String] = InlineParsers.escapedChar
 
@@ -103,7 +119,7 @@ case object ReStructuredText extends MarkupFormat { self =>
     override val renderOverrides = Seq(HTML.Overrides(value = ExtendedHTMLRenderer.custom))
   }
 
-  val extensions = Seq(
+  val extensions: Seq[ExtensionBundle] = Seq(
     BundledDefaults,
     RstExtensionSupport,
     StandardExtensions,

--- a/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
@@ -47,8 +47,6 @@ private[laika] object InlineParsers {
   val escapedChar: Parser[String] =
     oneOf('\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '#', '+', '-', '.', '!', '>', '|')
 
-  /** Parses an explicit hard line break.
-    */
   val lineBreak: SpanParserBuilder = SpanParserBuilder.standalone(literal("\\\r").as(LineBreak()))
 
   /** Parses a span of strong text enclosed by two consecutive occurrences of the specified character.
@@ -71,8 +69,6 @@ private[laika] object InlineParsers {
       recParsers: RecursiveSpanParsers
   ): PrefixedParser[List[Span]] = start ~> recParsers.recursiveSpans(delimitedBy(end))
 
-  /** Parses either strong spans enclosed in double asterisks or emphasized spans enclosed in single asterisks.
-    */
   val enclosedByAsterisk: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     strong('*') | em('*')
   }
@@ -84,7 +80,7 @@ private[laika] object InlineParsers {
   }
 
   /** Parses a span enclosed by a single occurrence of the specified character.
-    *  Recursively parses nested spans, too.
+    * Recursively parses nested spans, too.
     */
   private def enclosedBySingleChar(
       c: Char
@@ -95,7 +91,7 @@ private[laika] object InlineParsers {
   }
 
   /** Parses a span enclosed by two consecutive occurrences of the specified character.
-    *  Recursively parses nested spans, too.
+    * Recursively parses nested spans, too.
     */
   def enclosedByDoubleChar(
       c: Char
@@ -105,9 +101,6 @@ private[laika] object InlineParsers {
     span(start, end)
   }
 
-  /** Parses a literal span enclosed by one or more backticks.
-    *  Does neither parse nested spans nor Markdown escapes.
-    */
   val literalSpan: SpanParserBuilder = SpanParserBuilder.standalone {
     someOf('`').count >> { cnt =>
       delimitedBy("`" * cnt).trim.map(Literal(_))
@@ -116,9 +109,6 @@ private[laika] object InlineParsers {
 
   private def normalizeId(id: String): String = id.toLowerCase.replaceAll("[\n ]+", " ")
 
-  /** Parses a link, including nested spans in the link text.
-    *  Recognizes both, an inline link `[text](url)` and a link reference `[text][id]`.
-    */
   lazy val link: SpanParserBuilder = SpanParserBuilder.recursive { recParsers =>
     def unwrap(ref: LinkIdReference, suffix: String) = {
       if (ref.select(_.isInstanceOf[LinkIdReference]).tail.nonEmpty)
@@ -150,9 +140,6 @@ private[laika] object InlineParsers {
     }
   }
 
-  /** Parses an inline image.
-    *  Recognizes both, an inline image `![text](url)` and an image reference `![text][id]`.
-    */
   val image: SpanParserBuilder = SpanParserBuilder.recursive { recParsers =>
     def escape(text: LineSource, input: SourceFragment, f: String => Span): Span =
       recParsers.escapedText(DelimitedText.Undelimited).parse(text).toEither.fold(

--- a/core/shared/src/main/scala/laika/markdown/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/ListParsers.scala
@@ -94,8 +94,6 @@ private[laika] object ListParsers {
     }
   }
 
-  /** Parses a bullet list, called "unordered list" in the Markdown syntax description.
-    */
   val bulletLists: BlockParserBuilder =
     BlockParserBuilder.recursive { implicit recParsers =>
       PrefixedParser('+', '*', '-') {
@@ -111,8 +109,6 @@ private[laika] object ListParsers {
       }
     }.withLowPrecedence
 
-  /** Parses an enumerated list, called "ordered list" in the Markdown syntax description.
-    */
   val enumLists: BlockParserBuilder =
     BlockParserBuilder.recursive { implicit recParsers =>
       PrefixedParser(CharGroup.digit) {

--- a/core/shared/src/main/scala/laika/parse/markup/RootParser.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/RootParser.scala
@@ -17,12 +17,12 @@
 package laika.parse.markup
 
 import cats.data.NonEmptySet
-import laika.ast._
-import laika.bundle._
+import laika.ast.*
+import laika.bundle.*
 import laika.factory.MarkupFormat
 import laika.parse.Parser
 import laika.parse.text.PrefixedParser
-import laika.parse.builders._
+import laika.parse.builders.*
 
 import scala.collection.immutable.TreeSet
 
@@ -51,7 +51,7 @@ private[laika] class RootParser(markupParser: MarkupFormat, markupExtensions: Ma
     opt(blankLines) ~> blockList(rootBlock).map(RootElement(_))
 
   private lazy val sortedBlockParsers: Seq[BlockParserDefinition] =
-    createAndSortParsers(markupParser.blockParsers, markupExtensions.blockParsers)
+    createAndSortParsers(markupParser.blockParsers.all, markupExtensions.blockParsers)
 
   protected lazy val rootBlock: Parser[Block] = merge(
     sortedBlockParsers.filter(_.position != BlockPosition.NestedOnly)
@@ -77,7 +77,7 @@ private[laika] class RootParser(markupParser: MarkupFormat, markupExtensions: Ma
 
   protected lazy val spanParsers: Seq[PrefixedParser[Span]] = {
     val escapedText = SpanParserBuilder.standalone(escapeSequence.map(Text(_))).withLowPrecedence
-    val mainParsers = markupParser.spanParsers :+ escapedText
+    val mainParsers = markupParser.spanParsers.all :+ escapedText
 
     createAndSortParsers(mainParsers, markupExtensions.spanParsers).map { parserDef =>
       PrefixedParser(parserDef.startChars)(parserDef.parser)

--- a/core/shared/src/main/scala/laika/rst/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/InlineParsers.scala
@@ -256,18 +256,10 @@ private[laika] object InlineParsers {
       .prevNot(invalidInsideDelimiter)
       .nextNot(invalidAfterEndMarkup)
 
-  /** Parses a span of emphasized text.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#emphasis]]
-    */
   lazy val em: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     span(delimiter('*').prevNot('*'), delimiter("*").nextNot('*')).map(Emphasized(_))
   }.withLowPrecedence
 
-  /** Parses a span of text with strong emphasis.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#strong-emphasis]]
-    */
   lazy val strong: SpanParserBuilder = SpanParserBuilder.recursive { implicit recParsers =>
     val delim = literal("**")
     span(delim, delim).map(Strong(_))
@@ -280,18 +272,10 @@ private[laika] object InlineParsers {
       List(Text(text))
     }
 
-  /** Parses an inline literal element.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-literals]].
-    */
   lazy val inlineLiteral: SpanParserBuilder = SpanParserBuilder.standalone {
     markupStart("``", "``") ~> delimitedBy(markupEnd("``")).map(Literal(_))
   }
 
-  /** Parses a footnote reference.
-    *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#footnote-references]].
-    */
   lazy val footnoteRef: SpanParserBuilder = SpanParserBuilder.standalone {
     (markupStart("[", "]_") ~> footnoteLabel <~ markupEnd("]_")).withCursor.map {
       case (label, source) =>
@@ -299,10 +283,6 @@ private[laika] object InlineParsers {
     }
   }
 
-  /** Parses a citation reference.
-    *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#citation-references]].
-    */
   lazy val citationRef: SpanParserBuilder = SpanParserBuilder.standalone {
     (markupStart("[", "]_") ~> simpleRefName <~ markupEnd("]_")).withCursor.map {
       case (label, source) =>
@@ -310,10 +290,6 @@ private[laika] object InlineParsers {
     }
   }
 
-  /** Parses a substitution reference.
-    *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#substitution-references]].
-    */
   lazy val substitutionRef: SpanParserBuilder = SpanParserBuilder.standalone {
     (markupStart("|", "|") ~> simpleRefName ~ (markupEnd("|__") | markupEnd("|_") | markupEnd("|")))
       .withCursor.map { case (refName ~ endDelim, source) =>
@@ -326,10 +302,6 @@ private[laika] object InlineParsers {
       }
   }
 
-  /** Parses an inline internal link target.
-    *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-internal-targets]]
-    */
   lazy val internalTarget: SpanParserBuilder = SpanParserBuilder.recursive { recParsers =>
     markupStart("_`", "`") ~>
       recParsers.escapedText(delimitedBy(markupEnd("`")).nonEmpty).map { name =>
@@ -338,10 +310,6 @@ private[laika] object InlineParsers {
       }
   }
 
-  /** Parses an interpreted text element with the role name as a prefix.
-    *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#interpreted-text]]
-    */
   lazy val interpretedTextWithRolePrefix: SpanParserBuilder = SpanParserBuilder.recursive {
     recParsers =>
       ((markupStart(":", ":") ~> simpleRefName) ~ (":`" ~> recParsers.escapedText(
@@ -363,10 +331,6 @@ private[laika] object InlineParsers {
       }
     }.withLowPrecedence
 
-  /** Parses a phrase link reference (enclosed in back ticks).
-    *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-references]]
-    */
   lazy val phraseLinkRef: SpanParserBuilder = SpanParserBuilder.recursive { recParsers =>
     def ref(refName: String, url: String) = if (refName.isEmpty) url else refName
     val urlPart = "<" ~> delimitedBy('>').map { _.replaceAll("[ \n]+", "") }
@@ -388,10 +352,6 @@ private[laika] object InlineParsers {
     }
   }
 
-  /** Parses a simple link reference.
-    *
-    *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#hyperlink-references]]
-    */
   lazy val simpleLinkRef: SpanParserBuilder = SpanParserBuilder.standalone {
     markupEnd("__" | "_").withCursor.flatMap { case (delim, source) =>
       reverse(delim.length, simpleRefName <~ nextNot(invalidBeforeStartMarkup)).map { refName =>
@@ -424,16 +384,8 @@ private[laika] object InlineParsers {
     Set('-', ':', '/', '\'', ')', '}', '.', ',', ';', '!', '?')
   )
 
-  /** Parses a standalone HTTP or HTTPS hyperlink (with no surrounding markup).
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks]]
-    */
   lazy val uri: SpanParserBuilder = autoLinks.http
 
-  /** Parses a standalone email address (with no surrounding markup).
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks]]
-    */
   lazy val email: SpanParserBuilder = autoLinks.email
 
 }

--- a/core/shared/src/main/scala/laika/rst/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/ListParsers.scala
@@ -92,10 +92,6 @@ private[laika] object ListParsers {
 
   private lazy val bulletListStart = oneOf('*', '-', '+', '\u2022', '\u2023', '\u2043')
 
-  /** Parses a bullet list with any of the supported bullet characters.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#bullet-lists]].
-    */
   lazy val bulletList: BlockParserBuilder = BlockParserBuilder.recursive { implicit recParsers =>
     lookAhead(bulletListStart <~ ws.min(1)) >> { symbol =>
       val bullet = StringBullet(symbol)
@@ -139,10 +135,6 @@ private[laika] object ListParsers {
     }
   }
 
-  /** Parses an enumerated list in any of the supported combinations of enumeration style and formatting.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#enumerated-lists]].
-    */
   lazy val enumList: BlockParserBuilder = BlockParserBuilder.recursive { implicit recParsers =>
     import EnumType._
 
@@ -182,10 +174,6 @@ private[laika] object ListParsers {
     }
   }
 
-  /** Parses a definition list.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#definition-lists]].
-    */
   lazy val definitionList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val tableStart    = anyOf(' ', '=') ~ eol
     val explicitStart = ".. " | "__ "
@@ -210,10 +198,6 @@ private[laika] object ListParsers {
     (item <~ opt(blankLines)).rep.min(1).map(DefinitionList(_))
   }
 
-  /** Parses a field list.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists]].
-    */
   lazy val fieldList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val nameParser = ":" ~> recParsers.escapedUntil(':').line <~ (lookAhead(eol).as("") | " ")
 
@@ -225,10 +209,6 @@ private[laika] object ListParsers {
     item.rep.min(1).map(FieldList(_))
   }
 
-  /** Parses an option list.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#option-lists]].
-    */
   lazy val optionList: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val optionString = someOf(CharGroup.alphaNum.add('_').add('-'))
     val optionArg    = optionString | ("<" ~> delimitedBy('>')).map { "<" + _ + ">" }
@@ -257,10 +237,6 @@ private[laika] object ListParsers {
     (item <~ opt(blankLines)).rep.min(1).map(OptionList(_))
   }
 
-  /** Parses a block of lines with line breaks preserved.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#line-blocks]].
-    */
   lazy val lineBlock: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val itemStart = oneOf('|')
 

--- a/core/shared/src/main/scala/laika/rst/TableParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/TableParsers.scala
@@ -212,10 +212,6 @@ private[laika] object TableParsers {
     case _               => Nil
   }
 
-  /** Parses a grid table.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables]].
-    */
   lazy val gridTable: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val intersectChar = '+'
     val intersect     = oneOf(intersectChar).as(Intersection)
@@ -307,10 +303,6 @@ private[laika] object TableParsers {
 
   }
 
-  /** Parses a simple table.
-    *
-    * See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables]].
-    */
   lazy val simpleTable: BlockParserBuilder = BlockParserBuilder.recursive { recParsers =>
     val intersect   = someOf(' ').count
     val tableBorder = someOf('=').count

--- a/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
@@ -17,13 +17,20 @@
 package laika.config
 
 import laika.api.builder.OperationConfig
-import laika.ast._
+import laika.ast.*
 import laika.ast.DocumentType.{ Markup, Static, Template }
 import laika.ast.Path.Root
 import laika.bundle.BundleProvider.TestExtensionBundle
 import laika.bundle.ExtensionBundle.LaikaDefaults
-import laika.bundle.{ BundleOrigin, BundleProvider, ExtensionBundle }
+import laika.bundle.{
+  BlockParserBuilder,
+  BundleOrigin,
+  BundleProvider,
+  ExtensionBundle,
+  SpanParserBuilder
+}
 import laika.factory.MarkupFormat
+import laika.factory.MarkupFormat.MarkupParsers
 import laika.markdown.bundle.VerbatimHTML
 import laika.markdown.github.GitHubFlavor
 import munit.FunSuite
@@ -39,8 +46,12 @@ class OperationConfigSpec extends FunSuite {
 
     object Parser extends MarkupFormat {
       val fileSuffixes    = Set("foo")
-      val blockParsers    = Nil
-      val spanParsers     = Nil
+      val blockParsers    = new MarkupParsers[BlockParserBuilder] {
+        val all: Seq[BlockParserBuilder] = Nil
+      }
+      val spanParsers     = new MarkupParsers[SpanParserBuilder] {
+        val all: Seq[SpanParserBuilder] = Nil
+      }
       lazy val extensions = parserBundles
     }
 

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -23,6 +23,7 @@ import laika.ast.*
 import laika.ast.sample.TestSourceBuilders
 import laika.bundle.*
 import laika.factory.MarkupFormat
+import laika.factory.MarkupFormat.MarkupParsers
 import laika.parse.*
 import laika.parse.builders.*
 import laika.parse.combinator.Parsers
@@ -51,8 +52,12 @@ trait ParserSetup {
 
     new MarkupFormat {
       val fileSuffixes    = Set("foo")
-      val blockParsers    = blocks
-      val spanParsers     = spans
+      val blockParsers    = new MarkupParsers[BlockParserBuilder] {
+        val all: Seq[BlockParserBuilder] = blocks
+      }
+      val spanParsers     = new MarkupParsers[SpanParserBuilder] {
+        val all: Seq[SpanParserBuilder] = spans
+      }
       lazy val extensions = bundles
     }
 

--- a/core/shared/src/test/scala/laika/parse/markup/RootParserProvider.scala
+++ b/core/shared/src/test/scala/laika/parse/markup/RootParserProvider.scala
@@ -18,6 +18,7 @@ package laika.parse.markup
 
 import laika.bundle.{ BlockParserBuilder, MarkupExtensions, ParserBundle, SpanParserBuilder }
 import laika.factory.MarkupFormat
+import laika.factory.MarkupFormat.MarkupParsers
 
 /** @author Jens Halm
   */
@@ -34,8 +35,12 @@ object RootParserProvider {
 
     object Parser extends MarkupFormat {
       val fileSuffixes = Set.empty[String]
-      val blockParsers = bp
-      val spanParsers  = sp
+      val blockParsers = new MarkupParsers[BlockParserBuilder] {
+        val all: Seq[BlockParserBuilder] = bp
+      }
+      val spanParsers  = new MarkupParsers[SpanParserBuilder] {
+        val all: Seq[SpanParserBuilder] = sp
+      }
       val extensions   = Seq()
     }
 

--- a/docs/src/05-extending-laika/07-new-markup-output-formats.md
+++ b/docs/src/05-extending-laika/07-new-markup-output-formats.md
@@ -54,14 +54,15 @@ The contract a markup implementation has to adhere to is captured in the followi
 
 ```scala mdoc
 import laika.bundle.{ BlockParserBuilder, ExtensionBundle, SpanParserBuilder }
+import laika.factory.MarkupFormat.MarkupParsers
 
 trait MarkupFormat {
 
   def fileSuffixes: Set[String]
 
-  def blockParsers: Seq[BlockParserBuilder]
+  def blockParsers: MarkupParsers[BlockParserBuilder]
   
-  def spanParsers: Seq[SpanParserBuilder]
+  def spanParsers: MarkupParsers[SpanParserBuilder]
 
   def extensions: Seq[ExtensionBundle]
   
@@ -77,8 +78,12 @@ These are the four abstract method each parser has to implement.
   Laika supports a setup where input directories may contain source files written in different markup languages.
   In this case the format detection is solely based on the file suffix.
 
-* The `blockParsers` and `spanParsers` collections provide the definitions for the actual markup parsers. 
+* The `blockParsers` and `spanParsers` properties provide the definitions for the actual markup parsers. 
   These are the same types you've already seen when registering parsers as extensions.
+
+  Builtin parsers implement these two properties in a way that they also expose the individual
+  top-level parsers via its API so that users can alternatively cherry-pick them and compose
+  them with other parsers for their own extensions or custom formats.
 
   It may sound too good to be true, but the task of assembling the building blocks of a markup language
   in Laika is indeed merely declarative. 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
 addSbtPlugin("org.planet42" % "laika-sbt" % "0.19.3")
 
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.5.0-RC4")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.5.2")


### PR DESCRIPTION
To better support binary compatibility the parser implementations for markup formats (Markdown and reStructuredText) have been made private.

However, ideally there should be a convenient place for parser authors to at least make the top-level parsers available for other users in case they want to freely compose them for other purposes.

This is encouraged by changing `MarkupFormat.spanParsers/blockParsers` from a simple `Seq` to `MarkupParsers[E]`.
The trait has only one abstract property (`all: Seq[Block/SpanParserBuilder]`), but can be used to add properties for individual parsers.

For example, the bullet list parser for Markdown can now be simply accessed via `Markdown.blockParsers.bulletList`. This convention is not possible when the property is a simple `Seq`.