### PR TITLE
reduce use of compound suffixes - adjust Path.suffix to split at last dot

### DIFF
--- a/core/shared/src/main/scala/laika/ast/paths.scala
+++ b/core/shared/src/main/scala/laika/ast/paths.scala
@@ -141,15 +141,8 @@ object SegmentedVirtualPath {
           case multiple    => (multiple.init.mkString(char.toString), Some(multiple.last))
         }
 
-      def splitAtFirst(in: String, char: Char): (String, Option[String]) =
-        in.split(char).toSeq match {
-          case Seq()       => ("", None)
-          case Seq(single) => (single, None)
-          case multiple    => (multiple.head, Some(multiple.tail.mkString(char.toString)))
-        }
-
       val (name, fragment)   = splitAtLast(lastSegment, '#')
-      val (basename, suffix) = splitAtFirst(name, '.')
+      val (basename, suffix) = splitAtLast(name, '.')
 
       (
         Some(NonEmptyChain.fromChainAppend(Chain.fromSeq(segments.init), basename)),

--- a/core/shared/src/main/scala/laika/rewrite/DefaultTemplatePath.scala
+++ b/core/shared/src/main/scala/laika/rewrite/DefaultTemplatePath.scala
@@ -25,12 +25,12 @@ import laika.ast.Path.Root
   */
 object DefaultTemplatePath {
 
-  private val base: Path = Root / "default"
+  private val base: Path = ((Root / "default.template" / "doc")).parent
 
-  private[laika] def forSuffix(suffix: String): Path = base.withSuffix(s"template.$suffix")
+  private[laika] def forSuffix(suffix: String): Path = base.withSuffix(suffix)
 
   def forHTML: Path = forSuffix("html")
-  def forEPUB: Path = forSuffix("epub.xhtml")
+  def forEPUB: Path = forSuffix("xhtml")
   def forFO: Path   = forSuffix("fo")
 
 }

--- a/core/shared/src/test/scala/laika/ast/PathAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/PathAPISpec.scala
@@ -313,7 +313,7 @@ class PathAPISpec extends FunSuite {
 
   suffix("defined for an absolute path with suffix", abs_c / "foo.jpg", Some("jpg"))
 
-  suffix("use longest suffix in case of multiple dots", abs_c / "foo.tar.gz", Some("tar.gz"))
+  suffix("use shortest suffix in case of multiple dots", abs_c / "foo.tar.gz", Some("gz"))
 
   suffix(
     "defined for an absolute path with suffix and fragment",

--- a/docs/src/03-preparing-content/04-ebooks.md
+++ b/docs/src/03-preparing-content/04-ebooks.md
@@ -179,15 +179,9 @@ CSS for EPUB
 Since content files for EPUB are standard XHTML files (apart from optional EPUB-specific attributes), 
 you can style your e-books with standard CSS. 
 
-It is sufficient to simply place all CSS into the input directory, alongside the text markup and other file types. 
-References to these CSS files will be automatically added to the header section of all generated HTML files. 
-
-To enable a distinction between EPUB and website generation in case you want to produce both with the same inputs,
-Laika expects the following suffixes for CSS files:
-
-* Files ending with `.epub.css` will only be linked in HTML files for EPUB, not for the site
-* File ending with `.shared.css` will be linked for both
-* All other files ending with `.css` will only be used for website content
+The Helium API offers ways to register which CSS files you want to be linked from the EPUB documents
+or alternatively which directories to scan for CSS files.
+See [Auto-Linking CSS & JS Files] for details.
 
 When referencing images or fonts from your CSS files, you can use relative paths, 
 as the directory layout will be retained inside the EPUB container.
@@ -199,15 +193,9 @@ JavaScript for EPUB
 The scope of support for JavaScript may depend on the target reader, so early testing is recommended when
 scripting EPUB documents.
 
-It is sufficient to simply place all JavaScript into the input directory, alongside the text markup and other file types. 
-References to these JavaScript files will be automatically added to the header section of all generated HTML files. 
-
-To enable a distinction between EPUB and website generation in case you want to produce both with the same inputs,
-Laika expects the following suffixes for JavaScript files:
-
-* Files ending with `.epub.js` will only be linked in HTML files for EPUB, not for the site
-* File ending with `.shared.js` will be linked for both
-* All other files ending with `.js` will only be used for website content
+The Helium API offers ways to register which JavaScript files you want to be linked from the EPUB documents
+or alternatively which directories to scan for JavaScript files.
+See [Auto-Linking CSS & JS Files] for details.
 
 In case you want to create a custom EPUB template you need to provide some indicator in the config header whether
 the template needs scripting support, as each scripted document needs a flag in the OPF metadata for the EPUB container.

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -63,9 +63,9 @@ case object EPUB extends TwoPhaseRenderFormat[TagFormatter, BinaryPostProcessorB
     */
   object XHTML extends RenderFormat[TagFormatter] {
 
-    override val description: String = "EPUB.XHTML"
+    override val description: String = "XHTML"
 
-    val fileSuffix: String = "epub.xhtml"
+    val fileSuffix: String = "xhtml"
 
     val defaultRenderer: (TagFormatter, Element) => String = XHTMLRenderer
 

--- a/io/src/main/scala/laika/helium/builder/HeliumHeadDirectives.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumHeadDirectives.scala
@@ -33,9 +33,9 @@ private[helium] object HeliumHeadDirectives {
       epubIncludes: A
   ): Option[A] =
     cursor.root.outputContext.map(_.formatSelector) match {
-      case Some("epub") | Some("epub.xhtml") => epubIncludes.some
-      case Some("html")                      => siteIncludes.some
-      case _                                 => None
+      case Some("epub") | Some("xhtml") => epubIncludes.some
+      case Some("html")                 => siteIncludes.some
+      case _                            => None
     }
 
   private def findDocuments(

--- a/io/src/main/scala/laika/helium/builder/HeliumTreeProcessor.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumTreeProcessor.scala
@@ -49,7 +49,7 @@ private[helium] class HeliumTreeProcessor[F[_]: Sync](helium: Helium) {
       enabled <- tree.root.config.get(LaikaKeys.preview.enabled, false)
     } yield {
       if (enabled) tree
-      else tree.removeStaticDocuments(_ == Root / "helium" / "laika-preview.js")
+      else tree.removeStaticDocuments(_ == Root / "helium" / "site" / "laika-preview.js")
     }
 
     Sync[F].fromEither(newTree.leftMap(ConfigException.apply))

--- a/io/src/main/scala/laika/helium/generate/CSSVarGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/CSSVarGenerator.scala
@@ -51,7 +51,7 @@ private[helium] object CSSVarGenerator {
   def generate(settings: EPUBSettings): String = {
     val embeddedFonts = settings.bookConfig.fonts.flatMap { font =>
       font.resource.embedResource.map { res =>
-        generateFontFace(font, res.path.relativeTo(Root / "helium" / "laika-helium.epub.css"))
+        generateFontFace(font, res.path.relativeTo(Root / "helium" / "epub" / "laika-helium.css"))
       }
     }.mkString("", "\n\n", "\n\n")
     embeddedFonts + generate(

--- a/io/src/main/scala/laika/io/model/BinaryInput.scala
+++ b/io/src/main/scala/laika/io/model/BinaryInput.scala
@@ -18,7 +18,7 @@ package laika.io.model
 
 import cats.effect.{ Async, Sync }
 import fs2.io.file.Files
-import laika.ast.{ Navigatable, Path }
+import laika.ast.{ Navigatable, Path, StaticDocument }
 import laika.ast.Path.Root
 import laika.rewrite.nav.TargetFormats
 
@@ -44,6 +44,11 @@ class BinaryInput[F[_]] private (
 ) extends Navigatable {
 
   def withPath(newPath: Path): BinaryInput[F] = new BinaryInput(input, newPath, formats, sourceFile)
+
+  def forTargetFormats(newFormats: TargetFormats): BinaryInput[F] =
+    new BinaryInput(input, path, newFormats, sourceFile)
+
+  def descriptor: StaticDocument = StaticDocument(path, formats)
 
 }
 

--- a/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
+++ b/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
@@ -308,7 +308,7 @@ class InputTreeBuilder[F[_]] private[model] (
     * that is equivalent to having a HOCON file called `directory.conf` in that directory.
     */
   def addConfig(config: Config, treePath: Path): InputTreeBuilder[F] = addBuilderPart(
-    ConfigPart(treePath, config)
+    ConfigPart(treePath / "directory.conf", config)
   )
 
   /** Adds the specified styles for PDF to the input tree.

--- a/io/src/main/scala/laika/render/epub/MimeTypes.scala
+++ b/io/src/main/scala/laika/render/epub/MimeTypes.scala
@@ -26,23 +26,21 @@ private[epub] object MimeTypes {
   /** Maps files suffixes to mime types.
     */
   val supportedTypes: Map[String, String] = Map(
-    "jpg"        -> "image/jpeg",
-    "jpeg"       -> "image/jpeg",
-    "gif"        -> "image/gif",
-    "png"        -> "image/png",
-    "svg"        -> "image/svg+xml",
-    "mp3"        -> "audio/mpeg",
-    "mp4"        -> "audio/mp4",
-    "html"       -> "application/xhtml+xml",
-    "xhtml"      -> "application/xhtml+xml",
-    "epub.js"    -> "application/javascript",
-    "shared.js"  -> "application/javascript",
-    "epub.css"   -> "text/css",
-    "shared.css" -> "text/css",
-    "woff2"      -> "font/woff2",
-    "woff"       -> "application/font-woff",
-    "ttf"        -> "application/font-sfnt",
-    "otf"        -> "application/font-sfnt"
+    "jpg"   -> "image/jpeg",
+    "jpeg"  -> "image/jpeg",
+    "gif"   -> "image/gif",
+    "png"   -> "image/png",
+    "svg"   -> "image/svg+xml",
+    "mp3"   -> "audio/mpeg",
+    "mp4"   -> "audio/mp4",
+    "html"  -> "application/xhtml+xml",
+    "xhtml" -> "application/xhtml+xml",
+    "js"    -> "application/javascript",
+    "css"   -> "text/css",
+    "woff2" -> "font/woff2",
+    "woff"  -> "application/font-woff",
+    "ttf"   -> "application/font-sfnt",
+    "otf"   -> "application/font-sfnt"
   )
 
 }

--- a/io/src/main/scala/laika/render/epub/NavigationBuilder.scala
+++ b/io/src/main/scala/laika/render/epub/NavigationBuilder.scala
@@ -27,7 +27,7 @@ private[epub] object NavigationBuilder {
     */
   def fullPath(path: Path, forceXhtml: Boolean = false): String = {
     val finalPath =
-      if (forceXhtml || path.suffix.contains("html")) path.withSuffix("epub.xhtml") else path
+      if (forceXhtml || path.suffix.contains("html")) path.withSuffix("xhtml") else path
     val parent    = finalPath.parent match {
       case Root => ""
       case _    => finalPath.parent.toString
@@ -42,7 +42,7 @@ private[epub] object NavigationBuilder {
       link = item.link.map {
         case nl @ NavigationLink(it: InternalTarget, _, _) =>
           val adjustedPath =
-            (Root / "content" / it.relativeTo(Root / "doc").relativePath).withSuffix("epub.xhtml")
+            (Root / "content" / it.relativeTo(Root / "doc").relativePath).withSuffix("xhtml")
           nl.copy(target = InternalTarget(adjustedPath.relative))
         case other                                         => other
       }

--- a/io/src/main/scala/laika/render/epub/OPFRenderer.scala
+++ b/io/src/main/scala/laika/render/epub/OPFRenderer.scala
@@ -113,7 +113,7 @@ private[epub] class OPFRenderer {
   def render[F[_]](result: RenderedTreeRoot[F], title: String, config: BookConfig): String = {
 
     lazy val hasScriptDocuments: Boolean =
-      result.staticDocuments.exists(_.path.suffix.exists(s => s == "epub.js" || s == "shared.js"))
+      result.staticDocuments.exists(_.path.suffix.contains("js"))
 
     def isScripted(doc: RenderedDocument): Boolean =
       doc.config.get[ScriptedTemplate].getOrElse(ScriptedTemplate.Never) match {

--- a/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
@@ -92,9 +92,9 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
          |<title>Downloads</title>
          |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
          |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-         |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-         |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-         |<script src="helium/laika-helium.js"></script>
+         |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+         |<script src="helium/site/laika-helium.js"></script>
          |<script> /* for avoiding page load transitions */ </script>
          |</head>
          |<body>

--- a/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
@@ -25,7 +25,7 @@ import laika.format.{ EPUB, Markdown }
 import laika.helium.config.ColorQuintet
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
-import laika.io.implicits._
+import laika.io.implicits.*
 import laika.io.model.StringTreeOutput
 import laika.theme.ThemeProvider
 import munit.CatsEffectSuite
@@ -52,7 +52,11 @@ class HeliumEPUBCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   ): IO[String] = transformer(helium.build).use { t =>
     for {
       resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
-      res <- resultTree.extractStaticContent(Root / "helium" / "laika-helium.epub.css", start, end)
+      res        <- resultTree.extractStaticContent(
+        Root / "helium" / "epub" / "laika-helium.css",
+        start,
+        end
+      )
     } yield res
   }
 
@@ -60,7 +64,7 @@ class HeliumEPUBCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
     transformer(helium.build).use { t =>
       for {
         resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
-        res        <- resultTree.extractStaticContent(Root / "helium" / "laika-helium.epub.css")
+        res        <- resultTree.extractStaticContent(Root / "helium" / "epub" / "laika-helium.css")
       } yield res
     }
 
@@ -118,37 +122,37 @@ class HeliumEPUBCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |font-family: "Lato";
         |font-weight: normal;
         |font-style: normal;
-        |src: url("../laika/fonts/Lato-Regular.ttf");
+        |src: url("../../laika/fonts/Lato-Regular.ttf");
         |}
         |@font-face {
         |font-family: "Lato";
         |font-weight: normal;
         |font-style: italic;
-        |src: url("../laika/fonts/Lato-Italic.ttf");
+        |src: url("../../laika/fonts/Lato-Italic.ttf");
         |}
         |@font-face {
         |font-family: "Lato";
         |font-weight: bold;
         |font-style: normal;
-        |src: url("../laika/fonts/Lato-Bold.ttf");
+        |src: url("../../laika/fonts/Lato-Bold.ttf");
         |}
         |@font-face {
         |font-family: "Lato";
         |font-weight: bold;
         |font-style: italic;
-        |src: url("../laika/fonts/Lato-BoldItalic.ttf");
+        |src: url("../../laika/fonts/Lato-BoldItalic.ttf");
         |}
         |@font-face {
         |font-family: "Fira Mono";
         |font-weight: normal;
         |font-style: normal;
-        |src: url("../laika/fonts/FiraMono-Medium.otf");
+        |src: url("../../laika/fonts/FiraMono-Medium.otf");
         |}
         |@font-face {
         |font-family: "IcoFont";
         |font-weight: normal;
         |font-style: normal;
-        |src: url("../laika/fonts/icofont.ttf");
+        |src: url("../../laika/fonts/icofont.ttf");
         |}
         |""".stripMargin
     transformAndExtract(singleDoc, Helium.defaults)

--- a/io/src/test/scala/laika/helium/HeliumEPUBHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBHeadSpec.scala
@@ -23,9 +23,9 @@ import laika.ast.Path.Root
 import laika.format.{ EPUB, Markdown }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
-import laika.io.implicits._
+import laika.io.implicits.*
 import laika.io.model.StringTreeOutput
-import laika.theme._
+import laika.theme.*
 import munit.CatsEffectSuite
 
 class HeliumEPUBHeadSpec extends CatsEffectSuite with InputBuilder with ResultExtractor
@@ -47,7 +47,7 @@ class HeliumEPUBHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
        |<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
        |<meta name="generator" content="Typelevel Laika + Helium Theme" />
        |<title></title>
-       |<link rel="stylesheet" type="text/css" href="helium/laika-helium.epub.css" />""".stripMargin
+       |<link rel="stylesheet" type="text/css" href="helium/epub/laika-helium.css" />""".stripMargin
 
   def transformAndExtractHead(inputs: Seq[(Path, String)]): IO[String] =
     transformAndExtractHead(inputs, Helium.defaults)
@@ -57,7 +57,7 @@ class HeliumEPUBHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
       for {
         resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
         res        <- IO.fromEither(
-          resultTree.extractTidiedTagContent(Root / "name.epub.xhtml", "head")
+          resultTree.extractTidiedTagContent((Root / "name").withSuffix("xhtml"), "head")
             .toRight(new RuntimeException("Missing document under test"))
         )
       } yield res
@@ -72,7 +72,7 @@ class HeliumEPUBHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
     for {
       resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
       res        <- IO.fromEither(
-        resultTree.extractTidiedSubstring(Root / "name.epub.xhtml", start, end)
+        resultTree.extractTidiedSubstring(Root / "name.xhtml", start, end)
           .toRight(new RuntimeException("Missing document under test"))
       )
     } yield res
@@ -98,7 +98,7 @@ class HeliumEPUBHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
          |<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
          |<meta name="generator" content="Typelevel Laika + Helium Theme" />
          |<title></title>
-         |<link rel="stylesheet" type="text/css" href="helium/laika-helium.epub.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/epub/laika-helium.css" />
          |<link rel="stylesheet" type="text/css" href="custom-css/foo.shared.css" />
          |<script src="custom-js/foo.epub.js"></script>""".stripMargin
     transformAndExtractHead(inputs, helium).assertEquals(expected)
@@ -117,7 +117,7 @@ class HeliumEPUBHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
          |<meta name="author" content="Maria Green"/>
          |<meta name="author" content="Elena Blue"/>
          |<meta name="description" content="Some description"/>
-         |<link rel="stylesheet" type="text/css" href="helium/laika-helium.epub.css" />""".stripMargin
+         |<link rel="stylesheet" type="text/css" href="helium/epub/laika-helium.css" />""".stripMargin
     transformAndExtractHead(singleDoc, helium).assertEquals(expected)
   }
 

--- a/io/src/test/scala/laika/helium/HeliumEPUBTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBTocPageSpec.scala
@@ -55,7 +55,7 @@ class HeliumEPUBTocPageSpec extends CatsEffectSuite with InputBuilder with Resul
     for {
       resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
       res        <- IO.fromEither(
-        resultTree.extractTidiedSubstring(Root / "table-of-content.epub.xhtml", start, end)
+        resultTree.extractTidiedSubstring(Root / "table-of-content.xhtml", start, end)
           .toRight(new RuntimeException("Missing document under test"))
       )
     } yield res
@@ -73,16 +73,16 @@ class HeliumEPUBTocPageSpec extends CatsEffectSuite with InputBuilder with Resul
          |<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
          |<meta name="generator" content="Typelevel Laika + Helium Theme" />
          |<title>Contents</title>
-         |<link rel="stylesheet" type="text/css" href="helium/laika-helium.epub.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/epub/laika-helium.css" />
          |</head>
          |<body epub:type="bodymatter">
          |<main class="content">
          |<h1 class="title">Contents</h1>
          |<ul class="toc nav-list">
-         |<li class="level1 toc nav-leaf"><a href="doc-1.epub.xhtml">doc-1.md</a></li>
-         |<li class="level1 toc nav-leaf"><a href="doc-2.epub.xhtml">doc-2.md</a></li>
+         |<li class="level1 toc nav-leaf"><a href="doc-1.xhtml">doc-1.md</a></li>
+         |<li class="level1 toc nav-leaf"><a href="doc-2.xhtml">doc-2.md</a></li>
          |<li class="level1 toc nav-header">dir-1</li>
-         |<li class="level2 toc nav-leaf"><a href="dir-1/doc-3.epub.xhtml">doc-3.md</a></li>
+         |<li class="level2 toc nav-leaf"><a href="dir-1/doc-3.xhtml">doc-3.md</a></li>
          |</ul>
          |</main>
          |</body>""".stripMargin

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -106,9 +106,9 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
               |<title></title>
               |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
               |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-              |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-              |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-              |<script src="helium/laika-helium.js"></script>
+              |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+              |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+              |<script src="helium/site/laika-helium.js"></script>
               |<script> /* for avoiding page load transitions */ </script>""".stripMargin
 
   val heliumBase = Helium.defaults.site.landingPage()
@@ -188,10 +188,10 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
           |<title></title>
           |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
           |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-          |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-          |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
+          |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+          |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
           |<link rel="stylesheet" type="text/css" href="web-1/foo.css" />
-          |<script src="helium/laika-helium.js"></script>
+          |<script src="helium/site/laika-helium.js"></script>
           |<script src="web-1/foo-1.js"></script>
           |<script src="web-1/foo-2.js"></script>
           |<script> /* for avoiding page load transitions */ </script>""".stripMargin
@@ -219,11 +219,11 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
           |<title></title>
           |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
           |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-          |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-          |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
+          |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+          |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
           |<link rel="stylesheet" type="text/css" href="theme/bar.css" />
           |<link rel="stylesheet" type="text/css" href="web/foo.css" />
-          |<script src="helium/laika-helium.js"></script>
+          |<script src="helium/site/laika-helium.js"></script>
           |<script src="web/foo.js"></script>
           |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(inputs, helium.extendWith(themeExt)).assertEquals(expected)
@@ -247,10 +247,10 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
           |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
           |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
           |<link rel="stylesheet" type="text/css" href="https://foo.com/styles.css" integrity="xyz" crossorigin="anonymous" />
-          |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-          |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
+          |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+          |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
           |<script src="https://foo.com/script.js" defer integrity="xyz" crossorigin="anonymous"></script>
-          |<script src="helium/laika-helium.js"></script>
+          |<script src="helium/site/laika-helium.js"></script>
           |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(inputs, helium).assertEquals(expected)
   }
@@ -275,14 +275,14 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
            |<title></title>
            |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
            |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-           |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-           |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
+           |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+           |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
            |<style>
            |h1 {
            |color: #111111;
            |}
            |</style>
-           |<script src="helium/laika-helium.js"></script>
+           |<script src="helium/site/laika-helium.js"></script>
            |<script type="module">
            |$script
            |</script>
@@ -303,9 +303,9 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
                 |<meta name="description" content="Some description"/>
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-                |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-                |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-                |<script src="helium/laika-helium.js"></script>
+                |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+                |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+                |<script src="helium/site/laika-helium.js"></script>
                 |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(singleDoc, helium).assertEquals(expected)
   }
@@ -324,9 +324,9 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
                 |<link rel="canonical" href="http://very.canonical/"/>
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-                |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-                |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-                |<script src="helium/laika-helium.js"></script>
+                |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+                |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+                |<script src="helium/site/laika-helium.js"></script>
                 |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(docWithCanonicalLink, heliumBase).assertEquals(expected)
   }
@@ -350,9 +350,9 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
                 |<link rel="icon"  type="image/svg+xml" href="icon.svg"/>
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-                |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-                |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-                |<script src="helium/laika-helium.js"></script>
+                |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+                |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+                |<script src="helium/site/laika-helium.js"></script>
                 |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(inputs, helium).assertEquals(expected)
   }
@@ -380,10 +380,10 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
                 |<link rel="icon" sizes="64x64" type="image/png" href="../../img/icon-2.png"/>
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-                |<link rel="stylesheet" type="text/css" href="../helium/icofont.min.css" />
-                |<link rel="stylesheet" type="text/css" href="../helium/laika-helium.css" />
-                |<script src="../helium/laika-helium.js"></script>
-                |<script src="../helium/laika-versions.js"></script>
+                |<link rel="stylesheet" type="text/css" href="../helium/site/icofont.min.css" />
+                |<link rel="stylesheet" type="text/css" href="../helium/site/laika-helium.css" />
+                |<script src="../helium/site/laika-helium.js"></script>
+                |<script src="../helium/site/laika-versions.js"></script>
                 |<script>initVersions("../../", "/dir/name.html", "0.42", null);</script>
                 |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(inputs, helium, pathUnderTest).assertEquals(expected)
@@ -409,9 +409,9 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
                 |<title></title>
                 |<link rel="stylesheet" href="http://fonts.com/font-1.css">
                 |<link rel="stylesheet" href="http://fonts.com/font-2.css">
-                |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-                |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-                |<script src="helium/laika-helium.js"></script>
+                |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+                |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+                |<script src="helium/site/laika-helium.js"></script>
                 |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(singleDoc, helium).assertEquals(expected)
   }
@@ -423,10 +423,10 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
                 |<title></title>
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-                |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-                |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-                |<script src="helium/laika-helium.js"></script>
-                |<script src="helium/laika-versions.js"></script>
+                |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+                |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+                |<script src="helium/site/laika-helium.js"></script>
+                |<script src="helium/site/laika-versions.js"></script>
                 |<script>initVersions("../", "/name.html", "0.42", "https://foo.org/");</script>
                 |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(singleVersionedDoc, helium, Root / "0.42" / "name.html").assertEquals(
@@ -441,10 +441,10 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
                 |<title></title>
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
                 |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-                |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-                |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-                |<script src="helium/laika-helium.js"></script>
-                |<script src="helium/laika-versions.js"></script>
+                |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+                |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+                |<script src="helium/site/laika-helium.js"></script>
+                |<script src="helium/site/laika-versions.js"></script>
                 |<script>initVersions("", "", "", null);</script>
                 |<script> /* for avoiding page load transitions */ </script>""".stripMargin
     transformAndExtractHead(singleDoc, helium).assertEquals(expected)
@@ -524,9 +524,9 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
           |<title>Title</title>
           |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
           |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-          |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-          |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-          |<script src="helium/laika-helium.js"></script>
+          |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+          |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+          |<script src="helium/site/laika-helium.js"></script>
           |<script type="module">
           |import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
           |const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -101,12 +101,12 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
          |<title></title>
          |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
          |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-         |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-         |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-         |<link rel="stylesheet" type="text/css" href="helium/landing.page.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/site/landing-page.css" />
          |<link rel="stylesheet" type="text/css" href="styles/landing-extra.page.css" />
-         |<script src="helium/laika-helium.js"></script>
-         |<script src="helium/laika-versions.js"></script>
+         |<script src="helium/site/laika-helium.js"></script>
+         |<script src="helium/site/laika-versions.js"></script>
          |<script>initVersions("", "", "", null);</script>
          |<script> /* for avoiding page load transitions */ </script>
          |</head>
@@ -212,10 +212,10 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
          |<title></title>
          |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
          |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-         |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-         |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-         |<link rel="stylesheet" type="text/css" href="helium/landing.page.css" />
-         |<script src="helium/laika-helium.js"></script>
+         |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/site/landing-page.css" />
+         |<script src="helium/site/laika-helium.js"></script>
          |<script> /* for avoiding page load transitions */ </script>
          |</head>
          |<body>

--- a/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
@@ -52,7 +52,11 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   ): IO[String] = transformer(helium.build).use { t =>
     for {
       resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
-      res <- resultTree.extractStaticContent(Root / "helium" / "laika-helium.css", start, end)
+      res        <- resultTree.extractStaticContent(
+        Root / "helium" / "site" / "laika-helium.css",
+        start,
+        end
+      )
     } yield res
   }
 

--- a/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
@@ -76,9 +76,9 @@ class HeliumTocPageSpec extends CatsEffectSuite with InputBuilder with ResultExt
          |<title>Contents</title>
          |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
          |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
-         |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-         |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-         |<script src="helium/laika-helium.js"></script>
+         |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+         |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+         |<script src="helium/site/laika-helium.js"></script>
          |<script> /* for avoiding page load transitions */ </script>
          |</head>
          |<body>

--- a/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
@@ -210,7 +210,8 @@ class TreeParserFileIOSpec
   }
 
   object ExtraConfig extends CustomInputSetup {
-    val path: Path = Root / "tree-2" / "directory.conf"
+    val treePath: Path = Root / "tree-2"
+    val path: Path     = Root / "tree-2" / "directory.conf"
 
     def checkConfig(root: DocumentTreeRoot): Unit = {
       val actual = root
@@ -339,11 +340,11 @@ class TreeParserFileIOSpec
     "read a directory from the file system plus one extra config document built programmatically"
   ) {
     val config = ConfigBuilder
-      .withOrigin(Origin(TreeScope, ExtraConfig.path))
+      .withOrigin(Origin(TreeScope, ExtraConfig.treePath))
       .withValue("foo", 7).build
 
     CustomInput.run(
-      _.addConfig(config, ExtraConfig.path),
+      _.addConfig(config, ExtraConfig.treePath),
       ExtraConfig.expected(),
       ExtraConfig.checkConfig
     )

--- a/io/src/test/scala/laika/render/epub/HTMLNavRendererSpec.scala
+++ b/io/src/test/scala/laika/render/epub/HTMLNavRendererSpec.scala
@@ -43,7 +43,7 @@ class HTMLNavRendererSpec extends FunSuite {
     val expected =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">Title 2</a>
+        |          <a href="content/foo.xhtml">Title 2</a>
         |
         |        </li>
         |      </ol>""".stripMargin
@@ -54,11 +54,11 @@ class HTMLNavRendererSpec extends FunSuite {
     val expected =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">Title 2</a>
+        |          <a href="content/foo.xhtml">Title 2</a>
         |
         |        </li>
         |        <li id="toc-li-1">
-        |          <a href="content/bar.epub.xhtml">Title 3</a>
+        |          <a href="content/bar.xhtml">Title 3</a>
         |
         |        </li>
         |      </ol>""".stripMargin
@@ -69,7 +69,7 @@ class HTMLNavRendererSpec extends FunSuite {
     val html     =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">Title 2</a>
+        |          <a href="content/foo.xhtml">Title 2</a>
         |
         |        </li>
         |      </ol>""".stripMargin
@@ -82,7 +82,7 @@ class HTMLNavRendererSpec extends FunSuite {
     val html     =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/bar.epub.xhtml">Title 3</a>
+        |          <a href="content/bar.xhtml">Title 3</a>
         |
         |        </li>
         |      </ol>""".stripMargin
@@ -97,10 +97,10 @@ class HTMLNavRendererSpec extends FunSuite {
     val html     =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">Title 2</a>
+        |          <a href="content/foo.xhtml">Title 2</a>
         |        </li>
         |        <li id="toc-li-1">
-        |          <a href="content/bar.epub.xhtml">Title 3</a>
+        |          <a href="content/bar.xhtml">Title 3</a>
         |        </li>
         |      </ol>""".stripMargin
     val expected =
@@ -112,14 +112,14 @@ class HTMLNavRendererSpec extends FunSuite {
     val expected =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">Title 2</a>
+        |          <a href="content/foo.xhtml">Title 2</a>
         |
         |        </li>
         |        <li id="toc-li-1">
-        |          <a href="content/sub/bar.epub.xhtml">Tree 4</a>
+        |          <a href="content/sub/bar.xhtml">Tree 4</a>
         |      <ol class="toc">
         |        <li id="toc-li-2">
-        |          <a href="content/sub/bar.epub.xhtml">Title 3</a>
+        |          <a href="content/sub/bar.xhtml">Title 3</a>
         |
         |        </li>
         |      </ol>
@@ -132,14 +132,14 @@ class HTMLNavRendererSpec extends FunSuite {
     val expected =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">Title 2</a>
+        |          <a href="content/foo.xhtml">Title 2</a>
         |
         |        </li>
         |        <li id="toc-li-1">
-        |          <a href="content/sub/title.epub.xhtml">From TitleDoc</a>
+        |          <a href="content/sub/title.xhtml">From TitleDoc</a>
         |      <ol class="toc">
         |        <li id="toc-li-2">
-        |          <a href="content/sub/bar.epub.xhtml">Title 3</a>
+        |          <a href="content/sub/bar.xhtml">Title 3</a>
         |
         |        </li>
         |      </ol>
@@ -152,7 +152,7 @@ class HTMLNavRendererSpec extends FunSuite {
     val expected =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">Title 2</a>
+        |          <a href="content/foo.xhtml">Title 2</a>
         |
         |        </li>
         |      </ol>""".stripMargin
@@ -163,27 +163,27 @@ class HTMLNavRendererSpec extends FunSuite {
     val expected =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">Title 2</a>
+        |          <a href="content/foo.xhtml">Title 2</a>
         |      <ol class="toc">
         |        <li id="toc-li-1">
-        |          <a href="content/foo.epub.xhtml#A">Section A</a>
+        |          <a href="content/foo.xhtml#A">Section A</a>
         |
         |        </li>
         |        <li id="toc-li-2">
-        |          <a href="content/foo.epub.xhtml#B">Section B</a>
+        |          <a href="content/foo.xhtml#B">Section B</a>
         |
         |        </li>
         |      </ol>
         |        </li>
         |        <li id="toc-li-3">
-        |          <a href="content/bar.epub.xhtml">Title 3</a>
+        |          <a href="content/bar.xhtml">Title 3</a>
         |      <ol class="toc">
         |        <li id="toc-li-4">
-        |          <a href="content/bar.epub.xhtml#A">Section A</a>
+        |          <a href="content/bar.xhtml#A">Section A</a>
         |
         |        </li>
         |        <li id="toc-li-5">
-        |          <a href="content/bar.epub.xhtml#B">Section B</a>
+        |          <a href="content/bar.xhtml#B">Section B</a>
         |
         |        </li>
         |      </ol>
@@ -195,11 +195,11 @@ class HTMLNavRendererSpec extends FunSuite {
   test("not render a document with sections when the depth is 1") {
     val expected = """      <ol class="toc">
                      |        <li id="toc-li-0">
-                     |          <a href="content/foo.epub.xhtml">Title 2</a>
+                     |          <a href="content/foo.xhtml">Title 2</a>
                      |
                      |        </li>
                      |        <li id="toc-li-1">
-                     |          <a href="content/bar.epub.xhtml">Title 3</a>
+                     |          <a href="content/bar.xhtml">Title 3</a>
                      |
                      |        </li>
                      |      </ol>""".stripMargin
@@ -210,7 +210,7 @@ class HTMLNavRendererSpec extends FunSuite {
     val expected =
       """      <ol class="toc">
         |        <li id="toc-li-0">
-        |          <a href="content/foo.epub.xhtml">This &amp; That</a>
+        |          <a href="content/foo.xhtml">This &amp; That</a>
         |
         |        </li>
         |      </ol>""".stripMargin

--- a/io/src/test/scala/laika/render/epub/NCXRendererSpec.scala
+++ b/io/src/test/scala/laika/render/epub/NCXRendererSpec.scala
@@ -47,7 +47,7 @@ class NCXRendererSpec extends FunSuite {
         |      <navLabel>
         |        <text>Title 2</text>
         |      </navLabel>
-        |      <content src="content/foo.epub.xhtml" />
+        |      <content src="content/foo.xhtml" />
         |
         |    </navPoint>""".stripMargin
     run(SingleDocument.input, expected)
@@ -59,14 +59,14 @@ class NCXRendererSpec extends FunSuite {
         |      <navLabel>
         |        <text>Title 2</text>
         |      </navLabel>
-        |      <content src="content/foo.epub.xhtml" />
+        |      <content src="content/foo.xhtml" />
         |
         |    </navPoint>
         |    <navPoint id="navPoint-1">
         |      <navLabel>
         |        <text>Title 3</text>
         |      </navLabel>
-        |      <content src="content/bar.epub.xhtml" />
+        |      <content src="content/bar.xhtml" />
         |
         |    </navPoint>""".stripMargin
     run(TwoDocuments.input, expected)
@@ -79,19 +79,19 @@ class NCXRendererSpec extends FunSuite {
         |      <navLabel>
         |        <text>Title 2</text>
         |      </navLabel>
-        |      <content src="content/foo.epub.xhtml" />
+        |      <content src="content/foo.xhtml" />
         |
         |    </navPoint>
         |    <navPoint id="navPoint-1">
         |      <navLabel>
         |        <text>Tree 4</text>
         |      </navLabel>
-        |      <content src="content/sub/bar.epub.xhtml" />
+        |      <content src="content/sub/bar.xhtml" />
         |    <navPoint id="navPoint-2">
         |      <navLabel>
         |        <text>Title 3</text>
         |      </navLabel>
-        |      <content src="content/sub/bar.epub.xhtml" />
+        |      <content src="content/sub/bar.xhtml" />
         |
         |    </navPoint>
         |    </navPoint>""".stripMargin
@@ -104,7 +104,7 @@ class NCXRendererSpec extends FunSuite {
         |      <navLabel>
         |        <text>Title 2</text>
         |      </navLabel>
-        |      <content src="content/foo.epub.xhtml" />
+        |      <content src="content/foo.xhtml" />
         |
         |    </navPoint>""".stripMargin
     run(NestedTree.input, expected)
@@ -115,19 +115,19 @@ class NCXRendererSpec extends FunSuite {
                      |      <navLabel>
                      |        <text>Title 2</text>
                      |      </navLabel>
-                     |      <content src="content/foo.epub.xhtml" />
+                     |      <content src="content/foo.xhtml" />
                      |    <navPoint id="navPoint-1">
                      |      <navLabel>
                      |        <text>Section A</text>
                      |      </navLabel>
-                     |      <content src="content/foo.epub.xhtml#A" />
+                     |      <content src="content/foo.xhtml#A" />
                      |
                      |    </navPoint>
                      |    <navPoint id="navPoint-2">
                      |      <navLabel>
                      |        <text>Section B</text>
                      |      </navLabel>
-                     |      <content src="content/foo.epub.xhtml#B" />
+                     |      <content src="content/foo.xhtml#B" />
                      |
                      |    </navPoint>
                      |    </navPoint>
@@ -135,19 +135,19 @@ class NCXRendererSpec extends FunSuite {
                      |      <navLabel>
                      |        <text>Title 3</text>
                      |      </navLabel>
-                     |      <content src="content/bar.epub.xhtml" />
+                     |      <content src="content/bar.xhtml" />
                      |    <navPoint id="navPoint-4">
                      |      <navLabel>
                      |        <text>Section A</text>
                      |      </navLabel>
-                     |      <content src="content/bar.epub.xhtml#A" />
+                     |      <content src="content/bar.xhtml#A" />
                      |
                      |    </navPoint>
                      |    <navPoint id="navPoint-5">
                      |      <navLabel>
                      |        <text>Section B</text>
                      |      </navLabel>
-                     |      <content src="content/bar.epub.xhtml#B" />
+                     |      <content src="content/bar.xhtml#B" />
                      |
                      |    </navPoint>
                      |    </navPoint>""".stripMargin
@@ -159,14 +159,14 @@ class NCXRendererSpec extends FunSuite {
                      |      <navLabel>
                      |        <text>Title 2</text>
                      |      </navLabel>
-                     |      <content src="content/foo.epub.xhtml" />
+                     |      <content src="content/foo.xhtml" />
                      |
                      |    </navPoint>
                      |    <navPoint id="navPoint-1">
                      |      <navLabel>
                      |        <text>Title 3</text>
                      |      </navLabel>
-                     |      <content src="content/bar.epub.xhtml" />
+                     |      <content src="content/bar.xhtml" />
                      |
                      |    </navPoint>""".stripMargin
     run(DocumentsWithSections.input, expected)
@@ -178,7 +178,7 @@ class NCXRendererSpec extends FunSuite {
         |      <navLabel>
         |        <text>This &amp; That</text>
         |      </navLabel>
-        |      <content src="content/foo.epub.xhtml" />
+        |      <content src="content/foo.xhtml" />
         |
         |    </navPoint>""".stripMargin
     run(DocumentWithSpecialChars.input, expected)

--- a/io/src/test/scala/laika/render/epub/OPFRendererSpec.scala
+++ b/io/src/test/scala/laika/render/epub/OPFRendererSpec.scala
@@ -63,13 +63,12 @@ class OPFRendererSpec extends FunSuite {
       config = ConfigBuilder.empty.withValue[ScriptedTemplate](ScriptedTemplate.Auto).build
     )
 
-    private val static1 = ByteInput("", Path.parse("/sub/code.shared.js"))
-    private val static2 = ByteInput("", Path.parse("/sub/code.epub.js"))
-    private val static3 = ByteInput("", Path.parse("/sub/styles.epub.css"))
-    private val subtree = tree(Path.Root / "sub", 4, doc2)
+    private val staticJS  = ByteInput("", Path.parse("/sub/code.epub.js"))
+    private val staticCSS = ByteInput("", Path.parse("/sub/styles.epub.css"))
+    private val subtree   = tree(Path.Root / "sub", 4, doc2)
 
     def input(hasJS: Boolean): RenderedTreeRoot[IO] = rootTree(Path.Root, 1, doc1, subtree)
-      .withStaticDocuments(if (hasJS) Seq(static1, static2, static3) else Seq(static3))
+      .withStaticDocuments(if (hasJS) Seq(staticJS, staticCSS) else Seq(staticCSS))
 
   }
 
@@ -89,17 +88,17 @@ class OPFRendererSpec extends FunSuite {
 
   test("render a tree with a single document") {
     val manifestItems =
-      """    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" />"""
+      """    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" />"""
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />"""
+      """    <itemref idref="foo_xhtml" />"""
     run(SingleDocument.input, fileContent(manifestItems, spineRefs))
   }
 
   test("render a tree with a single document with the default locale rendered correctly") {
     val manifestItems =
-      """    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" />"""
+      """    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" />"""
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />"""
+      """    <itemref idref="foo_xhtml" />"""
     val expected = fileContent(manifestItems, spineRefs, language = Locale.getDefault.toLanguageTag)
     runWith(SingleDocument.input, configWithoutLanguage, expected)
   }
@@ -108,30 +107,30 @@ class OPFRendererSpec extends FunSuite {
     "render a tree with a single document with valid XML id for the name starting with a digit"
   ) {
     val manifestItems =
-      """    <item id="_01-foo_epub_xhtml" href="content/01-foo.epub.xhtml" media-type="application/xhtml+xml" />"""
+      """    <item id="_01-foo_xhtml" href="content/01-foo.xhtml" media-type="application/xhtml+xml" />"""
     val spineRefs     =
-      """    <itemref idref="_01-foo_epub_xhtml" />"""
+      """    <itemref idref="_01-foo_xhtml" />"""
     val expected = fileContent(manifestItems, spineRefs, language = Locale.getDefault.toLanguageTag)
     runWith(DocumentNameStartingWithDigit.input, configWithoutLanguage, expected)
   }
 
   test("render a tree with two documents") {
     val manifestItems =
-      """    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="bar_epub_xhtml" href="content/bar.epub.xhtml" media-type="application/xhtml+xml" />""".stripMargin
+      """    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="bar_xhtml" href="content/bar.xhtml" media-type="application/xhtml+xml" />""".stripMargin
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />
-        |    <itemref idref="bar_epub_xhtml" />"""
+      """    <itemref idref="foo_xhtml" />
+        |    <itemref idref="bar_xhtml" />"""
     run(TwoDocuments.input, fileContent(manifestItems, spineRefs))
   }
 
   test("render a tree with a title document") {
     val manifestItems =
-      """    <item id="title_epub_xhtml" href="content/title.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="bar_epub_xhtml" href="content/bar.epub.xhtml" media-type="application/xhtml+xml" />""".stripMargin
-    val titleRef      = """    <itemref idref="title_epub_xhtml" />"""
+      """    <item id="title_xhtml" href="content/title.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="bar_xhtml" href="content/bar.xhtml" media-type="application/xhtml+xml" />""".stripMargin
+    val titleRef      = """    <itemref idref="title_xhtml" />"""
     val spineRefs     =
-      """    <itemref idref="bar_epub_xhtml" />"""
+      """    <itemref idref="bar_xhtml" />"""
     val expected      =
       fileContent(manifestItems, spineRefs, titleRef = titleRef, title = "From TitleDoc")
     val actual        = renderer.render(DocumentPlusTitle.input, "From TitleDoc", config)
@@ -140,18 +139,18 @@ class OPFRendererSpec extends FunSuite {
 
   test("render a tree with a cover") {
     val manifestItems =
-      """    <item id="cover_epub_xhtml" href="content/cover.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="bar_epub_xhtml" href="content/bar.epub.xhtml" media-type="application/xhtml+xml" />
+      """    <item id="cover_xhtml" href="content/cover.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="bar_xhtml" href="content/bar.xhtml" media-type="application/xhtml+xml" />
         |    <item id="cover_png" href="content/cover.png" media-type="image/png" />""".stripMargin
     val coverEntries  = CoverEntries(
       metadata = """    <meta name="cover" content="cover_png" />""",
-      spine = """    <itemref idref="cover_epub_xhtml" />""",
-      guide = """    <reference type="cover" title="Cover" href="content/cover.epub.xhtml" />"""
+      spine = """    <itemref idref="cover_xhtml" />""",
+      guide = """    <reference type="cover" title="Cover" href="content/cover.xhtml" />"""
     )
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />
-        |    <itemref idref="bar_epub_xhtml" />""".stripMargin
+      """    <itemref idref="foo_xhtml" />
+        |    <itemref idref="bar_xhtml" />""".stripMargin
     val expected      = fileContent(manifestItems, spineRefs, coverEntries = Some(coverEntries))
     val coverConfig   = config.withCoverImage(Root / "cover.png")
     runWith(DocumentPlusCover.input, coverConfig, expected)
@@ -159,63 +158,62 @@ class OPFRendererSpec extends FunSuite {
 
   test("render a tree with a nested tree") {
     val manifestItems =
-      """    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="sub_bar_epub_xhtml" href="content/sub/bar.epub.xhtml" media-type="application/xhtml+xml" />""".stripMargin
+      """    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="sub_bar_xhtml" href="content/sub/bar.xhtml" media-type="application/xhtml+xml" />""".stripMargin
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />
-        |    <itemref idref="sub_bar_epub_xhtml" />"""
+      """    <itemref idref="foo_xhtml" />
+        |    <itemref idref="sub_bar_xhtml" />"""
     run(NestedTree.input, fileContent(manifestItems, spineRefs))
   }
 
   test("render a tree with two nested trees") {
     val manifestItems =
-      """    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="sub1_bar_epub_xhtml" href="content/sub1/bar.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="sub1_baz_epub_xhtml" href="content/sub1/baz.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="sub2_bar_epub_xhtml" href="content/sub2/bar.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="sub2_baz_epub_xhtml" href="content/sub2/baz.epub.xhtml" media-type="application/xhtml+xml" />"""
+      """    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="sub1_bar_xhtml" href="content/sub1/bar.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="sub1_baz_xhtml" href="content/sub1/baz.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="sub2_bar_xhtml" href="content/sub2/bar.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="sub2_baz_xhtml" href="content/sub2/baz.xhtml" media-type="application/xhtml+xml" />"""
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />
-        |    <itemref idref="sub1_bar_epub_xhtml" />
-        |    <itemref idref="sub1_baz_epub_xhtml" />
-        |    <itemref idref="sub2_bar_epub_xhtml" />
-        |    <itemref idref="sub2_baz_epub_xhtml" />"""
+      """    <itemref idref="foo_xhtml" />
+        |    <itemref idref="sub1_bar_xhtml" />
+        |    <itemref idref="sub1_baz_xhtml" />
+        |    <itemref idref="sub2_bar_xhtml" />
+        |    <itemref idref="sub2_baz_xhtml" />"""
     run(TwoNestedTrees.input, fileContent(manifestItems, spineRefs))
   }
 
   test("render a tree with a nested tree and static documents") {
     val manifestItems =
-      """    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" />
-        |    <item id="sub_bar_epub_xhtml" href="content/sub/bar.epub.xhtml" media-type="application/xhtml+xml" />
+      """    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" />
+        |    <item id="sub_bar_xhtml" href="content/sub/bar.xhtml" media-type="application/xhtml+xml" />
         |    <item id="sub_image-1_5x_jpg" href="content/sub/image-1.5x.jpg" media-type="image/jpeg" />
         |    <item id="sub_styles_epub_css" href="content/sub/styles.epub.css" media-type="text/css" />""".stripMargin
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />
-        |    <itemref idref="sub_bar_epub_xhtml" />"""
+      """    <itemref idref="foo_xhtml" />
+        |    <itemref idref="sub_bar_xhtml" />"""
     run(TreeWithStaticDocuments.input, fileContent(manifestItems, spineRefs))
   }
 
   test("render a tree with a nested tree and script documents") {
     val manifestItems =
-      """    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
-        |    <item id="sub_bar_epub_xhtml" href="content/sub/bar.epub.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
-        |    <item id="sub_code_shared_js" href="content/sub/code.shared.js" media-type="application/javascript" />
+      """    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
+        |    <item id="sub_bar_xhtml" href="content/sub/bar.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
         |    <item id="sub_code_epub_js" href="content/sub/code.epub.js" media-type="application/javascript" />
         |    <item id="sub_styles_epub_css" href="content/sub/styles.epub.css" media-type="text/css" />""".stripMargin
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />
-        |    <itemref idref="sub_bar_epub_xhtml" />"""
+      """    <itemref idref="foo_xhtml" />
+        |    <itemref idref="sub_bar_xhtml" />"""
     run(TreeWithScriptedDocuments.input(hasJS = true), fileContent(manifestItems, spineRefs))
   }
 
   test("render a tree with a nested tree and no script documents") {
     val manifestItems =
-      """    <item id="foo_epub_xhtml" href="content/foo.epub.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
-        |    <item id="sub_bar_epub_xhtml" href="content/sub/bar.epub.xhtml" media-type="application/xhtml+xml" />
+      """    <item id="foo_xhtml" href="content/foo.xhtml" media-type="application/xhtml+xml" properties="scripted"/>
+        |    <item id="sub_bar_xhtml" href="content/sub/bar.xhtml" media-type="application/xhtml+xml" />
         |    <item id="sub_styles_epub_css" href="content/sub/styles.epub.css" media-type="text/css" />""".stripMargin
     val spineRefs     =
-      """    <itemref idref="foo_epub_xhtml" />
-        |    <itemref idref="sub_bar_epub_xhtml" />"""
+      """    <itemref idref="foo_xhtml" />
+        |    <itemref idref="sub_bar_xhtml" />"""
     run(TreeWithScriptedDocuments.input(hasJS = false), fileContent(manifestItems, spineRefs))
   }
 

--- a/io/src/test/scala/laika/render/fo/TestTheme.scala
+++ b/io/src/test/scala/laika/render/fo/TestTheme.scala
@@ -53,13 +53,13 @@ object TestTheme {
     Root / "laika" / "fonts" / "Lato-BoldItalic.ttf",
     Root / "laika" / "fonts" / "FiraMono-Medium.otf",
     Root / "laika" / "fonts" / "icofont.ttf",
-    Root / "helium" / "laika-helium.js",
-    Root / "helium" / "landing.page.css",
-    Root / "helium" / "icofont.min.css",
+    Root / "helium" / "site" / "laika-helium.js",
+    Root / "helium" / "site" / "landing-page.css",
+    Root / "helium" / "site" / "icofont.min.css",
     Root / "helium" / "fonts" / "icofont.woff",
     Root / "helium" / "fonts" / "icofont.woff2",
-    Root / "helium" / "laika-helium.css",
-    Root / "helium" / "laika-helium.epub.css"
+    Root / "helium" / "site" / "laika-helium.css",
+    Root / "helium" / "epub" / "laika-helium.css"
   )
 
   val fonts = Seq(

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -72,8 +72,8 @@ private[preview] class SiteTransformer[F[_]: Async](
         val classifier =
           if (classifiers.value.isEmpty) "" else "-" + classifiers.value.mkString("-")
         val docName    = artifactBaseName + classifier + "." + suffix
-        val path       = downloadPath / docName
-        (path, StaticResult(renderBinary(renderer, new ParsedTree(root, tree.staticDocuments))))
+        val finalTree  = ParsedTree(root).addStaticDocuments(tree.staticDocuments)
+        (downloadPath / docName, StaticResult(renderBinary(renderer, finalTree)))
       }.toMap
     }
   }

--- a/sbt/src/sbt-test/site/config/expected.html
+++ b/sbt/src/sbt-test/site/config/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/defaults/expected.html
+++ b/sbt/src/sbt-test/site/defaults/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/docTypeMatcher/expected.html
+++ b/sbt/src/sbt-test/site/docTypeMatcher/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/excludeFilter/expected.html
+++ b/sbt/src/sbt-test/site/excludeFilter/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/generateMultipleFormats/expected.html
+++ b/sbt/src/sbt-test/site/generateMultipleFormats/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/github/expected.html
+++ b/sbt/src/sbt-test/site/github/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/html/expected.html
+++ b/sbt/src/sbt-test/site/html/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/includeAPI/expected.html
+++ b/sbt/src/sbt-test/site/includeAPI/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/includeEPUB/expected.html
+++ b/sbt/src/sbt-test/site/includeEPUB/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/includePDF/expected.html
+++ b/sbt/src/sbt-test/site/includePDF/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/packageSite/expected.html
+++ b/sbt/src/sbt-test/site/packageSite/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/rawContent/expected.html
+++ b/sbt/src/sbt-test/site/rawContent/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/renderMessageLevel/expected.html
+++ b/sbt/src/sbt-test/site/renderMessageLevel/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/rewriteRules/expected.html
+++ b/sbt/src/sbt-test/site/rewriteRules/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/siteRenderers/expected.html
+++ b/sbt/src/sbt-test/site/siteRenderers/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/sourceDirectories/expected.html
+++ b/sbt/src/sbt-test/site/sourceDirectories/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/sourceDirectories/expected2.html
+++ b/sbt/src/sbt-test/site/sourceDirectories/expected2.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/strict/expected.html
+++ b/sbt/src/sbt-test/site/strict/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/targetAPI/expected.html
+++ b/sbt/src/sbt-test/site/targetAPI/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/targetDir/expected.html
+++ b/sbt/src/sbt-test/site/targetDir/expected.html
@@ -18,9 +18,9 @@
   
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>

--- a/sbt/src/sbt-test/site/theme/expected.html
+++ b/sbt/src/sbt-test/site/theme/expected.html
@@ -16,9 +16,9 @@
   
   <link rel="stylesheet" href="http://home.com/myFont.css">
   
-  <link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
-    <link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
-  <script src="helium/laika-helium.js"></script>
+  <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+    <link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+  <script src="helium/site/laika-helium.js"></script>
   
   
   <script> /* for avoiding page load transitions */ </script>


### PR DESCRIPTION
This PR joins two pieces of work that would normally be delivered in separate PRs, but the nature of the required changes made that difficult, thus this joint PR.

### Changes in Behaviour

1. `Path.suffix` now splits on the last dot, like most other APIs. This addresses issues where this behaviour did not meet user expectations, but also actual bugs that could occur when input sources contain multiple dots in the file name.

2. The suffixes `.epub.css` and `.epub.js` do no longer have a special meaning in Laika. Previously they marked these files as "to be used for EPUB output only" and likewise marked all `.css` and `.js` files *without* this compound suffix as "for HTML output only". This type of compound suffix was directly supported in `Path.suffix`, causing the unexpected behaviour. But it was also overlapping/conflicting with an existing feature, which is to use HOCON to specify the output format the files contained in a directory should be included for (e.g. `laika.targetFormats = [html, pdf]`). The latter is now the **only** means to limit the output format for input sources.

Fixes #517

