### PR TITLE
preparing repackaging for 1.0 - move ADT members to companion + some more removals from public API

### DIFF
--- a/core/shared/src/main/scala/laika/api/MarkupParser.scala
+++ b/core/shared/src/main/scala/laika/api/MarkupParser.scala
@@ -18,13 +18,14 @@ package laika.api
 
 import cats.syntax.all.*
 import laika.api.builder.{ OperationConfig, ParserBuilder }
+import laika.api.errors.{ InvalidDocument, ParserError }
 import laika.ast.Path.Root
 import laika.ast.{ Document, EmbeddedConfigValue, Path, RewritePhase, UnresolvedDocument }
 import laika.config.Origin.DocumentScope
 import laika.config.{ Config, ConfigBuilder, ConfigValue, Origin }
 import laika.factory.MarkupFormat
 import laika.parse.markup.DocumentParser
-import laika.parse.markup.DocumentParser.{ DocumentInput, InvalidDocument, ParserError }
+import laika.parse.markup.DocumentParser.DocumentInput
 
 /** Performs a parse operation from text markup to a
   * document tree without a subsequent render operation.
@@ -92,16 +93,20 @@ class MarkupParser private[laika] (val format: MarkupFormat, val config: Operati
     }
 
     def rewritePhase(doc: Document, phase: RewritePhase): Either[ParserError, Document] = for {
-      rules  <- config.rewriteRulesFor(doc, phase).leftMap(ParserError(_, doc.path))
-      result <- doc.rewrite(rules).leftMap(ParserError.apply(_, doc.path))
+      rules  <- config.rewriteRulesFor(doc, phase).leftMap(ParserError(_))
+      result <- doc.rewrite(rules).leftMap(ParserError(_))
     } yield result
+
+    def asParserError(document: InvalidDocument): ParserError = new ParserError(
+      s"One or more error nodes in result:\n${InvalidDocument.format(document)}".trim
+    )
 
     def rewriteDocument(resolvedDoc: Document): Either[ParserError, Document] = for {
       phase1 <- rewritePhase(resolvedDoc, RewritePhase.Build)
       phase2 <- rewritePhase(phase1, RewritePhase.Resolve)
       result <- InvalidDocument
         .from(phase2, config.failOnMessages)
-        .map(ParserError(_))
+        .map(asParserError)
         .toLeft(phase2)
     } yield result
 
@@ -109,7 +114,7 @@ class MarkupParser private[laika] (val format: MarkupFormat, val config: Operati
       unresolved     <- docParser(input)
       resolvedConfig <- unresolved.config
         .resolve(Origin(DocumentScope, input.path), config.baseConfig)
-        .left.map(ParserError(_, input.path))
+        .left.map(ParserError(_))
       resolvedDoc = resolveDocument(unresolved, resolvedConfig)
       result <- rewriteDocument(resolvedDoc)
     } yield result

--- a/core/shared/src/main/scala/laika/api/Renderer.scala
+++ b/core/shared/src/main/scala/laika/api/Renderer.scala
@@ -18,10 +18,10 @@ package laika.api
 
 import cats.syntax.all.*
 import laika.api.builder.{ OperationConfig, RendererBuilder, TwoPhaseRendererBuilder }
+import laika.api.errors.RendererError
 import laika.ast.Path.Root
 import laika.ast.*
 import laika.factory.{ MarkupFormat, RenderContext, RenderFormat, TwoPhaseRenderFormat }
-import laika.parse.markup.DocumentParser.RendererError
 import laika.render.Formatter.Indentation
 import laika.rewrite.OutputContext
 import laika.rewrite.nav.{ NoOpPathTranslator, PathTranslator }
@@ -133,7 +133,7 @@ abstract class Renderer private[laika] (val config: OperationConfig, skipRewrite
       config
         .rewriteRulesFor(doc, RewritePhase.Render(OutputContext(format)))
         .map(_.rewriteElement(targetElement))
-        .leftMap(RendererError(_, doc.path))
+        .leftMap(RendererError(_))
     }
 
     (if (skipRewrite) Right(targetElement) else rewrite).map { elementToRender =>

--- a/core/shared/src/main/scala/laika/api/Renderer.scala
+++ b/core/shared/src/main/scala/laika/api/Renderer.scala
@@ -24,7 +24,7 @@ import laika.ast.*
 import laika.factory.{ MarkupFormat, RenderContext, RenderFormat, TwoPhaseRenderFormat }
 import laika.render.Formatter.Indentation
 import laika.rewrite.OutputContext
-import laika.rewrite.nav.{ NoOpPathTranslator, PathTranslator }
+import laika.rewrite.nav.PathTranslator
 
 /** Performs a render operation from a document AST to a target format
   * as a string. The document AST may be obtained by a preceding parse
@@ -70,7 +70,7 @@ abstract class Renderer private[laika] (val config: OperationConfig, skipRewrite
       }
     )
 
-  private val defaultPathTranslator: PathTranslator = NoOpPathTranslator
+  private val defaultPathTranslator: PathTranslator = PathTranslator.noOp
 
   /** Renders the specified document as a String.
     */

--- a/core/shared/src/main/scala/laika/api/Transformer.scala
+++ b/core/shared/src/main/scala/laika/api/Transformer.scala
@@ -17,10 +17,10 @@
 package laika.api
 
 import laika.api.builder.{ OperationConfig, TransformerBuilder, TwoPhaseTransformerBuilder }
+import laika.api.errors.TransformationError
 import laika.ast.Path
 import laika.ast.Path.Root
 import laika.factory.{ MarkupFormat, RenderFormat, TwoPhaseRenderFormat }
-import laika.parse.markup.DocumentParser.TransformationError
 
 /** Performs a transformation from text markup like Markdown or reStructuredText
   * to a target format like HTML as a String.

--- a/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
+++ b/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
@@ -17,8 +17,9 @@
 package laika.api.builder
 
 import laika.ast.RewriteRules.RewriteRulesBuilder
-import laika.config.{ Config, ConfigBuilder, ConfigEncoder, DefaultKey, Key, ValidationError }
-import laika.ast._
+import laika.config.{ Config, ConfigBuilder, ConfigEncoder, DefaultKey, Key }
+import laika.config.ConfigError.ValidationError
+import laika.ast.*
 import laika.bundle.ExtensionBundle.PathTranslatorExtensionContext
 import laika.bundle.{
   BundleOrigin,

--- a/core/shared/src/main/scala/laika/api/errors/errors.scala
+++ b/core/shared/src/main/scala/laika/api/errors/errors.scala
@@ -1,0 +1,129 @@
+package laika.api.errors
+
+import cats.syntax.all.*
+import cats.data.{ Chain, NonEmptyChain }
+import laika.ast.{ Document, DocumentTreeRoot, Invalid, MessageFilter, Path }
+import laika.config.ConfigError
+import laika.config.ConfigError.TreeConfigErrors
+
+sealed trait TransformationError {
+  def message: String
+}
+
+case class RendererError(message: String) extends TransformationError {
+  override def toString: String = message
+}
+
+object RendererError {
+
+  def apply(message: String): RendererError =
+    new RendererError(s"Rendering Error: $message")
+
+  def apply(configError: ConfigError): RendererError =
+    RendererError(s"Configuration Error: ${configError.message}")
+
+}
+
+case class ParserError(message: String) extends TransformationError {
+  override def toString: String = message
+}
+
+object ParserError {
+
+  def apply(message: String): ParserError =
+    new ParserError(s"Error parsing input: $message")
+
+  def apply(configError: ConfigError): ParserError =
+    ParserError(s"Configuration Error: ${configError.message}")
+
+}
+
+private[laika] case class InvalidDocument(
+    errors: Either[NonEmptyChain[ConfigError], NonEmptyChain[Invalid]],
+    path: Path
+) extends RuntimeException(
+      s"One or more errors processing document '$path': ${InvalidDocument.format(errors, path)}"
+    )
+
+private[laika] object InvalidDocument {
+
+  def apply(path: Path, error: ConfigError, errors: ConfigError*): InvalidDocument =
+    new InvalidDocument(Left(NonEmptyChain.fromChainPrepend(error, Chain.fromSeq(errors))), path)
+
+  def apply(path: Path, error: Invalid, errors: Invalid*): InvalidDocument =
+    new InvalidDocument(Right(NonEmptyChain.fromChainPrepend(error, Chain.fromSeq(errors))), path)
+
+  def indent(lineContent: String): String = {
+    val lines = lineContent.split('\n')
+    lines.head + "\n  " + lines.last
+  }
+
+  def format(
+      errors: Either[NonEmptyChain[ConfigError], NonEmptyChain[Invalid]],
+      path: Path
+  ): String =
+    errors.fold(
+      configErrors => configErrors.map(_.message).mkString_("\n"),
+      invalidElems => invalidElems.map(InvalidDocument.formatElement(path)).toList.mkString
+    )
+
+  def format(doc: InvalidDocument): String = format(doc.errors, doc.path)
+
+  def formatElement(docPath: Path)(element: Invalid): String = {
+    val pathStr = element.source.path.fold("") { srcPath =>
+      if (srcPath == docPath) "" else srcPath.toString + ":"
+    }
+    s"""  [$pathStr${element.source.position.line}]: ${element.message.content}
+       |
+       |  ${indent(element.source.position.lineContentWithCaret)}
+       |
+       |""".stripMargin
+  }
+
+  def from(document: Document, failOn: MessageFilter): Option[InvalidDocument] = {
+    val invalidElements = document.invalidElements(failOn)
+    NonEmptyChain.fromSeq(invalidElements).map(inv => InvalidDocument(Right(inv), document.path))
+  }
+
+}
+
+private[laika] case class InvalidDocuments(documents: NonEmptyChain[InvalidDocument])
+    extends RuntimeException(
+      s"One or more invalid documents:\n${InvalidDocuments.format(documents)}"
+    )
+
+private[laika] object InvalidDocuments {
+
+  def format(documents: NonEmptyChain[InvalidDocument]): String = {
+
+    def formatDoc(doc: InvalidDocument): String =
+      s"""${doc.path}
+         |
+         |${InvalidDocument.format(doc)}""".stripMargin
+
+    documents.map(formatDoc).mkString_("").trim
+  }
+
+  def from(
+      result: Either[TreeConfigErrors, DocumentTreeRoot],
+      failOn: MessageFilter
+  ): Either[InvalidDocuments, DocumentTreeRoot] = {
+    result.fold(
+      errors =>
+        Left(
+          InvalidDocuments(
+            errors.failures.map(err => InvalidDocument(Left(err.failures), err.path))
+          )
+        ),
+      root => from(root, failOn).toLeft(root)
+    )
+  }
+
+  def from(root: DocumentTreeRoot, failOn: MessageFilter): Option[InvalidDocuments] = {
+    val invalidDocs = root.allDocuments
+      .flatMap(InvalidDocument.from(_, failOn))
+    NonEmptyChain.fromSeq(invalidDocs)
+      .map(InvalidDocuments(_))
+  }
+
+}

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -22,17 +22,8 @@ import laika.ast.Path.Root
 import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.collection.TransitionalCollectionOps.*
 import laika.config.Config.ConfigResult
-import laika.config.{
-  Config,
-  ConfigEncoder,
-  ConfigError,
-  ConfigValue,
-  DocumentConfigErrors,
-  Key,
-  LaikaKeys,
-  Origin,
-  TreeConfigErrors
-}
+import laika.config.ConfigError.{ DocumentConfigErrors, TreeConfigErrors }
+import laika.config.{ Config, ConfigEncoder, ConfigError, ConfigValue, Key, LaikaKeys, Origin }
 import laika.parse.SourceFragment
 import laika.rewrite.{ OutputContext, ReferenceResolver }
 import laika.rewrite.link.{ LinkConfig, LinkValidation, LinkValidator, TargetValidation }

--- a/core/shared/src/main/scala/laika/ast/RewriteRules.scala
+++ b/core/shared/src/main/scala/laika/ast/RewriteRules.scala
@@ -19,7 +19,7 @@ package laika.ast
 import cats.syntax.all.*
 import laika.ast.RewriteRules.{ ChainedRewriteRules, RewritePhaseBuilder, RewriteRulesBuilder }
 import laika.config.Config.ConfigResult
-import laika.config.ConfigErrors
+import laika.config.ConfigError.ConfigErrors
 import laika.factory.{ RenderFormat, TwoPhaseRenderFormat }
 import laika.rewrite.{ OutputContext, TemplateFormatter, UnresolvedNodeDetector }
 import laika.rewrite.link.LinkResolver

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -21,6 +21,7 @@ import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
 import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.config.Config.IncludeMap
+import laika.config.ConfigError.TreeConfigErrors
 import laika.config.*
 import laika.rewrite.nav.{ AutonumberConfig, TargetFormats }
 import laika.rewrite.{ DefaultTemplatePath, OutputContext, TemplateRewriter }

--- a/core/shared/src/main/scala/laika/ast/links.scala
+++ b/core/shared/src/main/scala/laika/ast/links.scala
@@ -17,7 +17,8 @@
 package laika.ast
 
 import laika.ast
-import laika.config.{ ASTValue, ConfigValue, LaikaKeys }
+import laika.config.{ ConfigValue, LaikaKeys }
+import laika.config.ConfigValue.ASTValue
 import laika.parse.SourceFragment
 
 /** An internal or external link target that can be referenced by id, usually only part of the raw document tree and then

--- a/core/shared/src/main/scala/laika/ast/resolvers.scala
+++ b/core/shared/src/main/scala/laika/ast/resolvers.scala
@@ -1,6 +1,7 @@
 package laika.ast
 
-import laika.config.{ ASTValue, ConfigError, ConfigValue, InvalidType, Key, SimpleConfigValue }
+import laika.config.{ ASTValue, ConfigError, ConfigValue, Key, SimpleConfigValue }
+import ConfigError.InvalidType
 import laika.parse.SourceFragment
 
 /** Represents a placeholder inline element that needs

--- a/core/shared/src/main/scala/laika/ast/resolvers.scala
+++ b/core/shared/src/main/scala/laika/ast/resolvers.scala
@@ -127,7 +127,7 @@ case class TemplateContextReference(
     case Right(Some(ASTValue(s: TemplateSpan)))         => s
     case Right(Some(ASTValue(RootElement(content, _)))) => EmbeddedRoot(content)
     case Right(Some(ASTValue(e: Element)))              => TemplateElement(e)
-    case Right(Some(simple: SimpleValue))         => TemplateString(simple.render)
+    case Right(Some(simple: SimpleValue))               => TemplateString(simple.render)
     case Right(None) if !required                       => TemplateString("")
     case Right(None)                                    => TemplateElement(missing)
     case Right(Some(unsupported))                       => TemplateElement(invalidType(unsupported))
@@ -153,13 +153,13 @@ case class MarkupContextReference(
   type Self = MarkupContextReference
 
   def resolve(cursor: DocumentCursor): Span = cursor.resolveReference(ref) match {
-    case Right(Some(ASTValue(s: Span)))         => s
-    case Right(Some(ASTValue(e: Element)))      => TemplateElement(e)
-    case Right(Some(simple: SimpleValue)) => Text(simple.render)
-    case Right(None) if !required               => Text("")
-    case Right(None)                            => missing
-    case Right(Some(unsupported))               => invalidType(unsupported)
-    case Left(configError)                      => invalid(configError)
+    case Right(Some(ASTValue(s: Span)))    => s
+    case Right(Some(ASTValue(e: Element))) => TemplateElement(e)
+    case Right(Some(simple: SimpleValue))  => Text(simple.render)
+    case Right(None) if !required          => Text("")
+    case Right(None)                       => missing
+    case Right(Some(unsupported))          => invalidType(unsupported)
+    case Left(configError)                 => invalid(configError)
   }
 
   def withOptions(options: Options): MarkupContextReference = copy(options = options)

--- a/core/shared/src/main/scala/laika/ast/resolvers.scala
+++ b/core/shared/src/main/scala/laika/ast/resolvers.scala
@@ -1,8 +1,8 @@
 package laika.ast
 
-import laika.config.{ ASTValue, ConfigError, ConfigValue, Key, SimpleConfigValue }
+import laika.config.{ ConfigError, ConfigValue, Key }
 import ConfigError.InvalidType
-import laika.parse.SourceFragment
+import laika.config.ConfigValue.{ ASTValue, SimpleValue }
 
 /** Represents a placeholder inline element that needs
   *  to be resolved in a rewrite step.
@@ -14,6 +14,8 @@ trait SpanResolver extends Span with Unresolved {
   def resolve(cursor: DocumentCursor): Span
   def runsIn(phase: RewritePhase): Boolean
 }
+
+import laika.parse.SourceFragment
 
 /** Represents a placeholder block element that needs to be resolved in a rewrite step.
   *  Useful for elements that need access to the document, structure, title
@@ -125,7 +127,7 @@ case class TemplateContextReference(
     case Right(Some(ASTValue(s: TemplateSpan)))         => s
     case Right(Some(ASTValue(RootElement(content, _)))) => EmbeddedRoot(content)
     case Right(Some(ASTValue(e: Element)))              => TemplateElement(e)
-    case Right(Some(simple: SimpleConfigValue))         => TemplateString(simple.render)
+    case Right(Some(simple: SimpleValue))         => TemplateString(simple.render)
     case Right(None) if !required                       => TemplateString("")
     case Right(None)                                    => TemplateElement(missing)
     case Right(Some(unsupported))                       => TemplateElement(invalidType(unsupported))
@@ -153,7 +155,7 @@ case class MarkupContextReference(
   def resolve(cursor: DocumentCursor): Span = cursor.resolveReference(ref) match {
     case Right(Some(ASTValue(s: Span)))         => s
     case Right(Some(ASTValue(e: Element)))      => TemplateElement(e)
-    case Right(Some(simple: SimpleConfigValue)) => Text(simple.render)
+    case Right(Some(simple: SimpleValue)) => Text(simple.render)
     case Right(None) if !required               => Text("")
     case Right(None)                            => missing
     case Right(Some(unsupported))               => invalidType(unsupported)

--- a/core/shared/src/main/scala/laika/bundle/ParserBundle.scala
+++ b/core/shared/src/main/scala/laika/bundle/ParserBundle.scala
@@ -16,9 +16,8 @@
 
 package laika.bundle
 
-import laika.ast._
+import laika.ast.*
 import laika.parse.Parser
-import laika.parse.markup.DocumentParser.DocumentInput
 
 /** Bundles a collection of all types of parsers used in a transformation.
   *
@@ -87,7 +86,7 @@ class ParserBundle(
 class ParserHooks(
     val postProcessBlocks: Seq[Block] => Seq[Block] = identity,
     val postProcessDocument: UnresolvedDocument => UnresolvedDocument = identity,
-    val preProcessInput: DocumentInput => DocumentInput = identity
+    val preProcessInput: String => String = identity
 ) {
 
   /** Merges this instance with the specified base.

--- a/core/shared/src/main/scala/laika/config/Config.scala
+++ b/core/shared/src/main/scala/laika/config/Config.scala
@@ -18,8 +18,10 @@ package laika.config
 
 import laika.config.Config.ConfigResult
 import laika.config.ConfigError.{ DecodingError, NotFound }
+import laika.config.ConfigValue.{ ArrayValue, ObjectValue }
 import laika.parse.hocon.{ IncludeResource, ObjectBuilderValue }
 
+import scala.annotation.tailrec
 import scala.util.Try
 
 /** API for retrieving configuration values based on a string key and a decoder.
@@ -191,6 +193,7 @@ private[laika] class ObjectConfig(
     }
   }
 
+  @tailrec
   private def lookup(keySegments: Seq[String], target: ObjectValue): Option[Field] = {
     (target.values.find(_.key == keySegments.head), keySegments.tail) match {
       case (res, Nil)                                          => res

--- a/core/shared/src/main/scala/laika/config/Config.scala
+++ b/core/shared/src/main/scala/laika/config/Config.scala
@@ -17,6 +17,7 @@
 package laika.config
 
 import laika.config.Config.ConfigResult
+import laika.config.ConfigError.{ DecodingError, NotFound }
 import laika.parse.hocon.{ IncludeResource, ObjectBuilderValue }
 
 import scala.util.Try

--- a/core/shared/src/main/scala/laika/config/ConfigBuilder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigBuilder.scala
@@ -16,6 +16,8 @@
 
 package laika.config
 
+import ConfigValue.ObjectValue
+
 import laika.collection.TransitionalCollectionOps._
 
 /** A builder for creating a Config instance programmatically.

--- a/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
@@ -68,7 +68,7 @@ object ConfigDecoder {
 
     def apply(value: Traced[ConfigValue]) = value.value match {
       case s: SimpleValue => Right(s.render)
-      case invalid              => Left(InvalidType("String", invalid))
+      case invalid        => Left(InvalidType("String", invalid))
     }
 
   }

--- a/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
@@ -21,6 +21,7 @@ import cats.implicits._
 import laika.ast.RelativePath.CurrentDocument
 import laika.ast.{ ExternalTarget, InternalTarget, Path, VirtualPath, RelativePath, Target }
 import laika.time.PlatformDateTime
+import ConfigError.{ DecodingError, InvalidType }
 
 import java.net.URI
 import scala.util.Try

--- a/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
@@ -17,11 +17,12 @@
 package laika.config
 
 import cats.data.NonEmptyChain
-import cats.implicits._
+import cats.syntax.all.*
 import laika.ast.RelativePath.CurrentDocument
-import laika.ast.{ ExternalTarget, InternalTarget, Path, VirtualPath, RelativePath, Target }
+import laika.ast.{ ExternalTarget, InternalTarget, Path, RelativePath, Target, VirtualPath }
 import laika.time.PlatformDateTime
 import ConfigError.{ DecodingError, InvalidType }
+import ConfigValue.*
 
 import java.net.URI
 import scala.util.Try
@@ -66,7 +67,7 @@ object ConfigDecoder {
   implicit val string: ConfigDecoder[String] = new ConfigDecoder[String] {
 
     def apply(value: Traced[ConfigValue]) = value.value match {
-      case s: SimpleConfigValue => Right(s.render)
+      case s: SimpleValue => Right(s.render)
       case invalid              => Left(InvalidType("String", invalid))
     }
 

--- a/core/shared/src/main/scala/laika/config/ConfigEncoder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigEncoder.scala
@@ -17,6 +17,7 @@
 package laika.config
 
 import cats.data.NonEmptyChain
+import ConfigValue.*
 import laika.ast.{ Element, Path }
 import laika.time.PlatformDateTime
 

--- a/core/shared/src/main/scala/laika/config/ConfigError.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigError.scala
@@ -16,7 +16,7 @@
 
 package laika.config
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.data.NonEmptyChain
 import laika.ast.Path
 import laika.parse.Failure
@@ -31,84 +31,89 @@ sealed trait ConfigError {
   def message: String
 }
 
-/** Indicates that a value found in the configuration does not have the expected
-  * type so that type conversion is not even attempted.
-  */
-case class InvalidType(expected: String, actual: ConfigValue) extends ConfigError {
+object ConfigError {
 
-  val message: String =
-    s"Invalid type - expected: $expected, actual: ${actual.productPrefix.replace("Value", "")}"
+  /** Indicates that a value found in the configuration does not have the expected
+    * type so that type conversion is not even attempted.
+    */
+  case class InvalidType(expected: String, actual: ConfigValue) extends ConfigError {
 
-}
+    val message: String =
+      s"Invalid type - expected: $expected, actual: ${actual.productPrefix.replace("Value", "")}"
 
-/** An error that occurred when decoding a configuration value to a target type. */
-case class DecodingError(error: String, key: Option[Key] = None) extends ConfigError {
-  val message: String = key.fold("")(k => s"Error decoding '${k.toString}': ") + error
-  def withKey(key: Key): DecodingError = copy(key = Some(key))
-}
-
-/** A generic error for invalid values. */
-case class ValidationError(message: String) extends ConfigError
-
-/** An error that occurred when parsing HOCON input. */
-case class ConfigParserError(failure: Failure) extends ConfigError {
-  val message = failure.toString
-}
-
-/** Multiple errors that occurred when parsing HOCON input. */
-case class ConfigParserErrors(failures: Seq[Failure]) extends ConfigError {
-  val message = failures.map(_.toString).mkString("Multiple errors parsing HOCON: ", ", ", "")
-}
-
-/** Multiple errors that occurred when processing configuration. */
-case class ConfigErrors(failures: NonEmptyChain[ConfigError]) extends ConfigError {
-
-  val message =
-    failures.map(_.toString).mkString_("Multiple errors processing configuration: ", ", ", "")
-
-}
-
-/** Multiple errors that occurred when processing configuration for a document. */
-case class DocumentConfigErrors(path: Path, failures: NonEmptyChain[ConfigError])
-    extends ConfigError {
-
-  val message = failures.map(_.toString).mkString_(
-    s"Multiple errors processing configuration for document '$path': ",
-    ", ",
-    ""
-  )
-
-}
-
-object DocumentConfigErrors {
-
-  def apply(path: Path, error: ConfigError): DocumentConfigErrors = error match {
-    case ConfigErrors(errors) => new DocumentConfigErrors(path, errors)
-    case other                => new DocumentConfigErrors(path, NonEmptyChain.one(other))
   }
 
-}
+  /** An error that occurred when decoding a configuration value to a target type. */
+  case class DecodingError(error: String, key: Option[Key] = None) extends ConfigError {
+    val message: String = key.fold("")(k => s"Error decoding '${k.toString}': ") + error
 
-/** Multiple errors that occurred when processing configuration for a document tree. */
-case class TreeConfigErrors(failures: NonEmptyChain[DocumentConfigErrors]) extends ConfigError {
+    def withKey(key: Key): DecodingError = copy(key = Some(key))
+  }
 
-  val message = failures.map(_.toString).mkString_(
-    s"Multiple errors processing configuration for document tree: ",
-    ", ",
-    ""
-  )
+  /** A generic error for invalid values. */
+  case class ValidationError(message: String) extends ConfigError
 
-}
+  /** An error that occurred when parsing HOCON input. */
+  case class ConfigParserError(failure: Failure) extends ConfigError {
+    val message = failure.toString
+  }
 
-/** An error that occurred when resolving the interim result of a parsing operation. */
-case class ConfigResolverError(message: String) extends ConfigError
+  /** Multiple errors that occurred when parsing HOCON input. */
+  case class ConfigParserErrors(failures: Seq[Failure]) extends ConfigError {
+    val message = failures.map(_.toString).mkString("Multiple errors parsing HOCON: ", ", ", "")
+  }
 
-/** An error that occurred when loading a resource, before parsing could start. */
-case class ConfigResourceError(message: String) extends ConfigError
+  /** Multiple errors that occurred when processing configuration. */
+  case class ConfigErrors(failures: NonEmptyChain[ConfigError]) extends ConfigError {
 
-/** A required value that could not be found. */
-case class NotFound(key: Key) extends ConfigError {
-  val message: String = s"Not found: '$key'"
+    val message =
+      failures.map(_.toString).mkString_("Multiple errors processing configuration: ", ", ", "")
+
+  }
+
+  /** Multiple errors that occurred when processing configuration for a document. */
+  case class DocumentConfigErrors(path: Path, failures: NonEmptyChain[ConfigError])
+      extends ConfigError {
+
+    val message = failures.map(_.toString).mkString_(
+      s"Multiple errors processing configuration for document '$path': ",
+      ", ",
+      ""
+    )
+
+  }
+
+  object DocumentConfigErrors {
+
+    def apply(path: Path, error: ConfigError): DocumentConfigErrors = error match {
+      case ConfigErrors(errors) => new DocumentConfigErrors(path, errors)
+      case other                => new DocumentConfigErrors(path, NonEmptyChain.one(other))
+    }
+
+  }
+
+  /** Multiple errors that occurred when processing configuration for a document tree. */
+  case class TreeConfigErrors(failures: NonEmptyChain[DocumentConfigErrors]) extends ConfigError {
+
+    val message = failures.map(_.toString).mkString_(
+      s"Multiple errors processing configuration for document tree: ",
+      ", ",
+      ""
+    )
+
+  }
+
+  /** An error that occurred when resolving the interim result of a parsing operation. */
+  case class ConfigResolverError(message: String) extends ConfigError
+
+  /** An error that occurred when loading a resource, before parsing could start. */
+  case class ConfigResourceError(message: String) extends ConfigError
+
+  /** A required value that could not be found. */
+  case class NotFound(key: Key) extends ConfigError {
+    val message: String = s"Not found: '$key'"
+  }
+
 }
 
 /** A ConfigError as a RuntimeException for use cases where a Throwable is required. */

--- a/core/shared/src/main/scala/laika/config/ConfigError.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigError.scala
@@ -22,8 +22,7 @@ import laika.ast.Path
 import laika.parse.Failure
 
 /** Base trait for all configuration errors that occurred
-  * during parsing, resolving, retrieving or convering
-  * configuration values.
+  * during parsing, resolving, retrieving or decoding configuration values.
   *
   * @author Jens Halm
   */
@@ -115,6 +114,3 @@ object ConfigError {
   }
 
 }
-
-/** A ConfigError as a RuntimeException for use cases where a Throwable is required. */
-case class ConfigException(error: ConfigError) extends RuntimeException(error.message)

--- a/core/shared/src/main/scala/laika/config/ConfigParser.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigParser.scala
@@ -17,6 +17,7 @@
 package laika.config
 
 import laika.config.Config.IncludeMap
+import laika.config.ConfigError.{ ConfigResourceError, ConfigParserError }
 import laika.parse.{ Failure, Success }
 import laika.parse.hocon.{
   BuilderField,

--- a/core/shared/src/main/scala/laika/directive/api.scala
+++ b/core/shared/src/main/scala/laika/directive/api.scala
@@ -20,6 +20,7 @@ import cats.{ Functor, Semigroupal }
 import laika.ast.{ TemplateSpan, * }
 import laika.collection.TransitionalCollectionOps.*
 import laika.config.Origin.DirectiveScope
+import laika.config.ConfigError.DecodingError
 import laika.config.*
 import laika.parse.SourceFragment
 import laika.parse.directive.DirectiveParsers.ParsedDirective

--- a/core/shared/src/main/scala/laika/directive/std/ControlFlowDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/ControlFlowDirectives.scala
@@ -16,17 +16,10 @@
 
 package laika.directive.std
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import laika.ast.{ InvalidSpan, TemplateElement, TemplateScope, TemplateSpan, TemplateSpanSequence }
-import laika.config.{
-  ArrayValue,
-  BooleanValue,
-  ConfigValue,
-  Key,
-  NullValue,
-  ObjectValue,
-  StringValue
-}
+import laika.config.{ ConfigValue, Key }
+import laika.config.ConfigValue.*
 import laika.directive.Templates
 
 import scala.annotation.tailrec

--- a/core/shared/src/main/scala/laika/directive/std/IncludeDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/IncludeDirectives.scala
@@ -16,7 +16,7 @@
 
 package laika.directive.std
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import laika.ast.{
   Block,
   BlockScope,
@@ -28,7 +28,8 @@ import laika.ast.{
   TemplateSpan,
   TemplateSpanSequence
 }
-import laika.config.{ ASTValue, Config, Field, ObjectConfig, ObjectValue, Origin }
+import laika.config.ConfigValue.{ ASTValue, ObjectValue }
+import laika.config.{ Config, Field, ObjectConfig, Origin }
 import laika.directive.{ Blocks, Templates }
 import laika.parse.SourceFragment
 

--- a/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
@@ -23,7 +23,8 @@ import laika.bundle.BundleOrigin
 import laika.config.{ Key, LaikaKeys }
 import laika.config.ConfigValue.SimpleValue
 import laika.directive.*
-import laika.rewrite.link.{ InvalidTarget, RecoveredTarget, ValidTarget }
+import laika.rewrite.link.TargetValidation.*
+import laika.rewrite.link.TargetValidation.ValidTarget
 import laika.time.PlatformDateTime
 
 import scala.collection.immutable.TreeSet
@@ -169,9 +170,9 @@ private[laika] object StandardDirectives extends DirectiveRegistry {
 
     (attribute(0).as[String], attribute(1).as[String], cursor).mapN { (name, ref, cursor) =>
       cursor.resolveReference(Key.parse(ref)).leftMap(_.message).flatMap {
-        case None                           => Right(TemplateString(""))
+        case None                     => Right(TemplateString(""))
         case Some(value: SimpleValue) => Right(TemplateString(s"""$name="${value.render}""""))
-        case Some(_)                        =>
+        case Some(_)                  =>
           Left(
             s"value with key '$ref' is a structured value (Array, Object, AST) which is not supported by this directive"
           )

--- a/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
@@ -17,11 +17,12 @@
 package laika.directive.std
 
 import cats.data.NonEmptySet
-import cats.syntax.all._
-import laika.ast._
+import cats.syntax.all.*
+import laika.ast.*
 import laika.bundle.BundleOrigin
-import laika.config.{ Key, LaikaKeys, SimpleConfigValue }
-import laika.directive._
+import laika.config.{ Key, LaikaKeys }
+import laika.config.ConfigValue.SimpleValue
+import laika.directive.*
 import laika.rewrite.link.{ InvalidTarget, RecoveredTarget, ValidTarget }
 import laika.time.PlatformDateTime
 
@@ -169,7 +170,7 @@ private[laika] object StandardDirectives extends DirectiveRegistry {
     (attribute(0).as[String], attribute(1).as[String], cursor).mapN { (name, ref, cursor) =>
       cursor.resolveReference(Key.parse(ref)).leftMap(_.message).flatMap {
         case None                           => Right(TemplateString(""))
-        case Some(value: SimpleConfigValue) => Right(TemplateString(s"""$name="${value.render}""""))
+        case Some(value: SimpleValue) => Right(TemplateString(s"""$name="${value.render}""""))
         case Some(_)                        =>
           Left(
             s"value with key '$ref' is a structured value (Array, Object, AST) which is not supported by this directive"

--- a/core/shared/src/main/scala/laika/format/ReStructuredText.scala
+++ b/core/shared/src/main/scala/laika/format/ReStructuredText.scala
@@ -281,7 +281,7 @@ case object ReStructuredText extends MarkupFormat { self =>
     override val parsers: ParserBundle = new ParserBundle(
       markupParserHooks = Some(
         new ParserHooks(
-          preProcessInput = WhitespacePreprocessor.forInput,
+          preProcessInput = WhitespacePreprocessor.forString,
           postProcessDocument = DocInfoExtractor,
           postProcessBlocks = LinkTargetProcessor
         )

--- a/core/shared/src/main/scala/laika/parse/hocon/ConfigBuilderValue.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/ConfigBuilderValue.scala
@@ -16,7 +16,8 @@
 
 package laika.parse.hocon
 
-import laika.config.{ Key, SimpleConfigValue }
+import laika.config.ConfigValue.SimpleValue
+import laika.config.Key
 import laika.parse.Failure
 
 /** The base trait of the interim configuration model (usually obtained from a HOCON parser).
@@ -84,7 +85,7 @@ private[laika] case class InvalidBuilderValue(value: ConfigBuilderValue, failure
     extends ConfigBuilderValue
 
 /** A simple configuration value that does not need to be recursively resolved. */
-private[laika] case class ResolvedBuilderValue(value: SimpleConfigValue) extends ConfigBuilderValue
+private[laika] case class ResolvedBuilderValue(value: SimpleValue) extends ConfigBuilderValue
 
 /** Description of a resource to be included in the current configuration. */
 private[laika] sealed trait IncludeResource {

--- a/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
@@ -153,8 +153,8 @@ private[laika] object ConfigResolver {
           resolveValue(key)(other) match {
             case Some(simpleValue: SimpleValue) =>
               Some(StringValue(part.whitespace + simpleValue.render))
-            case Some(_: ASTValue)                    => None
-            case other                                => other
+            case Some(_: ASTValue)              => None
+            case other                          => other
           }
       }
 

--- a/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
@@ -20,6 +20,7 @@ import laika.collection.TransitionalCollectionOps.*
 import laika.config.Config.IncludeMap
 import laika.config.*
 import laika.config.ConfigError.{ ConfigParserErrors, ConfigResolverError }
+import laika.config.ConfigValue.*
 import laika.parse.Failure
 
 import scala.collection.mutable
@@ -150,7 +151,7 @@ private[laika] object ConfigResolver {
         case SelfReference => None
         case other         =>
           resolveValue(key)(other) match {
-            case Some(simpleValue: SimpleConfigValue) =>
+            case Some(simpleValue: SimpleValue) =>
               Some(StringValue(part.whitespace + simpleValue.render))
             case Some(_: ASTValue)                    => None
             case other                                => other

--- a/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/ConfigResolver.scala
@@ -16,9 +16,10 @@
 
 package laika.parse.hocon
 
-import laika.collection.TransitionalCollectionOps._
+import laika.collection.TransitionalCollectionOps.*
 import laika.config.Config.IncludeMap
-import laika.config._
+import laika.config.*
+import laika.config.ConfigError.{ ConfigParserErrors, ConfigResolverError }
 import laika.parse.Failure
 
 import scala.collection.mutable

--- a/core/shared/src/main/scala/laika/parse/hocon/HoconParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/hocon/HoconParsers.scala
@@ -16,14 +16,15 @@
 
 package laika.parse.hocon
 
-import cats.implicits._
+import cats.syntax.all.*
 import cats.data.NonEmptySet
 import laika.ast.~
-import laika.config._
+import laika.config.*
+import laika.config.ConfigValue.*
 import laika.parse.code.common.NumberLiteral.digits
 import laika.parse.text.{ CharGroup, Characters }
-import laika.parse.builders._
-import laika.parse.implicits._
+import laika.parse.builders.*
+import laika.parse.implicits.*
 import laika.parse.{ Failure, Message, Parser, SourceCursor }
 
 import scala.annotation.nowarn

--- a/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
@@ -16,15 +16,16 @@
 
 package laika.parse.markup
 
-import cats.implicits._
+import cats.implicits.*
 import cats.data.{ Chain, NonEmptyChain }
-import laika.ast._
+import laika.ast.*
 import laika.bundle.{ ConfigProvider, MarkupExtensions }
-import laika.config.{ ConfigError, ConfigParser, TreeConfigErrors }
+import laika.config.ConfigError.TreeConfigErrors
+import laika.config.{ ConfigError, ConfigParser }
 import laika.factory.MarkupFormat
 import laika.parse.combinator.Parsers
 import laika.parse.{ Parser, SourceCursor }
-import laika.parse.implicits._
+import laika.parse.implicits.*
 
 /** Responsible for creating the top level parsers for text markup and template documents,
   * by combining the parser for the root element with a parser for an (optional) configuration

--- a/core/shared/src/main/scala/laika/parse/text/WhitespacePreprocessor.scala
+++ b/core/shared/src/main/scala/laika/parse/text/WhitespacePreprocessor.scala
@@ -16,9 +16,6 @@
 
 package laika.parse.text
 
-import laika.parse.SourceCursor
-import laika.parse.markup.DocumentParser.DocumentInput
-
 /** Processes whitespace, removing or replacing most whitespace characters except
   * for newline and space.
   *
@@ -91,15 +88,5 @@ object WhitespacePreprocessor {
   /** Processes all whitespace in the specified string.
     */
   val forString: String => String = new WhitespacePreprocessor
-
-  /** Processes the specified Input instance and returns
-    * a new instance with the same path, but all whitespace
-    * pre-processed.
-    */
-  val forInput: DocumentInput => DocumentInput = { input =>
-    val raw          = input.source.input
-    val preprocessed = forString(raw)
-    input.copy(source = SourceCursor(preprocessed, input.path))
-  }
 
 }

--- a/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
@@ -18,15 +18,9 @@ package laika.rewrite
 
 import laika.config.Config.ConfigResult
 import laika.config.ConfigValue.ASTValue
-import laika.config.{
-  Config,
-  ConfigBuilder,
-  ConfigValue,
-  Field,
-  Key
-}
+import laika.config.{ Config, ConfigBuilder, ConfigValue, Field, Key }
 import laika.ast.{ Document, DocumentTree, Path, RawLink, SpanSequence, TreeCursor }
-import laika.config.ConfigValue.{ObjectValue, StringValue}
+import laika.config.ConfigValue.{ ObjectValue, StringValue }
 
 /** A resolver for context references in templates or markup documents.
   *

--- a/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
@@ -17,17 +17,16 @@
 package laika.rewrite
 
 import laika.config.Config.ConfigResult
+import laika.config.ConfigValue.ASTValue
 import laika.config.{
-  ASTValue,
   Config,
   ConfigBuilder,
   ConfigValue,
   Field,
-  Key,
-  ObjectValue,
-  StringValue
+  Key
 }
 import laika.ast.{ Document, DocumentTree, Path, RawLink, SpanSequence, TreeCursor }
+import laika.config.ConfigValue.{ObjectValue, StringValue}
 
 /** A resolver for context references in templates or markup documents.
   *

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -19,7 +19,8 @@ package laika.rewrite
 import cats.implicits.*
 import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.ast.*
-import laika.config.{ ConfigError, LaikaKeys, ValidationError }
+import laika.config.{ ConfigError, LaikaKeys }
+import laika.config.ConfigError.ValidationError
 import laika.factory.{ RenderFormat, TwoPhaseRenderFormat }
 import laika.parse.{ LineSource, SourceCursor }
 import laika.rewrite.ReferenceResolver.CursorKeys

--- a/core/shared/src/main/scala/laika/rewrite/Version.scala
+++ b/core/shared/src/main/scala/laika/rewrite/Version.scala
@@ -19,14 +19,9 @@ package laika.rewrite
 import cats.syntax.all.*
 import cats.data.NonEmptyChain
 import laika.ast.Path
-import laika.config.{
-  ConfigDecoder,
-  ConfigEncoder,
-  ConfigErrors,
-  DefaultKey,
-  LaikaKeys,
-  ValidationError
-}
+import laika.config.ConfigError.{ ConfigErrors, ValidationError }
+import laika.config.{ ConfigDecoder, ConfigEncoder, DefaultKey }
+import laika.config.LaikaKeys
 
 /** Configuration for a single version of the documentation.
   */

--- a/core/shared/src/main/scala/laika/rewrite/link/LinkConfig.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/LinkConfig.scala
@@ -18,6 +18,7 @@ package laika.rewrite.link
 
 import laika.ast.{ ExternalTarget, InternalTarget, Path, Target, VirtualPath }
 import laika.config.*
+import ConfigError.ValidationError
 
 sealed abstract class LinkConfig {
 

--- a/core/shared/src/main/scala/laika/rewrite/link/LinkValidator.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/LinkValidator.scala
@@ -36,7 +36,8 @@ import laika.config.{ Config, LaikaKeys }
 import laika.parse.SourceFragment
 import laika.rewrite.Versions
 import laika.rewrite.nav.TargetFormats
-import cats.syntax.all._
+import cats.syntax.all.*
+import TargetValidation.*
 
 /** Validates internal links based on the presence and configuration of the targets it points to.
   * A link target may be valid for all formats or just some, and it may point to a sub-directory
@@ -183,11 +184,15 @@ private[laika] class LinkValidator(
 }
 
 sealed trait TargetValidation
-case object ValidTarget                   extends TargetValidation
-case class InvalidTarget(message: String) extends TargetValidation
 
-case class RecoveredTarget(message: String, recoveredTarget: ResolvedInternalTarget)
-    extends TargetValidation
+object TargetValidation {
+  case object ValidTarget                   extends TargetValidation
+  case class InvalidTarget(message: String) extends TargetValidation
+
+  case class RecoveredTarget(message: String, recoveredTarget: ResolvedInternalTarget)
+      extends TargetValidation
+
+}
 
 private[laika] class TargetLookup(cursor: RootCursor) extends (Path => Option[TargetFormats]) {
 

--- a/core/shared/src/main/scala/laika/rewrite/nav/AutonumberConfig.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/AutonumberConfig.scala
@@ -134,7 +134,8 @@ private[nav] object Scope {
     case "sections"  => Right(Sections)
     case "all"       => Right(All)
     case "none"      => Right(None)
-    case other       => Left(ValidationError(s"Invalid value for autonumbering.scope: $other"))
+    case other       =>
+      Left(ConfigError.ValidationError(s"Invalid value for autonumbering.scope: $other"))
   }
 
 }

--- a/core/shared/src/main/scala/laika/rewrite/nav/PathTranslator.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/PathTranslator.scala
@@ -110,6 +110,21 @@ object PathTranslator {
   def postTranslate(baseTranslator: PathTranslator)(f: Path => Path): PathTranslator =
     new PathTranslatorExtension(baseTranslator, postTranslate = f)
 
+  /** Path translator implementation that returns all paths unmodified.
+    *
+    * Used in scenarios where only a single document gets rendered and there is no use case for
+    * cross references or static or versioned documents.
+    */
+  val noOp: PathTranslator = new PathTranslator {
+    def getAttributes(path: Path): Option[PathAttributes] = None
+
+    def translate(input: Path): Path = input
+
+    def translate(input: RelativePath): RelativePath = input
+
+    def forReferencePath(path: Path): PathTranslator = this
+  }
+
 }
 
 private[laika] class PathTranslatorExtension(
@@ -272,16 +287,4 @@ private[laika] class TargetLookup(cursor: RootCursor) extends (Path => Option[Pa
   // paths which have validation disabled might not appear in the lookup, we treat them as static and
   // pick the versioned flag from its directory config.
 
-}
-
-/** Path translator implementation that returns all paths unmodified.
-  *
-  * Used in scenarios where only a single document gets rendered and there is no use case for
-  * cross references or static or versioned documents.
-  */
-object NoOpPathTranslator extends PathTranslator {
-  def getAttributes(path: Path): Option[PathAttributes] = None
-  def translate(input: Path): Path                      = input
-  def translate(input: RelativePath): RelativePath      = input
-  def forReferencePath(path: Path): PathTranslator      = this
 }

--- a/core/shared/src/main/scala/laika/rst/std/StandardBlockDirectives.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardBlockDirectives.scala
@@ -18,7 +18,8 @@ package laika.rst.std
 
 import cats.data.NonEmptySet
 import laika.ast.*
-import laika.config.{ Field, LaikaKeys, ObjectValue, Origin, StringValue }
+import laika.config.ConfigValue.{ StringValue, ObjectValue }
+import laika.config.{ Field, LaikaKeys, Origin }
 import laika.parse.{ GeneratedSource, SourceFragment }
 import laika.parse.markup.RecursiveParsers
 import laika.rst.ast.{ Contents, FieldList, Include, RstStyle }

--- a/core/shared/src/test/scala/laika/api/ParseAPISpec.scala
+++ b/core/shared/src/test/scala/laika/api/ParseAPISpec.scala
@@ -17,11 +17,10 @@
 package laika.api
 
 import laika.api.builder.OperationConfig
-import laika.ast.Path.Root
-import laika.ast._
+import laika.api.errors.ParserError
+import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.format.{ HTML, Markdown }
-import laika.parse.markup.DocumentParser.ParserError
 import laika.rewrite.OutputContext
 import munit.FunSuite
 
@@ -103,7 +102,7 @@ class ParseAPISpec extends FunSuite
                 |
                 |  [invalid2]
                 |  ^""".stripMargin
-    assertEquals(MarkupParser.of(Markdown).build.parse(input), Left(ParserError(msg, Root / "doc")))
+    assertEquals(MarkupParser.of(Markdown).build.parse(input), Left(new ParserError(msg)))
   }
 
   test("replace unresolved nodes with invalid elements") {

--- a/core/shared/src/test/scala/laika/api/RenderPhaseRewrite.scala
+++ b/core/shared/src/test/scala/laika/api/RenderPhaseRewrite.scala
@@ -1,10 +1,10 @@
 package laika.api
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import laika.api.builder.OperationConfig
+import laika.api.errors.RendererError
 import laika.ast.{ Document, RewritePhase }
 import laika.factory.RenderFormat
-import laika.parse.markup.DocumentParser.RendererError
 
 trait RenderPhaseRewrite {
 
@@ -22,7 +22,7 @@ trait RenderPhaseRewrite {
     config
       .rewriteRulesFor(doc, RewritePhase.Render(format))
       .flatMap(doc.rewrite)
-      .leftMap(RendererError(_, doc.path))
+      .leftMap(RendererError(_))
   }
 
 }

--- a/core/shared/src/test/scala/laika/ast/DocumentAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentAPISpec.scala
@@ -18,11 +18,10 @@ package laika.ast
 
 import laika.api.MarkupParser
 import laika.api.builder.OperationConfig
-import laika.ast.Path.Root
+import laika.api.errors.ParserError
 import laika.ast.sample.ParagraphCompanionShortcuts
 import laika.config.LaikaKeys
 import laika.format.Markdown
-import laika.parse.markup.DocumentParser.ParserError
 import munit.FunSuite
 
 class DocumentAPISpec extends FunSuite
@@ -78,7 +77,7 @@ class DocumentAPISpec extends FunSuite
       .withConfigValue(LaikaKeys.firstHeaderAsTitle, true)
       .build
       .parse(markup)
-      .flatMap(_.title.toRight(ParserError("no title", Root)))
+      .flatMap(_.title.toRight(ParserError("no title")))
 
     assertEquals(res, Right(SpanSequence("Title")))
   }

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -18,7 +18,7 @@ package laika.ast
 
 import cats.data.NonEmptyChain
 import laika.api.builder.OperationConfig
-import laika.config.{ ArrayValue, Config, ConfigParser, Key, LongValue, Origin }
+import laika.config.{ Config, ConfigParser, Key, Origin }
 import laika.config.ConfigError.{
   DocumentConfigErrors,
   InvalidType,
@@ -35,6 +35,7 @@ import laika.ast.sample.{
   TestSourceBuilders
 }
 import laika.config.Config.ConfigResult
+import laika.config.ConfigValue.{ ArrayValue, LongValue }
 import laika.config.Origin.{ DocumentScope, Scope, TreeScope }
 import laika.format.HTML
 import laika.parse.GeneratedSource

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -18,15 +18,10 @@ package laika.ast
 
 import cats.data.NonEmptyChain
 import laika.api.builder.OperationConfig
-import laika.config.{
-  ArrayValue,
-  Config,
-  ConfigParser,
+import laika.config.{ ArrayValue, Config, ConfigParser, Key, LongValue, Origin }
+import laika.config.ConfigError.{
   DocumentConfigErrors,
   InvalidType,
-  Key,
-  LongValue,
-  Origin,
   TreeConfigErrors,
   ValidationError
 }

--- a/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
@@ -18,7 +18,8 @@ package laika.ast.sample
 
 import laika.ast.Path.Root
 import laika.ast.*
-import laika.config.{ Config, ConfigBuilder, LaikaKeys, Origin, TreeConfigErrors }
+import laika.config.ConfigError.TreeConfigErrors
+import laika.config.{ Config, ConfigBuilder, LaikaKeys, Origin }
 import laika.rewrite.link.LinkValidation
 
 object SampleTrees {

--- a/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
+++ b/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
@@ -18,10 +18,9 @@ package laika.bundle
 
 import laika.ast.RewriteRules.RewritePhaseBuilder
 import laika.config.{ Config, ConfigParser }
-import laika.ast._
+import laika.ast.*
 import laika.directive.{ DirectiveRegistry, Templates }
 import laika.parse.Parser
-import laika.parse.markup.DocumentParser.DocumentInput
 import laika.rewrite.nav.PathTranslator
 
 /** @author Jens Halm
@@ -49,7 +48,7 @@ object BundleProvider {
   def forParserHooks(
       postProcessBlocks: Seq[Block] => Seq[Block] = identity,
       postProcessDocument: UnresolvedDocument => UnresolvedDocument = identity,
-      preProcessInput: DocumentInput => DocumentInput = identity,
+      preProcessInput: String => String = identity,
       origin: BundleOrigin = BundleOrigin.User
   ): ExtensionBundle = new TestExtensionBundle(origin) {
 

--- a/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
@@ -21,6 +21,7 @@ import laika.ast.{ DocumentMetadata, IconGlyph, IconStyle }
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
 import laika.config.ConfigError.{ DecodingError, ConfigErrors, ValidationError }
+import laika.config.ConfigValue.ASTValue
 import laika.rewrite.{ Version, Versions }
 import laika.rewrite.link.{
   ApiLinks,

--- a/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
@@ -20,6 +20,7 @@ import cats.data.NonEmptyChain
 import laika.ast.{ DocumentMetadata, IconGlyph, IconStyle }
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
+import laika.config.ConfigError.{ DecodingError, ConfigErrors, ValidationError }
 import laika.rewrite.{ Version, Versions }
 import laika.rewrite.link.{
   ApiLinks,

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -22,6 +22,7 @@ import laika.ast.Path.Root
 import laika.ast.*
 import laika.ast.sample.TestSourceBuilders
 import laika.bundle.*
+import ConfigError.ConfigParserError
 import laika.factory.MarkupFormat
 import laika.factory.MarkupFormat.MarkupParsers
 import laika.parse.*

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -31,7 +31,6 @@ import laika.parse.combinator.Parsers
 import laika.parse.css.CSSParsers
 import laika.parse.directive.ConfigHeaderParser
 import laika.parse.implicits.*
-import laika.parse.markup.DocumentParser.DocumentInput
 import laika.parse.text.TextParsers
 import laika.rewrite.ReferenceResolver.CursorKeys
 import munit.FunSuite
@@ -264,9 +263,8 @@ class ParserHookSpec extends FunSuite with ParserSetup {
     )
   )
 
-  def preProcess(append: String): DocumentInput => DocumentInput = { input =>
-    val raw = input.source.input
-    input.copy(source = SourceCursor(raw + append, input.path))
+  def preProcess(append: String): String => String = { raw =>
+    raw + append
   }
 
   def appendString(root: RootElement, append: String): RootElement =

--- a/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
@@ -16,15 +16,15 @@
 
 package laika.directive
 
-import cats.implicits._
+import cats.syntax.all.*
 import laika.api.{ MarkupParser, RenderPhaseRewrite }
 import laika.api.builder.OperationConfig
+import laika.api.errors.TransformationError
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.TestSourceBuilders
 import laika.bundle.ParserBundle
 import laika.format.{ HTML, Markdown }
-import laika.parse.markup.DocumentParser.TransformationError
 import laika.parse.markup.RootParserProvider
 import laika.parse.{ Parser, SourceFragment }
 import munit.FunSuite

--- a/core/shared/src/test/scala/laika/directive/std/LinkDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/LinkDirectiveSpec.scala
@@ -16,12 +16,12 @@
 
 package laika.directive.std
 
+import laika.api.errors.TransformationError
 import laika.api.{ MarkupParser, RenderPhaseRewrite }
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.format.{ HTML, Markdown }
-import laika.parse.markup.DocumentParser.TransformationError
 import munit.FunSuite
 
 class LinkDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts with TestSourceBuilders

--- a/core/shared/src/test/scala/laika/directive/std/MarkupParserSetup.scala
+++ b/core/shared/src/test/scala/laika/directive/std/MarkupParserSetup.scala
@@ -17,10 +17,10 @@
 package laika.directive.std
 
 import laika.api.MarkupParser
+import laika.api.errors.ParserError
 import laika.ast.Path.Root
 import laika.ast.{ Document, MessageFilter, Path }
 import laika.format.Markdown
-import laika.parse.markup.DocumentParser.ParserError
 
 /** @author Jens Halm
   */

--- a/core/shared/src/test/scala/laika/directive/std/TemplateParserSetup.scala
+++ b/core/shared/src/test/scala/laika/directive/std/TemplateParserSetup.scala
@@ -16,11 +16,12 @@
 
 package laika.directive.std
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
-import laika.ast._
-import laika.config.{ Config, ConfigParser, ValidationError }
+import laika.ast.*
+import laika.config.{ Config, ConfigParser }
+import laika.config.ConfigError.ValidationError
 import laika.directive.DirectiveSupport
 import laika.format.HTML
 import laika.parse.SourceCursor

--- a/core/shared/src/test/scala/laika/parse/PositionTrackingSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/PositionTrackingSpec.scala
@@ -17,9 +17,9 @@
 package laika.parse
 
 import laika.api.MarkupParser
+import laika.api.errors.ParserError
 import laika.format.Markdown
 import laika.markdown.github.GitHubFlavor
-import laika.parse.markup.DocumentParser.ParserError
 import munit.FunSuite
 
 /** @author Jens Halm
@@ -29,8 +29,8 @@ class PositionTrackingSpec extends FunSuite {
   private val parser = MarkupParser.of(Markdown).using(GitHubFlavor).build
 
   def parseAndExtractMessage(input: String): String = parser.parse(input) match {
-    case Left(ParserError(message, _)) => message
-    case Right(doc)                    => s"Unexpected success: $doc"
+    case Left(ParserError(message)) => message
+    case Right(doc)                 => s"Unexpected success: $doc"
   }
 
   def run(input: String, expectedMessage: String)(implicit loc: munit.Location): Unit =

--- a/core/shared/src/test/scala/laika/parse/code/languages/LanguageSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/code/languages/LanguageSpec.scala
@@ -17,13 +17,13 @@
 package laika.parse.code.languages
 
 import laika.api.MarkupParser
-import laika.ast._
+import laika.api.errors.ParserError
+import laika.ast.*
 import laika.config.LaikaKeys
 import laika.format.Markdown
 import laika.markdown.github.GitHubFlavor
 import laika.parse.code.{ CodeCategory, SyntaxHighlighting }
-import laika.parse.code.CodeCategory._
-import laika.parse.markup.DocumentParser.ParserError
+import laika.parse.code.CodeCategory.*
 import munit.FunSuite
 
 /** @author Jens Halm

--- a/core/shared/src/test/scala/laika/parse/hocon/ConfigResolverSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/hocon/ConfigResolverSpec.scala
@@ -19,7 +19,8 @@ package laika.parse.hocon
 import laika.config.Config.IncludeMap
 import laika.config.*
 import munit.FunSuite
-import ConfigError.{ ValidationError, ConfigResolverError }
+import ConfigError.{ConfigResolverError, ValidationError}
+import ConfigValue.*
 
 /** @author Jens Halm
   */

--- a/core/shared/src/test/scala/laika/parse/hocon/ConfigResolverSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/hocon/ConfigResolverSpec.scala
@@ -19,7 +19,7 @@ package laika.parse.hocon
 import laika.config.Config.IncludeMap
 import laika.config.*
 import munit.FunSuite
-import ConfigError.{ConfigResolverError, ValidationError}
+import ConfigError.{ ConfigResolverError, ValidationError }
 import ConfigValue.*
 
 /** @author Jens Halm

--- a/core/shared/src/test/scala/laika/parse/hocon/ConfigResolverSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/hocon/ConfigResolverSpec.scala
@@ -17,8 +17,9 @@
 package laika.parse.hocon
 
 import laika.config.Config.IncludeMap
-import laika.config._
+import laika.config.*
 import munit.FunSuite
+import ConfigError.{ ValidationError, ConfigResolverError }
 
 /** @author Jens Halm
   */

--- a/core/shared/src/test/scala/laika/parse/hocon/HoconErrorSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/hocon/HoconErrorSpec.scala
@@ -16,7 +16,8 @@
 
 package laika.parse.hocon
 
-import laika.config.{ ConfigParser, ConfigParserErrors }
+import laika.config.ConfigParser
+import laika.config.ConfigError.ConfigParserErrors
 import munit.FunSuite
 
 /** @author Jens Halm

--- a/core/shared/src/test/scala/laika/parse/hocon/ResultBuilders.scala
+++ b/core/shared/src/test/scala/laika/parse/hocon/ResultBuilders.scala
@@ -16,7 +16,7 @@
 
 package laika.parse.hocon
 
-import laika.config.{ BooleanValue, DoubleValue, LongValue, NullValue }
+import laika.config.ConfigValue.*
 
 /** @author Jens Halm
   */

--- a/core/shared/src/test/scala/laika/rewrite/LinkValidatorSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/LinkValidatorSpec.scala
@@ -18,8 +18,9 @@ package laika.rewrite
 
 import laika.ast.Path.Root
 import laika.ast.sample.SampleTrees
-import laika.ast._
-import laika.rewrite.link.{ InvalidTarget, LinkValidation, RecoveredTarget, ValidTarget }
+import laika.ast.*
+import laika.rewrite.link.LinkValidation
+import laika.rewrite.link.TargetValidation.*
 import laika.rewrite.nav.TargetFormats
 import munit.FunSuite
 

--- a/core/shared/src/test/scala/laika/rst/TableParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/TableParsersSpec.scala
@@ -16,7 +16,7 @@
 
 package laika.rst
 
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.ParagraphCompanionShortcuts
 import laika.bundle.ParserBundle
 import laika.format.ReStructuredText

--- a/core/shared/src/test/scala/laika/rst/bundle/ExtendedHTMLRendererSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/bundle/ExtendedHTMLRendererSpec.scala
@@ -17,11 +17,11 @@
 package laika.rst.bundle
 
 import laika.api.Renderer
-import laika.ast._
+import laika.api.errors.RendererError
+import laika.ast.*
 import laika.ast.sample.ParagraphCompanionShortcuts
 import laika.format.{ HTML, ReStructuredText }
-import laika.parse.markup.DocumentParser.RendererError
-import laika.rst.ast._
+import laika.rst.ast.*
 import munit.FunSuite
 
 class ExtendedHTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts {

--- a/core/shared/src/test/scala/laika/rst/std/StandardBlockDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/std/StandardBlockDirectivesSpec.scala
@@ -21,9 +21,10 @@ import laika.api.{ MarkupParser, RenderPhaseRewrite }
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, SampleTrees }
-import laika.config.{ ConfigValue, Field, LaikaKeys, ObjectValue, StringValue }
+import laika.config.{ ConfigValue, Field, LaikaKeys }
+import laika.config.ConfigValue.{ ObjectValue, StringValue }
 import laika.format.{ AST, HTML, ReStructuredText }
 import laika.parse.GeneratedSource
 import laika.rewrite.ReferenceResolver.CursorKeys

--- a/core/shared/src/test/scala/laika/rst/std/StandardSpanDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/std/StandardSpanDirectivesSpec.scala
@@ -16,13 +16,13 @@
 
 package laika.rst.std
 
+import laika.api.errors.TransformationError
 import laika.api.{ MarkupParser, RenderPhaseRewrite }
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
 import laika.ast.*
 import laika.ast.sample.ParagraphCompanionShortcuts
 import laika.format.{ AST, ReStructuredText }
-import laika.parse.markup.DocumentParser.TransformationError
 import laika.time.PlatformDateTime
 import munit.FunSuite
 

--- a/docs/src/06-sub-modules/03-laikas-hocon-api.md
+++ b/docs/src/06-sub-modules/03-laikas-hocon-api.md
@@ -156,6 +156,7 @@ You can then flatMap on the string decoder to obtain a Color decoder:
 
 ```scala mdoc:silent
 import laika.config._
+import laika.config.ConfigError.DecodingError
 
 implicit val colorDecoder: ConfigDecoder[Color] = 
   ConfigDecoder.string.flatMap { str =>

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -23,6 +23,7 @@ import laika.ast.*
 import laika.config.*
 import laika.config.ConfigError.ValidationError
 import laika.factory.*
+import laika.io.errors.ConfigException
 import laika.io.model.{ BinaryOutput, RenderedTreeRoot }
 import laika.render.epub.{ ContainerWriter, XHTMLRenderer }
 import laika.render.{ HTMLFormatter, TagFormatter }

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -21,6 +21,7 @@ import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
 import laika.ast.*
 import laika.config.*
+import laika.config.ConfigError.ValidationError
 import laika.factory.*
 import laika.io.model.{ BinaryOutput, RenderedTreeRoot }
 import laika.render.epub.{ ContainerWriter, XHTMLRenderer }

--- a/io/src/main/scala/laika/helium/builder/HeliumTreeProcessor.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumTreeProcessor.scala
@@ -18,12 +18,13 @@ package laika.helium.builder
 
 import cats.data.Kleisli
 import cats.effect.Sync
-import cats.syntax.all._
+import cats.syntax.all.*
 import laika.ast.Path.Root
-import laika.config.{ ConfigException, LaikaKeys }
+import laika.config.LaikaKeys
 import laika.factory.Format
 import laika.helium.Helium
 import laika.helium.generate.{ DownloadPageGenerator, LandingPageGenerator, TocPageGenerator }
+import laika.io.errors.ConfigException
 import laika.io.model.ParsedTree
 import laika.theme.Theme.TreeProcessor
 

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -20,6 +20,7 @@ import laika.ast.Path.Root
 import laika.ast.*
 import laika.config.ConfigEncoder.ObjectBuilder
 import laika.config.*
+import laika.config.ConfigValue.ObjectValue
 import laika.helium.Helium
 import laika.helium.config.*
 

--- a/io/src/main/scala/laika/helium/generate/DownloadPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/DownloadPageGenerator.scala
@@ -35,9 +35,10 @@ import laika.ast.{
   Title,
   TitledBlock
 }
-import laika.config.{ ConfigException, LaikaKeys }
+import laika.config.LaikaKeys
 import laika.helium.config.DownloadPage
 import laika.io.config.SiteConfig
+import laika.io.errors.ConfigException
 import laika.io.model.ParsedTree
 import laika.rewrite.nav.{ CoverImages, Selections }
 import laika.theme.Theme.TreeProcessor

--- a/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
@@ -21,7 +21,8 @@ import cats.syntax.all.*
 import cats.effect.Sync
 import laika.ast.Path.Root
 import laika.ast.{ Document, Element, RootElement }
-import laika.config.{ ConfigBuilder, ConfigException, LaikaKeys }
+import laika.config.{ ConfigBuilder, LaikaKeys }
+import laika.io.errors.ConfigException
 import laika.rewrite.nav.TitleDocumentConfig
 import laika.theme.Theme.TreeProcessor
 

--- a/io/src/main/scala/laika/io/api/TreeParser.scala
+++ b/io/src/main/scala/laika/io/api/TreeParser.scala
@@ -20,13 +20,14 @@ import cats.data.NonEmptyList
 import cats.effect.{ Async, Resource }
 import laika.api.MarkupParser
 import laika.api.builder.{ OperationConfig, ParserBuilder }
+import laika.api.errors.ParserError
 import laika.ast.{ StyleDeclarationSet, TemplateDocument }
 import laika.io.descriptor.ParserDescriptor
 import laika.io.model.{ InputTreeBuilder, ParsedTree }
 import laika.io.ops.InputOps
 import laika.io.runtime.{ Batch, ParserRuntime }
 import laika.parse.markup.DocumentParser
-import laika.parse.markup.DocumentParser.{ DocumentInput, ParserError }
+import laika.parse.markup.DocumentParser.DocumentInput
 import laika.theme.{ Theme, ThemeProvider }
 
 /** Parser for a tree of input documents.

--- a/io/src/main/scala/laika/io/api/TreeRenderer.scala
+++ b/io/src/main/scala/laika/io/api/TreeRenderer.scala
@@ -84,7 +84,7 @@ object TreeRenderer {
     def copying(toCopy: Seq[BinaryInput[F]]): OutputOps[F] =
       new OutputOps(renderer, theme, input, staticDocuments ++ toCopy)
 
-    def toOutput(output: TreeOutput): Op[F] =
+    private[io] def toOutput(output: TreeOutput): Op[F] =
       new Op[F](renderer, theme, input, output, staticDocuments)
 
   }

--- a/io/src/main/scala/laika/io/api/TreeTransformer.scala
+++ b/io/src/main/scala/laika/io/api/TreeTransformer.scala
@@ -118,7 +118,7 @@ object TreeTransformer {
 
     type Result = Op[F]
 
-    def toOutput(output: TreeOutput): Op[F] =
+    private[io] def toOutput(output: TreeOutput): Op[F] =
       new Op[F](parsers, renderer, theme, input, mapper, output)
 
   }

--- a/io/src/main/scala/laika/io/config/IncludeHandler.scala
+++ b/io/src/main/scala/laika/io/config/IncludeHandler.scala
@@ -19,9 +19,10 @@ package laika.io.config
 import java.io.File
 import java.net.URL
 import cats.effect.{ Async, Sync }
-import cats.implicits._
+import cats.implicits.*
 import laika.config.Config.IncludeMap
-import laika.config.{ ConfigParser, ConfigResourceError }
+import laika.config.ConfigError.ConfigResourceError
+import laika.config.ConfigParser
 import laika.io.runtime.Batch
 import laika.parse.hocon.{
   IncludeAny,

--- a/io/src/main/scala/laika/io/config/ResourceLoader.scala
+++ b/io/src/main/scala/laika/io/config/ResourceLoader.scala
@@ -17,11 +17,11 @@
 package laika.io.config
 
 import cats.effect.{ Async, Sync }
-import cats.syntax.all._
+import cats.syntax.all.*
 import fs2.io.file.Files
 import laika.ast.DocumentType
 import laika.ast.Path.Root
-import laika.config.ConfigResourceError
+import laika.config.ConfigError.ConfigResourceError
 import laika.io.model.{ FilePath, TextInput }
 
 import java.io.{ FileNotFoundException, InputStream }

--- a/io/src/main/scala/laika/io/errors/errors.scala
+++ b/io/src/main/scala/laika/io/errors/errors.scala
@@ -1,0 +1,75 @@
+package laika.io.errors
+
+import laika.api.errors.InvalidDocument
+import laika.ast.Path
+import laika.config.ConfigError
+import laika.io.model.FilePath
+
+/** A ConfigError as a RuntimeException for use cases where a Throwable is required. */
+private[laika] case class ConfigException(error: ConfigError) extends RuntimeException(
+      error.message
+    )
+
+private[laika] case class NoMatchingParser(path: Path, suffixes: Set[String])
+    extends RuntimeException(
+      s"No matching parser available for path: $path - supported suffixes: ${suffixes.mkString(",")}"
+    )
+
+private[laika] case class DuplicatePath(path: Path, filePaths: Set[String] = Set.empty)
+    extends RuntimeException(
+      s"Duplicate path: $path ${DuplicatePath.filePathMessage(filePaths)}"
+    )
+
+private[laika] object DuplicatePath {
+
+  private[errors] def filePathMessage(filePaths: Set[String]): String =
+    if (filePaths.isEmpty) "(no matching file paths)"
+    else s"with matching file paths: ${filePaths.mkString(", ")}"
+
+}
+
+private[laika] case class MissingDirectory(path: FilePath) extends RuntimeException(
+      s"Path does not exist or is not a directory: ${path.toString}"
+    )
+
+private[laika] case class ParserErrors(errors: Set[Throwable]) extends RuntimeException(
+      s"Multiple errors during parsing: ${errors.map(_.getMessage).mkString(", ")}"
+    )
+
+private[laika] case class RendererErrors(errors: Seq[Throwable]) extends RuntimeException(
+      s"Multiple errors during rendering: ${errors.map(_.getMessage).mkString(", ")}"
+    )
+
+private[laika] sealed trait DocumentTransformationError extends RuntimeException {
+  def path: Path
+
+  def message: String
+}
+
+private[laika] case class DocumentRendererError(message: String, path: Path)
+    extends RuntimeException(s"Error rendering document '$path': $message")
+    with DocumentTransformationError
+
+private[laika] object DocumentRendererError {
+
+  def apply(configError: ConfigError, path: Path): DocumentRendererError =
+    DocumentRendererError(s"Configuration Error: ${configError.message}", path)
+
+}
+
+private[laika] case class DocumentParserError(message: String, path: Path)
+    extends DocumentTransformationError {
+  override def toString: String = s"Error parsing document '$path': $message"
+}
+
+private[laika] object DocumentParserError {
+
+  def apply(configError: ConfigError, path: Path): DocumentParserError =
+    DocumentParserError(s"Configuration Error: ${configError.message}", path)
+
+  def apply(document: InvalidDocument): DocumentParserError = DocumentParserError(
+    s"One or more error nodes in result:\n${InvalidDocument.format(document)}".trim,
+    document.path
+  )
+
+}

--- a/io/src/main/scala/laika/io/errors/errors.scala
+++ b/io/src/main/scala/laika/io/errors/errors.scala
@@ -40,15 +40,8 @@ private[laika] case class RendererErrors(errors: Seq[Throwable]) extends Runtime
       s"Multiple errors during rendering: ${errors.map(_.getMessage).mkString(", ")}"
     )
 
-private[laika] sealed trait DocumentTransformationError extends RuntimeException {
-  def path: Path
-
-  def message: String
-}
-
 private[laika] case class DocumentRendererError(message: String, path: Path)
     extends RuntimeException(s"Error rendering document '$path': $message")
-    with DocumentTransformationError
 
 private[laika] object DocumentRendererError {
 
@@ -58,9 +51,7 @@ private[laika] object DocumentRendererError {
 }
 
 private[laika] case class DocumentParserError(message: String, path: Path)
-    extends DocumentTransformationError {
-  override def toString: String = s"Error parsing document '$path': $message"
-}
+    extends RuntimeException(s"Error parsing document '$path': $message")
 
 private[laika] object DocumentParserError {
 

--- a/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
+++ b/io/src/main/scala/laika/io/model/InputTreeBuilder.scala
@@ -34,9 +34,9 @@ import laika.ast.{
 import laika.bundle.{ DocumentTypeMatcher, Precedence }
 import laika.config.Config
 import laika.io.descriptor.TreeInputDescriptor
+import laika.io.errors.*
 import laika.io.model.InputTree.{ BuilderContext, BuilderStep }
 import laika.io.runtime.DirectoryScanner
-import laika.io.runtime.ParserRuntime.{ MissingDirectory, ParserErrors }
 
 import java.io.InputStream
 import scala.io.Codec

--- a/io/src/main/scala/laika/io/model/TextInput.scala
+++ b/io/src/main/scala/laika/io/model/TextInput.scala
@@ -45,7 +45,7 @@ class TextInput[F[_]: Functor] private (
     val sourceFile: Option[FilePath] = None
 ) extends Navigatable {
 
-  lazy val asDocumentInput: F[DocumentInput] = input.map(DocumentInput(path, _))
+  private[laika] lazy val asDocumentInput: F[DocumentInput] = input.map(DocumentInput(path, _))
 }
 
 object TextInput {

--- a/io/src/main/scala/laika/io/model/TreeOutput.scala
+++ b/io/src/main/scala/laika/io/model/TreeOutput.scala
@@ -20,15 +20,15 @@ import scala.io.Codec
 
 /** A (virtual) tree of output documents.
   */
-sealed trait TreeOutput
+private[io] sealed trait TreeOutput
 
 /** A directory as a target for a rendering operation of a document tree.
   *
   * The specified codec will be used for writing all character output.
   */
-case class DirectoryOutput(directory: FilePath, codec: Codec) extends TreeOutput
+private[io] case class DirectoryOutput(directory: FilePath, codec: Codec) extends TreeOutput
 
 /** Instructs the renderer to produce an in-memory representation of the
   * tree of rendered outputs.
   */
-case object StringTreeOutput extends TreeOutput
+private[io] case object InMemoryOutput extends TreeOutput

--- a/io/src/main/scala/laika/io/ops/TextOutputOps.scala
+++ b/io/src/main/scala/laika/io/ops/TextOutputOps.scala
@@ -16,7 +16,7 @@
 
 package laika.io.ops
 
-import laika.io.model.{ DirectoryOutput, FilePath, TreeOutput }
+import laika.io.model.{ DirectoryOutput, FilePath, InMemoryOutput, TreeOutput }
 
 import scala.io.Codec
 
@@ -55,12 +55,17 @@ private[io] trait TextOutputOps[F[_]] {
     DirectoryOutput(dir, codec)
   )
 
+  /** Builder step that instructs the renderer to only produce an in - memory representation of the
+    * tree of rendered outputs.
+    */
+  def toMemory: Result = toOutput(InMemoryOutput)
+
   /** Builder step that instructs the runtime to render
     * to the specified tree output.
     *
     * This is a generic method based on Laika's IO model that concrete
     * methods delegate to.
     */
-  def toOutput(tree: TreeOutput): Result
+  private[io] def toOutput(tree: TreeOutput): Result
 
 }

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -20,12 +20,13 @@ import cats.effect.{ Async, Sync }
 import cats.syntax.all.*
 import fs2.io.file.Files
 import laika.api.Renderer
+import laika.api.errors.InvalidDocuments
 import laika.ast.Path.Root
 import laika.ast.*
-import laika.config.{ ConfigError, ConfigException, LaikaKeys }
+import laika.config.{ ConfigError, LaikaKeys }
 import laika.io.api.{ BinaryTreeRenderer, TreeRenderer }
+import laika.io.errors.*
 import laika.io.model.*
-import laika.parse.markup.DocumentParser.InvalidDocuments
 import laika.rewrite.nav.*
 import laika.rewrite.{ DefaultTemplatePath, OutputContext, Versions }
 
@@ -98,7 +99,9 @@ private[io] object RendererRuntime {
           val outputDoc         = document.withPath(outputPath)
           for {
             renderResult <- Async[F].fromEither(
-              renderer.render(outputDoc, docPathTranslator, styles)
+              renderer
+                .render(outputDoc, docPathTranslator, styles)
+                .leftMap(e => DocumentRendererError(e.message, document.path))
             )
             _            <- output(outputPath).writer(renderResult)
           } yield {
@@ -327,18 +330,5 @@ private[io] object RendererRuntime {
       _ <- op.renderer.postProcessor.process(finalTree, op.output, op.config)
     } yield ()
   }
-
-  // TODO - unify with ParserErrors (as TransformationErrors)
-  case class DuplicatePath(path: Path, filePaths: Set[String] = Set.empty) extends RuntimeException(
-        s"Duplicate path: $path ${filePathMessage(filePaths)}"
-      )
-
-  case class RendererErrors(errors: Seq[Throwable]) extends RuntimeException(
-        s"Multiple errors during rendering: ${errors.map(_.getMessage).mkString(", ")}"
-      )
-
-  private def filePathMessage(filePaths: Set[String]): String =
-    if (filePaths.isEmpty) "(no matching file paths)"
-    else s"with matching file paths: ${filePaths.mkString(", ")}"
 
 }

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -147,7 +147,7 @@ private[io] object RendererRuntime {
         Files.forAsync[F].createDirectories(file.toFS2Path)
 
       op.output match {
-        case StringTreeOutput            =>
+        case InMemoryOutput              =>
           val renderOps =
             renderDocuments(finalRoot, pathTranslator, versions, styles)(p => TextOutput.noOp(p))
           val copyOps   = copyDocuments(staticDocs, None, pathTranslatorF)
@@ -320,7 +320,7 @@ private[io] object RendererRuntime {
           op.renderer.interimRenderer,
           op.theme,
           preparedTree,
-          StringTreeOutput,
+          InMemoryOutput,
           op.staticDocuments
         ),
         op.theme.inputs,

--- a/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
+++ b/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
@@ -25,7 +25,8 @@ import laika.ast.DocumentType.{ Ignored, Static }
 import laika.ast.Path.Root
 import laika.ast.{ DocumentType, Path, SegmentedPath }
 import laika.config.Config.ConfigResult
-import laika.config.{ ConfigDecoder, ConfigException, ConfigParser }
+import laika.config.{ ConfigDecoder, ConfigParser }
+import laika.io.errors.ConfigException
 import laika.io.model.{ BinaryInput, DirectoryInput, FilePath }
 import laika.rewrite.{ VersionScannerConfig, Versions }
 

--- a/io/src/main/scala/laika/render/epub/ContainerWriter.scala
+++ b/io/src/main/scala/laika/render/epub/ContainerWriter.scala
@@ -17,11 +17,11 @@
 package laika.render.epub
 
 import cats.effect.{ Async, Sync }
-import cats.implicits.*
+import cats.syntax.all.*
 import laika.ast.Path
 import laika.ast.Path.Root
-import laika.config.ConfigException
 import laika.format.EPUB
+import laika.io.errors.ConfigException
 import laika.io.model.*
 import laika.render.TagFormatter
 import laika.theme.config.BookConfig

--- a/io/src/main/scala/laika/theme/config/Font.scala
+++ b/io/src/main/scala/laika/theme/config/Font.scala
@@ -19,6 +19,7 @@ package laika.theme.config
 import laika.ast.Path.Root
 import laika.ast.{ Path, VirtualPath }
 import laika.config.*
+import laika.config.ConfigError.DecodingError
 import laika.io.model.FilePath
 
 /** Represents a font resource, either based on a local classpath or file system resource,

--- a/io/src/test/scala/laika/ast/ConfigSpec.scala
+++ b/io/src/test/scala/laika/ast/ConfigSpec.scala
@@ -28,6 +28,7 @@ import laika.config._
 import laika.config.ConfigValue.{ ObjectValue, LongValue }
 import laika.format.{ HTML, Markdown, ReStructuredText }
 import laika.io.FileIO
+import laika.io.errors.ConfigException
 import laika.io.helper.{ InputBuilder, TestThemeBuilder }
 import laika.io.implicits._
 import laika.io.model.{ FilePath, InputTreeBuilder, ParsedTree }

--- a/io/src/test/scala/laika/ast/ConfigSpec.scala
+++ b/io/src/test/scala/laika/ast/ConfigSpec.scala
@@ -25,6 +25,7 @@ import laika.ast.sample.TestSourceBuilders
 import laika.bundle.BundleProvider
 import laika.config.Origin.{ DocumentScope, TreeScope }
 import laika.config._
+import laika.config.ConfigValue.{ ObjectValue, LongValue }
 import laika.format.{ HTML, Markdown, ReStructuredText }
 import laika.io.FileIO
 import laika.io.helper.{ InputBuilder, TestThemeBuilder }

--- a/io/src/test/scala/laika/directive/std/IncludeDirectiveSpec.scala
+++ b/io/src/test/scala/laika/directive/std/IncludeDirectiveSpec.scala
@@ -21,9 +21,9 @@ import laika.api.MarkupParser
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
 import laika.ast._
-import laika.config.ConfigException
 import laika.format.{ HTML, Markdown }
 import laika.io.api.TreeParser
+import laika.io.errors.ConfigException
 import laika.io.helper.InputBuilder
 import laika.io.implicits._
 import laika.rewrite.{ DefaultTemplatePath, OutputContext }

--- a/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
@@ -26,7 +26,6 @@ import laika.format.{ HTML, Markdown }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits.*
-import laika.io.model.StringTreeOutput
 import laika.render.TagFormatter
 import laika.rewrite.nav.{ ChoiceConfig, CoverImage, SelectionConfig, Selections }
 import laika.theme.*
@@ -63,7 +62,7 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
   ): IO[String] =
     transformer(helium.build, configure).use { t =>
       for {
-        resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+        resultTree <- t.fromInput(build(inputs)).toMemory.transform
         res        <- IO.fromEither(
           resultTree.extractTidiedSubstring(Root / "downloads.html", start, end)
             .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
@@ -26,7 +26,6 @@ import laika.helium.config.ColorQuintet
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits.*
-import laika.io.model.StringTreeOutput
 import laika.theme.ThemeProvider
 import munit.CatsEffectSuite
 
@@ -51,7 +50,7 @@ class HeliumEPUBCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- resultTree.extractStaticContent(
         Root / "helium" / "epub" / "laika-helium.css",
         start,
@@ -63,7 +62,7 @@ class HeliumEPUBCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   def transformAndExtract(inputs: Seq[(Path, String)], helium: Helium): IO[String] =
     transformer(helium.build).use { t =>
       for {
-        resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+        resultTree <- t.fromInput(build(inputs)).toMemory.transform
         res        <- resultTree.extractStaticContent(Root / "helium" / "epub" / "laika-helium.css")
       } yield res
     }

--- a/io/src/test/scala/laika/helium/HeliumEPUBHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBHeadSpec.scala
@@ -24,7 +24,6 @@ import laika.format.{ EPUB, Markdown }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits.*
-import laika.io.model.StringTreeOutput
 import laika.theme.*
 import munit.CatsEffectSuite
 
@@ -55,7 +54,7 @@ class HeliumEPUBHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
   def transformAndExtractHead(inputs: Seq[(Path, String)], helium: Helium): IO[String] =
     transformer(helium.build).use { t =>
       for {
-        resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+        resultTree <- t.fromInput(build(inputs)).toMemory.transform
         res        <- IO.fromEither(
           resultTree.extractTidiedTagContent((Root / "name").withSuffix("xhtml"), "head")
             .toRight(new RuntimeException("Missing document under test"))
@@ -70,7 +69,7 @@ class HeliumEPUBHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- IO.fromEither(
         resultTree.extractTidiedSubstring(Root / "name.xhtml", start, end)
           .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/helium/HeliumEPUBTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBTocPageSpec.scala
@@ -25,7 +25,6 @@ import laika.format.{ EPUB, Markdown }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits._
-import laika.io.model.StringTreeOutput
 import laika.theme._
 import munit.CatsEffectSuite
 
@@ -53,7 +52,7 @@ class HeliumEPUBTocPageSpec extends CatsEffectSuite with InputBuilder with Resul
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- IO.fromEither(
         resultTree.extractTidiedSubstring(Root / "table-of-content.xhtml", start, end)
           .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/helium/HeliumFORendererSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumFORendererSpec.scala
@@ -26,7 +26,6 @@ import laika.helium.config.ColorQuintet
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits._
-import laika.io.model.StringTreeOutput
 import laika.markdown.github.GitHubFlavor
 import laika.parse.code.SyntaxHighlighting
 import laika.rewrite.nav.CoverImage
@@ -57,7 +56,7 @@ class HeliumFORendererSpec extends CatsEffectSuite with InputBuilder with Result
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- IO.fromEither(
         resultTree.extractTidiedSubstring(Root / "doc.fo", start, end)
           .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/helium/HeliumFOTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumFOTocPageSpec.scala
@@ -24,7 +24,6 @@ import laika.format.{ Markdown, XSLFO }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits._
-import laika.io.model.StringTreeOutput
 import laika.theme._
 import munit.CatsEffectSuite
 
@@ -52,7 +51,7 @@ class HeliumFOTocPageSpec extends CatsEffectSuite with InputBuilder with ResultE
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- IO.fromEither(
         resultTree.extractTidiedSubstring(Root / "table-of-content.fo", start, end)
           .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/helium/HeliumFooterSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumFooterSpec.scala
@@ -24,7 +24,6 @@ import laika.format.{ HTML, Markdown }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits._
-import laika.io.model.StringTreeOutput
 import laika.theme._
 import munit.CatsEffectSuite
 
@@ -45,7 +44,7 @@ class HeliumFooterSpec extends CatsEffectSuite with InputBuilder with ResultExtr
   def transformAndExtract(inputs: Seq[(Path, String)], helium: Helium): IO[String] =
     transformer(helium.build).use { t =>
       for {
-        resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+        resultTree <- t.fromInput(build(inputs)).toMemory.transform
         res        <- IO.fromEither(
           resultTree.extractTidiedSubstring(
             Root / "doc-1.html",

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -25,7 +25,7 @@ import laika.helium.config.Favicon
 import laika.io.api.{ TreeParser, TreeRenderer, TreeTransformer }
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps, TestThemeBuilder }
 import laika.io.implicits.*
-import laika.io.model.{ InputTree, StringTreeOutput }
+import laika.io.model.InputTree
 import laika.markdown.github.GitHubFlavor
 import laika.rewrite.link.LinkValidation
 import laika.theme.ThemeProvider
@@ -122,7 +122,7 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
       underTest: Path = Root / "name.html"
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- IO.fromEither(
         resultTree.extractTidiedTagContent(underTest, "head")
           .toRight(new RuntimeException("Missing document under test"))
@@ -137,7 +137,7 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- IO.fromEither(
         resultTree.extractTidiedSubstring(Root / "name.html", start, end)
           .toRight(new RuntimeException("Missing document under test"))
@@ -148,7 +148,7 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
   test("Helium defaults via separate parser and renderer") {
     parserAndRenderer.use { case (p, r) =>
       p.fromInput(build(singleDocPlusHome)).parse.flatMap { tree =>
-        r.from(tree.root).toOutput(StringTreeOutput).render
+        r.from(tree.root).toMemory.render
       }
     }
       .map(_.extractTidiedSubstring(Root / "name.html", "<head>", "</head>"))

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -25,7 +25,6 @@ import laika.helium.config.*
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits.*
-import laika.io.model.StringTreeOutput
 import laika.theme.*
 import munit.CatsEffectSuite
 
@@ -112,7 +111,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
   ): IO[String] =
     transformer(helium.build).use { t =>
       for {
-        resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+        resultTree <- t.fromInput(build(inputs)).toMemory.transform
         res        <- IO.fromEither(
           resultTree.extractTidiedSubstring(docPath, start, end)
             .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -26,7 +26,6 @@ import laika.helium.config.*
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits.*
-import laika.io.model.StringTreeOutput
 import laika.theme.*
 import laika.theme.config.Color
 import munit.CatsEffectSuite
@@ -56,7 +55,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- IO.fromEither(
         resultTree.extractTidiedSubstring(Root / "index.html", start, end)
           .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/helium/HeliumRenderOverridesSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumRenderOverridesSpec.scala
@@ -26,7 +26,6 @@ import laika.helium.config.{ AnchorPlacement, HeliumIcon }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits.*
-import laika.io.model.StringTreeOutput
 import laika.markdown.github.GitHubFlavor
 import laika.parse.code.SyntaxHighlighting
 import laika.render.TagFormatter
@@ -61,7 +60,7 @@ class HeliumRenderOverridesSpec extends CatsEffectSuite with InputBuilder with R
   ): IO[String] =
     transformer(helium.build, configure).use { t =>
       for {
-        resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+        resultTree <- t.fromInput(build(inputs)).toMemory.transform
         res        <- IO.fromEither(
           resultTree.extractTidiedSubstring(Root / "doc.html", start, end)
             .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
@@ -26,7 +26,6 @@ import laika.helium.config.{ AnchorPlacement, ColorQuintet }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits._
-import laika.io.model.StringTreeOutput
 import laika.theme.ThemeProvider
 import munit.CatsEffectSuite
 
@@ -51,7 +50,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- resultTree.extractStaticContent(
         Root / "helium" / "site" / "laika-helium.css",
         start,

--- a/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
@@ -25,7 +25,6 @@ import laika.format.{ HTML, Markdown }
 import laika.io.api.TreeTransformer
 import laika.io.helper.{ InputBuilder, ResultExtractor, StringOps }
 import laika.io.implicits._
-import laika.io.model.StringTreeOutput
 import laika.theme._
 import munit.CatsEffectSuite
 
@@ -53,7 +52,7 @@ class HeliumTocPageSpec extends CatsEffectSuite with InputBuilder with ResultExt
       end: String
   ): IO[String] = transformer(helium.build).use { t =>
     for {
-      resultTree <- t.fromInput(build(inputs)).toOutput(StringTreeOutput).transform
+      resultTree <- t.fromInput(build(inputs)).toMemory.transform
       res        <- IO.fromEither(
         resultTree.extractTidiedSubstring(Root / "table-of-content.html", start, end)
           .toRight(new RuntimeException("Missing document under test"))

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -21,20 +21,20 @@ import cats.data.{ Chain, NonEmptyChain }
 import cats.effect.{ IO, Resource }
 import laika.api.MarkupParser
 import laika.api.builder.OperationConfig
+import laika.api.errors.{ InvalidDocument, InvalidDocuments }
 import laika.ast.DocumentType.*
 import laika.ast.Path.Root
 import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, SampleTrees, TestSourceBuilders }
 import laika.bundle.*
-import laika.config.{ ConfigBuilder, ConfigException, LaikaKeys }
+import laika.config.{ ConfigBuilder, LaikaKeys }
 import laika.format.{ HTML, Markdown, ReStructuredText }
 import laika.io.api.TreeParser
+import laika.io.errors.{ ConfigException, DuplicatePath, ParserErrors }
 import laika.io.helper.InputBuilder
 import laika.io.implicits.*
 import laika.io.model.{ InputTree, InputTreeBuilder, ParsedTree }
-import laika.io.runtime.ParserRuntime.{ DuplicatePath, ParserErrors }
 import laika.parse.Parser
-import laika.parse.markup.DocumentParser.{ InvalidDocument, InvalidDocuments }
 import laika.parse.text.TextParsers
 import laika.rewrite.nav.TargetFormats
 import laika.rewrite.{ DefaultTemplatePath, OutputContext, Version, Versions }

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -46,7 +46,7 @@ import laika.render.*
 import laika.render.fo.TestTheme
 import laika.render.fo.TestTheme.staticHTMLPaths
 import laika.rewrite.ReferenceResolver.CursorKeys
-import laika.rewrite.nav.{ NoOpPathTranslator, PrettyURLs, TargetFormats }
+import laika.rewrite.nav.{ PathTranslator, PrettyURLs, TargetFormats }
 import laika.rewrite.{ DefaultTemplatePath, OutputContext, Version, Versions }
 import munit.CatsEffectSuite
 
@@ -141,7 +141,7 @@ class TreeRendererSpec extends CatsEffectSuite
       TemplateRoot.fallback,
       Config.empty,
       outputContext,
-      NoOpPathTranslator,
+      PathTranslator.noOp,
       coverDocument = coverDocument,
       staticDocuments = staticDocuments.map(Inputs.ByteInput.empty(_))
     )

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -209,7 +209,7 @@ class TreeRendererSpec extends CatsEffectSuite
       .use(
         _
           .from(input)
-          .toOutput(StringTreeOutput)
+          .toMemory
           .render
       )
 
@@ -364,7 +364,7 @@ class TreeRendererSpec extends CatsEffectSuite
       .use(
         _
           .from(HTMLRenderer.defaultRoot(input))
-          .toOutput(StringTreeOutput)
+          .toMemory
           .render
       )
       .attempt
@@ -398,7 +398,7 @@ class TreeRendererSpec extends CatsEffectSuite
       .use(
         _
           .from(HTMLRenderer.defaultRoot(input))
-          .toOutput(StringTreeOutput)
+          .toMemory
           .render
       )
       .attempt
@@ -840,7 +840,7 @@ class TreeRendererSpec extends CatsEffectSuite
         _
           .from(treeRoot)
           .copying(Seq(Inputs.ByteInput("...", Root / "static1.txt")))
-          .toOutput(StringTreeOutput)
+          .toMemory
           .render
       )
       .assertEquals(
@@ -870,7 +870,7 @@ class TreeRendererSpec extends CatsEffectSuite
       .use(
         _
           .from(treeRoot)
-          .toOutput(StringTreeOutput)
+          .toMemory
           .render
       )
       .assertEquals(
@@ -938,7 +938,7 @@ class TreeRendererSpec extends CatsEffectSuite
         _
           .from(treeRoot)
           .copying(staticDocs)
-          .toOutput(StringTreeOutput)
+          .toMemory
           .render
       )
       .assertEquals(expectedRendered)
@@ -1002,7 +1002,7 @@ class TreeRendererSpec extends CatsEffectSuite
         _
           .from(treeRoot)
           .copying(staticDocs)
-          .toOutput(StringTreeOutput)
+          .toMemory
           .render
       )
       .assertEquals(expectedRendered)
@@ -1179,7 +1179,7 @@ class TreeRendererSpec extends CatsEffectSuite
         _
           .from(versionedInput())
           .copying(Seq(versionInfoInput))
-          .toOutput(StringTreeOutput)
+          .toMemory
           .render
       )
       .flatMap(tree =>

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -21,6 +21,7 @@ import cats.effect.{ Async, IO, Resource }
 import cats.syntax.all.*
 import fs2.io.file.Files
 import laika.api.Renderer
+import laika.api.errors.{ InvalidDocument, InvalidDocuments }
 import laika.ast.Path.Root
 import laika.ast.*
 import laika.ast.sample.{
@@ -35,13 +36,12 @@ import laika.config.{ Config, ConfigBuilder, LaikaKeys, Origin }
 import laika.format.*
 import laika.helium.generate.FOStyles
 import laika.io.api.{ BinaryTreeRenderer, TreeRenderer }
+import laika.io.errors.{ DuplicatePath, RendererErrors }
 import laika.io.helper.{ InputBuilder, RenderResult, TestThemeBuilder }
 import laika.io.implicits.*
 import laika.io.model.*
-import laika.io.runtime.RendererRuntime.{ DuplicatePath, RendererErrors }
 import laika.io.runtime.VersionInfoGenerator
 import laika.parse.GeneratedSource
-import laika.parse.markup.DocumentParser.{ InvalidDocument, InvalidDocuments }
 import laika.render.*
 import laika.render.fo.TestTheme
 import laika.render.fo.TestTheme.staticHTMLPaths

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -38,8 +38,7 @@ import laika.io.model.{
   RenderContent,
   RenderedDocument,
   RenderedTree,
-  RenderedTreeRoot,
-  StringTreeOutput
+  RenderedTreeRoot
 }
 import laika.parse.Parser
 import laika.parse.code.SyntaxHighlighting
@@ -115,7 +114,7 @@ class TreeTransformerSpec extends CatsEffectSuite
     .use(
       _
         .fromInput(inputs)
-        .toOutput(StringTreeOutput)
+        .toMemory
         .describe
     )
 
@@ -128,7 +127,7 @@ class TreeTransformerSpec extends CatsEffectSuite
     transformer.use(
       _
         .fromInput(build(inputs))
-        .toOutput(StringTreeOutput)
+        .toMemory
         .transform
     )
 
@@ -408,7 +407,7 @@ class TreeTransformerSpec extends CatsEffectSuite
       .use(
         _
           .fromInput(input)
-          .toOutput(StringTreeOutput)
+          .toMemory
           .transform
       )
     renderResult.assertEquals(

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -47,7 +47,7 @@ import laika.parse.text.TextParsers
 import laika.render.fo.TestTheme
 import laika.rewrite.{ DefaultTemplatePath, OutputContext }
 import laika.rewrite.link.SlugBuilder
-import laika.rewrite.nav.NoOpPathTranslator
+import laika.rewrite.nav.PathTranslator
 import laika.theme.ThemeProvider
 import munit.CatsEffectSuite
 
@@ -186,7 +186,7 @@ class TreeTransformerSpec extends CatsEffectSuite
     TemplateRoot.fallback,
     Config.empty,
     outputContext,
-    NoOpPathTranslator,
+    PathTranslator.noOp,
     coverDocument = coverDocument,
     staticDocuments = staticDocuments.map(ByteInput.empty(_))
   )

--- a/io/src/test/scala/laika/render/epub/InputTreeBuilder.scala
+++ b/io/src/test/scala/laika/render/epub/InputTreeBuilder.scala
@@ -24,7 +24,7 @@ import laika.format.EPUB
 import laika.io.model.*
 import laika.io.helper.InputBuilder
 import laika.rewrite.OutputContext
-import laika.rewrite.nav.NoOpPathTranslator
+import laika.rewrite.nav.PathTranslator
 
 trait InputTreeBuilder extends InputBuilder {
 
@@ -76,7 +76,7 @@ trait InputTreeBuilder extends InputBuilder {
       TemplateRoot.empty,
       Config.empty,
       outputContext,
-      NoOpPathTranslator, // not reflecting real result, but not part of any assertions
+      PathTranslator.noOp, // not reflecting real result, but not part of any assertions
       coverDocument = cover
     )
   }

--- a/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
+++ b/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
@@ -18,15 +18,15 @@ package laika.render.fo
 
 import cats.data.NonEmptySet
 import laika.api.Renderer
+import laika.api.errors.RendererError
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.config.{ ConfigBuilder, LaikaKeys }
 import laika.format.XSLFO
 import laika.parse.GeneratedSource
 import laika.parse.code.CodeCategory
-import laika.parse.markup.DocumentParser.RendererError
 import laika.rewrite.OutputContext
 import laika.rewrite.nav.{
   ConfigurablePathTranslator,

--- a/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
+++ b/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
@@ -30,8 +30,8 @@ import laika.parse.code.CodeCategory
 import laika.rewrite.OutputContext
 import laika.rewrite.nav.{
   ConfigurablePathTranslator,
-  NoOpPathTranslator,
   PathAttributes,
+  PathTranslator,
   TargetFormats,
   TranslatorConfig
 }
@@ -48,7 +48,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
     """<fo:block space-after="3mm"><fo:leader leader-length="100%" leader-pattern="rule" rule-style="solid" rule-thickness="2pt"></fo:leader></fo:block>"""
 
   def render(elem: Element, style: StyleDeclarationSet): Either[RendererError, String] =
-    defaultRenderer.render(elem, Root / "doc", NoOpPathTranslator, style)
+    defaultRenderer.render(elem, Root / "doc", PathTranslator.noOp, style)
 
   def run(input: Element, expectedFO: String)(implicit loc: munit.Location): Unit =
     assertEquals(render(input, TestTheme.foStyles), Right(expectedFO))
@@ -62,7 +62,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
       loc: munit.Location
   ): Unit =
     assertEquals(
-      defaultRenderer.render(input, Root / "doc", NoOpPathTranslator, style),
+      defaultRenderer.render(input, Root / "doc", PathTranslator.noOp, style),
       Right(expectedFO)
     )
 
@@ -72,7 +72,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
     val res = Renderer.of(XSLFO).renderMessages(messageFilter).build.render(
       elem,
       Root / "doc",
-      NoOpPathTranslator,
+      PathTranslator.noOp,
       TestTheme.foStyles
     )
     assertEquals(res, Right(expectedFO))
@@ -82,7 +82,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
     val res = Renderer.of(XSLFO).unformatted.build.render(
       input,
       Root / "doc",
-      NoOpPathTranslator,
+      PathTranslator.noOp,
       TestTheme.foStyles
     )
     assertEquals(res, Right(expectedFO))

--- a/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
@@ -28,7 +28,7 @@ import laika.bundle.{ BundleOrigin, BundleProvider, ExtensionBundle }
 import laika.format.{ HTML, Markdown }
 import laika.io.helper.TestThemeBuilder
 import laika.rewrite.OutputContext
-import laika.rewrite.nav.NoOpPathTranslator
+import laika.rewrite.nav.PathTranslator
 import munit.FunSuite
 
 /** @author Jens Halm
@@ -121,7 +121,7 @@ class ThemeBundleSpec extends FunSuite {
       DocumentTree.builder.addDocument(Document(Root / "doc.md", RootElement.empty)).buildRoot
     val compoundTranslator = config(themeBundles, appBundles)
       .pathTranslatorFor(testTree, OutputContext(HTML))
-      .getOrElse(NoOpPathTranslator)
+      .getOrElse(PathTranslator.noOp)
     assertEquals(compoundTranslator.translate(Root / "doc.md"), Root / "doc-theme-app.html")
   }
 

--- a/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
+++ b/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
@@ -28,7 +28,7 @@ import laika.io.model.{ RenderedDocument, RenderedTree, RenderedTreeRoot }
 import laika.render.fo.TestTheme
 import laika.render.pdf.FOConcatenation
 import laika.rewrite.OutputContext
-import laika.rewrite.nav.NoOpPathTranslator
+import laika.rewrite.nav.PathTranslator
 import laika.theme.config.BookConfig
 import munit.FunSuite
 
@@ -47,7 +47,7 @@ class FOConcatenationSpec extends FunSuite with TestSourceBuilders {
     defaultTemplate = TemplateRoot(TemplateElement(invalidElement)),
     config = Config.empty,
     outputContext = OutputContext(XSLFO),
-    pathTranslator = NoOpPathTranslator,
+    pathTranslator = PathTranslator.noOp,
     styles = TestTheme.foStyles
   )
 

--- a/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
+++ b/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
@@ -18,13 +18,13 @@ package laika.render
 
 import cats.effect.IO
 import laika.api.builder.OperationConfig
+import laika.api.errors.InvalidDocument
 import laika.ast.Path.Root
 import laika.ast.*
 import laika.ast.sample.TestSourceBuilders
 import laika.config.Config
 import laika.format.XSLFO
 import laika.io.model.{ RenderedDocument, RenderedTree, RenderedTreeRoot }
-import laika.parse.markup.DocumentParser.InvalidDocument
 import laika.render.fo.TestTheme
 import laika.render.pdf.FOConcatenation
 import laika.rewrite.OutputContext

--- a/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
@@ -21,7 +21,7 @@ import cats.syntax.all.*
 import laika.api.Renderer
 import laika.api.builder.{ OperationConfig, TwoPhaseRendererBuilder }
 import laika.ast.{ DocumentTreeRoot, TemplateRoot }
-import laika.config.{ Config, ConfigException }
+import laika.config.Config
 import laika.factory.{
   BinaryPostProcessor,
   BinaryPostProcessorBuilder,
@@ -31,6 +31,7 @@ import laika.factory.{
 import laika.format.{ Markdown, PDF, XSLFO }
 import laika.io.FileIO
 import laika.io.api.BinaryTreeRenderer
+import laika.io.errors.ConfigException
 import laika.io.helper.RenderResult
 import laika.io.implicits.*
 import laika.io.model.{ BinaryOutput, RenderedTreeRoot }

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -23,11 +23,12 @@ import laika.api.Renderer
 import laika.api.builder.OperationConfig
 import laika.ast.{ MessageFilter, Path }
 import laika.config.Config.ConfigResult
-import laika.config.{ ConfigException, LaikaKeys }
+import laika.config.LaikaKeys
 import laika.factory.{ BinaryPostProcessorBuilder, TwoPhaseRenderFormat }
 import laika.format.HTML
 import laika.io.api.{ BinaryTreeRenderer, TreeParser, TreeRenderer }
 import laika.io.config.SiteConfig
+import laika.io.errors.ConfigException
 import laika.io.implicits._
 import laika.io.model._
 import laika.preview.SiteTransformer.ResultMap

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -82,7 +82,7 @@ private[preview] class SiteTransformer[F[_]: Async](
   def transformHTML(tree: ParsedTree[F], renderer: TreeRenderer[F]): F[ResultMap[F]] = {
     renderer
       .from(tree)
-      .toOutput(StringTreeOutput)
+      .toMemory
       .render
       .map { root =>
         val map   = root.allDocuments.map { doc =>

--- a/preview/src/main/scala/laika/preview/StaticFileScanner.scala
+++ b/preview/src/main/scala/laika/preview/StaticFileScanner.scala
@@ -22,8 +22,8 @@ import fs2.io.file.Files
 import laika.api.builder.OperationConfig
 import laika.ast.Path
 import laika.ast.Path.Root
-import laika.config.ConfigException
 import laika.io.config.SiteConfig
+import laika.io.errors.ConfigException
 import laika.io.model.{ BinaryInput, FilePath }
 import laika.io.runtime.DirectoryScanner
 import laika.rewrite.Versions


### PR DESCRIPTION
This is a bit of a grab bag of small changes to prepare for the final repackaging step.

* It moves ADT members to the companion for improved scaladoc navigation for the following types:
    * `laika.config.ConfigValue`
    * `laika.config.ConfigError`
    * `laika.rewrite.link.TargetValidation`

* It moves error types for `laika-core` from the `DocumentParser` companion to a new package `laika.api.errors` so that the `DocumentParser` can be removed from the public API.

* It removes the `TreeOutput` model from public APIs in favor of adding a `.toMemory` method to all transformer builders which removes the need for having the ADT in public.

* Makes error types in `laika-io` private. It's unclear whether there is demand for having access to them. In case there is, it's better to re-introduce them in a 1.x minor as they are in need of some additional polishing.

* Exposes `NoOpPathTranslator` in `PathTranslator.noOp` instead.

This is the last PR before a major repackaging PR that addresses the issue of having multiple semi-populated skeleton packages after all the removals from public API in M2.