### PR TITLE
set up unidoc publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         os: [ubuntu-latest]
         scala: [2.12, 2.13, 3]
         java: [temurin@8, temurin@17]
-        project: [rootJS, rootJVM, plugin]
+        project: [rootJS, rootJVM, plugin, api]
         exclude:
           - scala: 2.13
             java: temurin@17
@@ -43,6 +43,10 @@ jobs:
           - project: plugin
             scala: 2.13
           - project: plugin
+            scala: 3
+          - project: api
+            scala: 2.13
+          - project: api
             scala: 3
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -190,6 +194,16 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.12-plugin
 
       - name: Inflate target directories (2.12, plugin)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.12, api)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12-api
+
+      - name: Inflate target directories (2.12, api)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p sbt/target pdf/target preview/target core/js/target io/target core/jvm/target project/target
+        run: mkdir -p sbt/target pdf/target preview/target core/js/target io/target unidoc/target core/jvm/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar sbt/target pdf/target preview/target core/js/target io/target core/jvm/target project/target
+        run: tar cf targets.tar sbt/target pdf/target preview/target core/js/target io/target unidoc/target core/jvm/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
             java: temurin@17
           - project: plugin
             java: temurin@17
+          - project: api
+            java: temurin@17
           - project: plugin
             scala: 2.13
           - project: plugin

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ inThisBuild(
     },
     githubWorkflowBuildMatrixExclusions ++= {
       MatrixExclude(Map("project" -> "plugin", "java" -> JavaSpec.temurin("17").render)) ::
+        MatrixExclude(Map("project" -> "api", "java" -> JavaSpec.temurin("17").render)) ::
         List("2.13", "3").map(scala =>
           MatrixExclude(Map("project" -> "plugin", "scala" -> scala))
         ) ++:

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ val http4s = Seq(
 )
 
 lazy val root = tlCrossRootProject
-  .aggregate(core, pdf, io, preview, api)
+  .aggregate(core, pdf, io, preview)
   .configureRoot { root =>
     root.aggregate(plugin, api) // don't include the plugin in rootJVM, only in root
       .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -20,11 +20,15 @@ inThisBuild(
     tlCiDependencyGraphJob := false,
     githubWorkflowJavaVersions += JavaSpec.temurin("17"),
     githubWorkflowBuildMatrixAdditions ~= { matrix =>
-      matrix + ("project" -> (matrix("project") :+ "plugin"))
+      matrix +
+        ("project" -> (matrix("project") :+ "plugin" :+ "api"))
     },
     githubWorkflowBuildMatrixExclusions ++= {
       MatrixExclude(Map("project" -> "plugin", "java" -> JavaSpec.temurin("17").render)) ::
-        List("2.13", "3").map(scala => MatrixExclude(Map("project" -> "plugin", "scala" -> scala)))
+        List("2.13", "3").map(scala =>
+          MatrixExclude(Map("project" -> "plugin", "scala" -> scala))
+        ) ++:
+        List("2.13", "3").map(scala => MatrixExclude(Map("project" -> "api", "scala" -> scala)))
     },
     githubWorkflowBuild ++= Seq(
       WorkflowStep.Sbt(
@@ -68,7 +72,7 @@ val http4s = Seq(
 lazy val root = tlCrossRootProject
   .aggregate(core, pdf, io, preview, api)
   .configureRoot { root =>
-    root.aggregate(plugin) // don't include the plugin in rootJVM, only in root
+    root.aggregate(plugin, api) // don't include the plugin in rootJVM, only in root
       .settings(
         crossScalaVersions := Nil,
         scalaVersion       := versions.scala2_12

--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,7 @@ lazy val api = project
   .enablePlugins(TypelevelUnidocPlugin)
   .settings(
     name                                       := "laika-docs",
+    crossScalaVersions                         := Seq(versions.scala2_12),
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(core.js),
     Compile / packageDoc / mappings            :=
       ScaladocCleanup.removeUnwantedEntries(

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ lazy val api = project
   .settings(
     name                                       := "laika-docs",
     crossScalaVersions                         := Seq(versions.scala2_12),
-    ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(core.js),
+    ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(core.js, plugin),
     Compile / packageDoc / mappings            :=
       ScaladocCleanup.removeUnwantedEntries(
         (ScalaUnidoc / packageDoc / mappings).value,

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,6 @@ lazy val api = project
   .enablePlugins(TypelevelUnidocPlugin)
   .settings(
     name                                       := "laika-docs",
-    crossScalaVersions                         := Seq(versions.scala2_12),
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(core.js, plugin),
     Compile / packageDoc / mappings            :=
       ScaladocCleanup.removeUnwantedEntries(

--- a/build.sbt
+++ b/build.sbt
@@ -66,17 +66,12 @@ val http4s = Seq(
 )
 
 lazy val root = tlCrossRootProject
-  .aggregate(core, pdf, io, preview)
+  .aggregate(core, pdf, io, preview, api)
   .configureRoot { root =>
     root.aggregate(plugin) // don't include the plugin in rootJVM, only in root
-      .enablePlugins(ScalaUnidocPlugin)
       .settings(
-        crossScalaVersions                         := Nil,
-        scalaVersion                               := versions.scala2_12,
-        ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(
-          plugin,
-          core.js
-        )
+        crossScalaVersions := Nil,
+        scalaVersion       := versions.scala2_12
       )
   }
 
@@ -99,6 +94,19 @@ lazy val docs = project.in(file("docs"))
     ),
     mdocExtraArguments        := Seq("--no-link-hygiene"),
     scalacOptions ~= disableUnusedWarningsForMdoc
+  )
+
+lazy val api = project
+  .in(file("unidoc"))
+  .enablePlugins(TypelevelUnidocPlugin)
+  .settings(
+    name                                       := "laika-docs",
+    ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(core.js),
+    Compile / packageDoc / mappings            :=
+      ScaladocCleanup.removeUnwantedEntries(
+        (ScalaUnidoc / packageDoc / mappings).value,
+        (ThisBuild / baseDirectory).value
+      )
   )
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html >
+<html>
+        <head>
+          <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+          <title></title>
+          <meta name="description" content="" />
+          <meta name="keywords" content="" />
+          <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+          
+      
+      <link href="lib/index.css" media="screen" type="text/css" rel="stylesheet" />
+      <link href="lib/template.css" media="screen" type="text/css" rel="stylesheet" />
+      <link href="lib/diagrams.css" media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />
+      <script type="text/javascript" src="lib/jquery.min.js"></script>
+      <script type="text/javascript" src="lib/jquery.panzoom.min.js"></script>
+      <script type="text/javascript" src="lib/jquery.mousewheel.min.js"></script>
+      <script type="text/javascript" src="lib/index.js"></script>
+      <script type="text/javascript" src="index.js"></script>
+      <script type="text/javascript" src="lib/scheduler.js"></script>
+      <script type="text/javascript" src="lib/template.js"></script>
+      
+      <script type="text/javascript">
+        /* this variable can be used by the JS to determine the path to the root document */
+        var toRoot = '';
+      </script>
+    
+        </head>
+        <body>
+      <div id="search">
+        <span id="doc-title"><span id="doc-version"></span></span>
+        <span class="close-results"><span class="left">&lt;</span> Back</span>
+        <div id="textfilter">
+          <span class="input">
+            <input autocapitalize="none" placeholder="Search" id="index-input" type="text" accesskey="/" />
+            <i class="clear material-icons"></i>
+            <i id="search-icon" class="material-icons"></i>
+          </span>
+        </div>
+    </div>
+      <div id="search-results">
+        <div id="search-progress">
+          <div id="progress-fill"></div>
+        </div>
+        <div id="results-content">
+          <div id="entity-results"></div>
+          <div id="member-results"></div>
+        </div>
+      </div>
+      <div id="content-scroll-container" style="-webkit-overflow-scrolling: touch;">
+        <div id="content-container" style="-webkit-overflow-scrolling: touch;">
+          <div id="subpackage-spacer">
+            <div id="packages">
+              <h1>Packages</h1>
+              <ul>
+                <li name="_root_.root" visbl="pub" class="indented0 current" data-isabs="false" fullComment="no" group="Ungrouped">
+      <a id="_root_"></a><a id="root:_root_"></a>
+      <span class="permalink">
+      <a href="index.html" title="Permalink">
+        <i class="material-icons"></i>
+      </a>
+    </span>
+      <span class="modifier_kind">
+        <span class="modifier"></span>
+        <span class="kind">package</span>
+      </span>
+      <span class="symbol">
+        <span class="name">root</span>
+      </span>
+      
+      
+    </li><li name="_root_.laika" visbl="pub" class="indented1 " data-isabs="false" fullComment="no" group="Ungrouped">
+      <a id="laika"></a><a id="laika:laika"></a>
+      <span class="permalink">
+      <a href="laika/index.html" title="Permalink">
+        <i class="material-icons"></i>
+      </a>
+    </span>
+      <span class="modifier_kind">
+        <span class="modifier"></span>
+        <span class="kind">package</span>
+      </span>
+      <span class="symbol">
+        <a title="" href="laika/index.html"><span class="name">laika</span></a>
+      </span>
+      
+      
+    </li>
+              </ul>
+            </div>
+          </div>
+          <div id="content">
+            <body class="package value">
+      <div id="definition">
+        <div class="big-circle package">p</div>
+        
+        <h1>root package<span class="permalink">
+      <a href="index.html" title="Permalink">
+        <i class="material-icons"></i>
+      </a>
+    </span></h1>
+        
+      </div>
+
+      <h4 id="signature" class="signature">
+      <span class="modifier_kind">
+        <span class="modifier"></span>
+        <span class="kind">package</span>
+      </span>
+      <span class="symbol">
+        <span class="name">root</span>
+      </span>
+      </h4>
+
+      
+          <div id="comment" class="fullcommenttop"></div>
+        
+
+      
+
+      <div id="template">
+        <div id="allMembers">
+        
+
+        
+
+        
+
+        
+
+        
+
+        
+        </div>
+
+        <div id="inheritedMembers">
+        
+        
+        </div>
+
+        <div id="groupedMembers">
+        <div class="group" name="Ungrouped">
+              <h3>Ungrouped</h3>
+              
+            </div>
+        </div>
+
+      </div>
+
+      <div id="tooltip"></div>
+
+      <div id="footer">  </div>
+    </body>
+          </div>
+        </div>
+      </div>
+    </body>
+      </html>

--- a/project/ScaladocCleanup.scala
+++ b/project/ScaladocCleanup.scala
@@ -1,0 +1,23 @@
+import java.io.File
+
+object ScaladocCleanup {
+
+  def removeUnwantedEntries(
+      mappings: Seq[(File, String)],
+      basePath: sbt.File
+  ): Seq[(File, String)] = {
+
+    // remove unwanted folders
+    val filtered = mappings.filterNot { case (_, mapping) =>
+      mapping.startsWith("org") || mapping.startsWith("sbt") || mapping.startsWith("scodec")
+    }
+
+    // replace root index to remove unwanted entries from navigation
+    filtered.map { case (file, mapping) =>
+      if (mapping == "index.html") (new File(basePath, "docs/api/index.html"), mapping)
+      else (file, mapping)
+    }
+
+  }
+
+}


### PR DESCRIPTION
Includes a workaround for the scaladoc bugs that trigger inclusion of navigation entries for dependencies (sbt, scodec).

Only runs on Scala 2.12.