### PR TITLE
API cleanup - move some more ADT types into their companion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,8 @@ lazy val api = project
     Compile / packageDoc / mappings            :=
       ScaladocCleanup.removeUnwantedEntries(
         (ScalaUnidoc / packageDoc / mappings).value,
-        (ThisBuild / baseDirectory).value
+        (ThisBuild / baseDirectory).value,
+        scalaBinaryVersion.value
       )
   )
 

--- a/core/js/src/main/scala/laika/config/PlatformDateTimeImpl.scala
+++ b/core/js/src/main/scala/laika/config/PlatformDateTimeImpl.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 /** @author Jens Halm
   */
-object PlatformDateTimeImpl extends PlatformDateTime {
+private[laika] object PlatformDateTimeImpl extends PlatformDateTime {
 
   type Type = js.Date
 

--- a/core/js/src/test/scala/laika/time/PlatformDateDirectiveSpec.scala
+++ b/core/js/src/test/scala/laika/time/PlatformDateDirectiveSpec.scala
@@ -1,7 +1,14 @@
 package laika.time
 
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
-import laika.ast.{ Replace, RewriteRules, RootElement, TemplateRoot, TemplateSpan, TemplateString }
+import laika.ast.{
+  RewriteAction,
+  RewriteRules,
+  RootElement,
+  TemplateRoot,
+  TemplateSpan,
+  TemplateString
+}
 import laika.config.PlatformDateTime
 import laika.directive.std.{ MarkupParserSetup, TemplateParserSetup }
 import munit.FunSuite
@@ -34,7 +41,7 @@ class PlatformDateDirectiveSpec extends FunSuite
 
   def normalizeWhitespace(rootElement: RootElement): RootElement =
     rootElement.rewriteChildren(RewriteRules.forTemplates { case ts: TemplateString =>
-      Replace(TemplateString(normalizeWhitespace(ts.content)))
+      RewriteAction.Replace(TemplateString(normalizeWhitespace(ts.content)))
     })
 
   def runTemplate(input: String, config: String, expectedContent: TemplateSpan*)(implicit

--- a/core/jvm/src/main/scala/laika/config/PlatformDateTimeImpl.scala
+++ b/core/jvm/src/main/scala/laika/config/PlatformDateTimeImpl.scala
@@ -25,7 +25,7 @@ import scala.util.Try
 
 /** @author Jens Halm
   */
-object PlatformDateTimeImpl extends PlatformDateTime {
+private[laika] object PlatformDateTimeImpl extends PlatformDateTime {
 
   type Type = OffsetDateTime
 

--- a/core/jvm/src/test/scala/laika/markdown/MarkdownToHTMLSpec.scala
+++ b/core/jvm/src/test/scala/laika/markdown/MarkdownToHTMLSpec.scala
@@ -72,9 +72,9 @@ class MarkdownToHTMLSpec extends FunSuite {
           // Markdown always writes p tags inside blockquotes
           fmt.indentedElement("blockquote", qb)
         case (fmt, h @ Header(_, _, Id(_)))                  =>
-          fmt.child(h.withOptions(NoOpt)) // Markdown classic does not generate header ids
+          fmt.child(h.clearOptions) // Markdown classic does not generate header ids
         case (fmt, t @ Title(_, Id("unordered")))            => fmt.child(Header(2, t.content))
-        case (fmt, t @ Title(_, Id(_)))                      => fmt.child(t.withOptions(NoOpt))
+        case (fmt, t @ Title(_, Id(_)))                      => fmt.child(t.clearOptions)
       }
       .withMessageFilters(
         MessageFilters.custom(failOn = MessageFilter.None, render = MessageFilter.None)

--- a/core/jvm/src/test/scala/laika/markdown/MarkdownToHTMLSpec.scala
+++ b/core/jvm/src/test/scala/laika/markdown/MarkdownToHTMLSpec.scala
@@ -61,7 +61,7 @@ class MarkdownToHTMLSpec extends FunSuite {
       .from(Markdown).to(HTML)
       .strict.withRawContent
       .usingSpanRule { case LinkPathReference(content, relPath, _, title, opt) =>
-        Replace(
+        RewriteAction.Replace(
           SpanLink(content, renderPath(relPath), title, opt)
         ) // We do not validate cross-links in these tests
       }

--- a/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
+++ b/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
@@ -332,7 +332,7 @@ object OperationConfig {
     processBundles(Nil, sortBundles(bundles).toList)
       .reverse
       .reduceLeftOption(_ withBase _)
-      .getOrElse(ExtensionBundle.Empty)
+      .getOrElse(ExtensionBundle.empty)
   }
 
   /** A configuration instance with all the libraries default extension bundles.

--- a/core/shared/src/main/scala/laika/api/bundle/DirectiveRegistry.scala
+++ b/core/shared/src/main/scala/laika/api/bundle/DirectiveRegistry.scala
@@ -82,7 +82,7 @@ trait DirectiveRegistry extends ExtensionBundle { self =>
     *  Example:
     *
     *  {{{
-    *  case class Note (title: String, content: Seq[Block], options: Options = NoOpt)
+    *  case class Note (title: String, content: Seq[Block], options: Options = Options.empty)
     *                                                       extends Block with BlockContainer[Note]
     *  object MyDirectives extends DirectiveRegistry {
     *    val blockDirectives = Seq(

--- a/core/shared/src/main/scala/laika/api/bundle/ExtensionBundle.scala
+++ b/core/shared/src/main/scala/laika/api/bundle/ExtensionBundle.scala
@@ -257,8 +257,8 @@ object ExtensionBundle {
       val config: Config
   )
 
-  /** An empty bundle */
-  object Empty extends ExtensionBundle {
+  /** An empty bundle. */
+  val empty: ExtensionBundle = new ExtensionBundle {
     val description: String           = "Empty extension bundle"
     override val origin: BundleOrigin = BundleOrigin.Library
   }

--- a/core/shared/src/main/scala/laika/api/bundle/PathTranslator.scala
+++ b/core/shared/src/main/scala/laika/api/bundle/PathTranslator.scala
@@ -60,11 +60,11 @@ trait PathTranslator {
     * in case a `siteBaseURL` is configured.
     */
   def translate(target: Target): Target = target match {
-    case rt: ResolvedInternalTarget =>
+    case rt: InternalTarget.Resolved =>
       rt.copy(absolutePath = translate(rt.absolutePath), relativePath = translate(rt.relativePath))
-    case at: AbsoluteInternalTarget => at.copy(path = translate(at.path))
-    case rt: RelativeInternalTarget => rt.copy(path = translate(rt.path))
-    case et                         => et
+    case at: InternalTarget.Absolute => at.copy(path = translate(at.path))
+    case rt: InternalTarget.Relative => rt.copy(path = translate(rt.path))
+    case et                          => et
   }
 
   /** Creates a copy of this path translator that uses the specified reference path for resolving
@@ -140,7 +140,7 @@ private[laika] class PathTranslatorExtension(
   )
 
   def translate(input: RelativePath): RelativePath = {
-    val absolute   = RelativeInternalTarget(input).relativeTo(refPath).absolutePath
+    val absolute   = InternalTarget.Relative(input).relativeTo(refPath).absolutePath
     val translated = translate(absolute)
     translated.relativeTo(translatedRefPath)
   }
@@ -178,13 +178,13 @@ private[laika] case class ConfigurablePathTranslator(
   }
 
   def translate(input: RelativePath): RelativePath = {
-    val absolute   = RelativeInternalTarget(input).relativeTo(refPath).absolutePath
+    val absolute   = InternalTarget.Relative(input).relativeTo(refPath).absolutePath
     val translated = translate(absolute)
     translated.relativeTo(translatedRefPath)
   }
 
   override def translate(target: Target): Target = (target, config.siteBaseURL) match {
-    case (ResolvedInternalTarget(absolutePath, _, formats), Some(baseURL))
+    case (InternalTarget.Resolved(absolutePath, _, formats), Some(baseURL))
         if !formats.contains(outputContext.formatSelector) =>
       ExternalTarget(
         baseURL + translate(absolutePath.withSuffix("html"), isHTMLTarget = true).relative.toString

--- a/core/shared/src/main/scala/laika/api/bundle/directives.scala
+++ b/core/shared/src/main/scala/laika/api/bundle/directives.scala
@@ -669,7 +669,7 @@ trait DirectiveBuilderContext[E <: Element] {
     *  The implementation of this directive could look like this:
     *
     *  {{{
-    *  case class Note (title: String, content: Seq[Block], options: Options = NoOpt)
+    *  case class Note (title: String, content: Seq[Block], options: Options = Options.empty)
     *                                                      extends Block with BlockContainer[Note]
     *
     *  object MyDirectives extends DirectiveRegistry {
@@ -701,7 +701,7 @@ trait DirectiveBuilderContext[E <: Element] {
     *  {{{
     *  case class Message (severity: Int,
     *                      content: Seq[Block],
-    *                      options: Options = NoOpt) extends Block
+    *                      options: Options = Options.empty) extends Block
     *                                                with BlockContainer[Message]
     *
     *  val blockDirectives = Seq(
@@ -724,7 +724,7 @@ trait DirectiveBuilderContext[E <: Element] {
     *  {{{
     *  case class Message (severity: Int,
     *                      content: Seq[Block],
-    *                      options: Options = NoOpt) extends Block
+    *                      options: Options = Options.empty) extends Block
     *                                                with BlockContainer[Message]
     *
     *  val blockDirectives = Seq(
@@ -758,7 +758,7 @@ object SpanDirectives extends DirectiveBuilderContext[Span] {
       parser: RecursiveSpanParsers,
       source: SourceFragment,
       rewriteRules: RewriteRules = RewriteRules.empty,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends SpanResolver with RewritableContainer with DirectiveInstanceBase {
     type Self = DirectiveInstance
     val typeName: String                                 = "span"
@@ -780,7 +780,7 @@ object SpanDirectives extends DirectiveBuilderContext[Span] {
   private[laika] case class SeparatorInstance(
       parsedResult: ParsedDirective,
       source: SourceFragment,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends Span with SeparatorInstanceBase with SpanResolver {
     type Self = SeparatorInstance
     def withOptions(options: Options): SeparatorInstance = copy(options = options)
@@ -810,7 +810,7 @@ object BlockDirectives extends DirectiveBuilderContext[Block] {
       parser: RecursiveParsers,
       source: SourceFragment,
       rewriteRules: RewriteRules = RewriteRules.empty,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends BlockResolver with RewritableContainer with DirectiveInstanceBase {
     type Self = DirectiveInstance
     val typeName: String                                 = "block"
@@ -832,7 +832,7 @@ object BlockDirectives extends DirectiveBuilderContext[Block] {
   private[laika] case class SeparatorInstance(
       parsedResult: ParsedDirective,
       source: SourceFragment,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends Block with SeparatorInstanceBase with BlockResolver {
     type Self = SeparatorInstance
     def withOptions(options: Options): SeparatorInstance = copy(options = options)
@@ -866,7 +866,7 @@ object TemplateDirectives extends DirectiveBuilderContext[TemplateSpan] {
       parsedResult: ParsedDirective,
       parser: RecursiveSpanParsers,
       source: SourceFragment,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends SpanResolver with TemplateSpan with DirectiveInstanceBase {
     type Self = DirectiveInstance
     val typeName: String                                 = "template"
@@ -884,7 +884,7 @@ object TemplateDirectives extends DirectiveBuilderContext[TemplateSpan] {
   private[laika] case class SeparatorInstance(
       parsedResult: ParsedDirective,
       source: SourceFragment,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends TemplateSpan with SeparatorInstanceBase with SpanResolver {
     type Self = SeparatorInstance
     def withOptions(options: Options): SeparatorInstance = copy(options = options)

--- a/core/shared/src/main/scala/laika/api/errors/errors.scala
+++ b/core/shared/src/main/scala/laika/api/errors/errors.scala
@@ -24,14 +24,11 @@ case class InvalidInput(error: Failure) extends ParserError {
   val message: String = s"Error parsing input: ${error.message}"
 }
 
-case class InvalidElements(errors: Either[NonEmptyChain[ConfigError], NonEmptyChain[Invalid]])
+case class InvalidElements(elements: NonEmptyChain[Invalid])
     extends ParserError {
 
   val message: String = {
-    val formatted = errors.fold(
-      configErrors => configErrors.map(_.message).mkString_("\n"),
-      invalidElems => invalidElems.map(InvalidDocument.formatElement("", _)).toList.mkString
-    )
+    val formatted = elements.map(InvalidDocument.formatElement("", _)).toList.mkString
     s"One or more error nodes in result:\n$formatted".trim
   }
 

--- a/core/shared/src/main/scala/laika/ast/InvalidElement.scala
+++ b/core/shared/src/main/scala/laika/ast/InvalidElement.scala
@@ -27,7 +27,7 @@ case class InvalidSpan(
     message: RuntimeMessage,
     source: SourceFragment,
     fallback: Span,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Span with Invalid {
   type Self            = InvalidSpan
   type FallbackElement = Span
@@ -51,7 +51,7 @@ case class InvalidBlock(
     message: RuntimeMessage,
     source: SourceFragment,
     fallback: Block,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Block with Invalid {
   type Self            = InvalidBlock
   type FallbackElement = Block
@@ -79,7 +79,7 @@ object InvalidBlock {
   * the user has configured with the `renderErrors` method to debug in a visual mode
   * in which case the errors will get rendered in-place in the output.
   */
-case class RuntimeMessage(level: MessageLevel, content: String, options: Options = NoOpt)
+case class RuntimeMessage(level: MessageLevel, content: String, options: Options = Options.empty)
     extends Span
     with Block
     with TextContainer {

--- a/core/shared/src/main/scala/laika/ast/RewriteRules.scala
+++ b/core/shared/src/main/scala/laika/ast/RewriteRules.scala
@@ -21,6 +21,7 @@ import laika.api.format.{ RenderFormat, TwoPhaseRenderFormat }
 import laika.ast.RewriteRules.{ ChainedRewriteRules, RewritePhaseBuilder, RewriteRulesBuilder }
 import laika.api.config.Config.ConfigResult
 import laika.api.config.ConfigError.MultipleErrors
+import laika.ast.RewriteAction.*
 import laika.config.Selections
 import laika.internal.link.LinkResolver
 import laika.internal.nav.SectionBuilder
@@ -312,17 +313,21 @@ object RewriteRules {
   */
 sealed trait RewriteAction[+T]
 
-/** Indicates that the element a rewrite rule had been applied to should be replaced with this new value.
-  */
-case class Replace[T](newValue: T) extends RewriteAction[T]
+object RewriteAction {
 
-/** Indicates that the element a rewrite rule had been applied to should be kept in the document AST unchanged.
-  */
-case object Retain extends RewriteAction[Nothing]
+  /** Indicates that the element a rewrite rule had been applied to should be replaced with this new value.
+    */
+  case class Replace[T](newValue: T) extends RewriteAction[T]
 
-/** Indicates that the element a rewrite rule had been applied to should be removed from the document AST.
-  */
-case object Remove extends RewriteAction[Nothing]
+  /** Indicates that the element a rewrite rule had been applied to should be kept in the document AST unchanged.
+    */
+  case object Retain extends RewriteAction[Nothing]
+
+  /** Indicates that the element a rewrite rule had been applied to should be removed from the document AST.
+    */
+  case object Remove extends RewriteAction[Nothing]
+
+}
 
 /** Represents one of the rewrite phases for document AST transformations.
   *

--- a/core/shared/src/main/scala/laika/ast/Table.scala
+++ b/core/shared/src/main/scala/laika/ast/Table.scala
@@ -23,7 +23,7 @@ case class Table(
     body: TableBody,
     caption: Caption = Caption(),
     columns: Columns = Columns(Nil),
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Block
     with ElementTraversal with RewritableContainer {
   type Self = Table
@@ -59,7 +59,7 @@ sealed trait TableContainer extends TableElement with ElementContainer[TableElem
 
 /** Contains the header rows of a table.
   */
-case class TableHead(content: Seq[Row], options: Options = NoOpt) extends TableElement
+case class TableHead(content: Seq[Row], options: Options = Options.empty) extends TableElement
     with TableContainer with RewritableContainer {
   type Self = TableHead
 
@@ -71,7 +71,7 @@ case class TableHead(content: Seq[Row], options: Options = NoOpt) extends TableE
 
 /** Contains the body rows of a table.
   */
-case class TableBody(content: Seq[Row], options: Options = NoOpt) extends TableElement
+case class TableBody(content: Seq[Row], options: Options = Options.empty) extends TableElement
     with TableContainer with RewritableContainer {
   type Self = TableBody
 
@@ -83,7 +83,7 @@ case class TableBody(content: Seq[Row], options: Options = NoOpt) extends TableE
 
 /** The table caption.
   */
-case class Caption(content: Seq[Span] = Nil, options: Options = NoOpt) extends TableElement
+case class Caption(content: Seq[Span] = Nil, options: Options = Options.empty) extends TableElement
     with SpanContainer {
   type Self = Caption
   def withContent(newContent: Seq[Span]): Caption = copy(content = newContent)
@@ -97,7 +97,7 @@ object Caption extends SpanContainerCompanion {
 
 /** Contains the (optional) column specification of a table.
   */
-case class Columns(content: Seq[Column], options: Options = NoOpt) extends TableElement
+case class Columns(content: Seq[Column], options: Options = Options.empty) extends TableElement
     with TableContainer {
   type Self = Columns
   def withOptions(options: Options): Columns = copy(options = options)
@@ -112,7 +112,7 @@ object Columns {
 
 /** The options (like styles) for a column table.
   */
-case class Column(options: Options = NoOpt) extends TableElement {
+case class Column(options: Options = Options.empty) extends TableElement {
   type Self = Column
   def withOptions(options: Options): Column = copy(options = options)
 }
@@ -121,7 +121,7 @@ case class Column(options: Options = NoOpt) extends TableElement {
   *  cells with a colspan greater than 1, this row may contain
   *  fewer cells than the number of columns in the table.
   */
-case class Row(content: Seq[Cell], options: Options = NoOpt) extends TableElement
+case class Row(content: Seq[Cell], options: Options = Options.empty) extends TableElement
     with TableContainer with RewritableContainer {
   type Self = Row
 
@@ -143,7 +143,7 @@ case class Cell(
     content: Seq[Block],
     colspan: Int = 1,
     rowspan: Int = 1,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends TableElement
     with BlockContainer {
   type Self = Cell

--- a/core/shared/src/main/scala/laika/ast/Table.scala
+++ b/core/shared/src/main/scala/laika/ast/Table.scala
@@ -155,18 +155,26 @@ case class Cell(
   */
 sealed abstract class CellType
 
-/** A cell in the head part of the table.
-  */
-case object HeadCell extends CellType with BlockContainerCompanion {
-  type ContainerType = Cell
-  def apply(blocks: Seq[Block]): Cell                    = Cell(this, blocks)
-  protected def createBlockContainer(blocks: Seq[Block]) = Cell(this, blocks)
-}
+object CellType {
 
-/** A cell in the body part of the table.
-  */
-case object BodyCell extends CellType with BlockContainerCompanion {
-  type ContainerType = Cell
-  def apply(blocks: Seq[Block]): Cell                    = Cell(this, blocks)
-  protected def createBlockContainer(blocks: Seq[Block]) = Cell(this, blocks)
+  /** A cell in the head part of the table.
+    */
+  case object HeadCell extends CellType with BlockContainerCompanion {
+    type ContainerType = Cell
+
+    def apply(blocks: Seq[Block]): Cell = Cell(this, blocks)
+
+    protected def createBlockContainer(blocks: Seq[Block]) = Cell(this, blocks)
+  }
+
+  /** A cell in the body part of the table.
+    */
+  case object BodyCell extends CellType with BlockContainerCompanion {
+    type ContainerType = Cell
+
+    def apply(blocks: Seq[Block]): Cell = Cell(this, blocks)
+
+    protected def createBlockContainer(blocks: Seq[Block]) = Cell(this, blocks)
+  }
+
 }

--- a/core/shared/src/main/scala/laika/ast/TargetValidation.scala
+++ b/core/shared/src/main/scala/laika/ast/TargetValidation.scala
@@ -6,7 +6,7 @@ object TargetValidation {
   case object ValidTarget                   extends TargetValidation
   case class InvalidTarget(message: String) extends TargetValidation
 
-  case class RecoveredTarget(message: String, recoveredTarget: ResolvedInternalTarget)
+  case class RecoveredTarget(message: String, recoveredTarget: InternalTarget.Resolved)
       extends TargetValidation
 
 }

--- a/core/shared/src/main/scala/laika/ast/base.scala
+++ b/core/shared/src/main/scala/laika/ast/base.scala
@@ -71,7 +71,7 @@ abstract class Element extends Product with Serializable {
 
   /** Returns a new instance of this element with all options removed from it.
     */
-  def clearOptions: Self = withOptions(NoOpt)
+  def clearOptions: Self = withOptions(Options.empty)
 
   /** Returns a new instance of this element with the specified options replacing the current value.
     */

--- a/core/shared/src/main/scala/laika/ast/blocks.scala
+++ b/core/shared/src/main/scala/laika/ast/blocks.scala
@@ -22,7 +22,7 @@ import laika.parse.SourceFragment
 
 /** The root element of a document tree.
   */
-case class RootElement(content: Seq[Block], options: Options = NoOpt) extends Block
+case class RootElement(content: Seq[Block], options: Options = Options.empty) extends Block
     with BlockContainer {
   type Self = RootElement
   def withContent(newContent: Seq[Block]): RootElement = copy(content = newContent)
@@ -36,7 +36,7 @@ object RootElement extends BlockContainerCompanion {
 
 /** A paragraph consisting of span elements.
   */
-case class Paragraph(content: Seq[Span], options: Options = NoOpt) extends Block
+case class Paragraph(content: Seq[Span], options: Options = Options.empty) extends Block
     with SpanContainer {
   type Self = Paragraph
   def withContent(newContent: Seq[Span]): Paragraph = copy(content = newContent)
@@ -50,7 +50,7 @@ object Paragraph extends SpanContainerCompanion {
 
 /** A literal block with unparsed text content.
   */
-case class LiteralBlock(content: String, options: Options = NoOpt) extends Block
+case class LiteralBlock(content: String, options: Options = Options.empty) extends Block
     with TextContainer {
   type Self = LiteralBlock
   def withOptions(options: Options): LiteralBlock = copy(options = options)
@@ -58,7 +58,7 @@ case class LiteralBlock(content: String, options: Options = NoOpt) extends Block
 
 /** A literal block with parsed text content.
   */
-case class ParsedLiteralBlock(content: Seq[Span], options: Options = NoOpt) extends Block
+case class ParsedLiteralBlock(content: Seq[Span], options: Options = Options.empty) extends Block
     with SpanContainer {
   type Self = ParsedLiteralBlock
   def withContent(newContent: Seq[Span]): ParsedLiteralBlock = copy(content = newContent)
@@ -82,7 +82,7 @@ case class CodeBlock(
     language: String,
     content: Seq[Span],
     codeOptions: Seq[String] = Nil,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Block with SpanContainer {
   type Self = CodeBlock
   def withContent(newContent: Seq[Span]): CodeBlock = copy(content = newContent)
@@ -99,38 +99,49 @@ case class CodeBlock(
   * Can be used as both block and inline element.
   * If supported by a parser it usually has to be explicitly enabled due to security concerns.
   */
-case class RawContent(formats: NonEmptySet[String], content: String, options: Options = NoOpt)
-    extends Block with Span with TextContainer {
+case class RawContent(
+    formats: NonEmptySet[String],
+    content: String,
+    options: Options = Options.empty
+) extends Block with Span with TextContainer {
   type Self = RawContent
   def withOptions(options: Options): RawContent = copy(options = options)
 }
 
 /** A horizontal rule.
   */
-case class Rule(options: Options = NoOpt) extends Block {
+case class Rule(options: Options = Options.empty) extends Block {
   type Self = Rule
   def withOptions(options: Options): Rule = copy(options = options)
 }
 
 /** A named document fragment that usually gets rendered separately from the main root element
   */
-case class DocumentFragment(name: String, root: Element, options: Options = NoOpt) extends Block {
+case class DocumentFragment(name: String, root: Element, options: Options = Options.empty)
+    extends Block {
   type Self = DocumentFragment
   def withOptions(options: Options): DocumentFragment = copy(options = options)
 }
 
 /** An element that only gets rendered for a specific output format.
   */
-case class TargetFormat(formats: NonEmptySet[String], element: Element, options: Options = NoOpt)
-    extends Block {
+case class TargetFormat(
+    formats: NonEmptySet[String],
+    element: Element,
+    options: Options = Options.empty
+) extends Block {
   type Self = TargetFormat
   def withOptions(options: Options): TargetFormat = copy(options = options)
 }
 
 /** Represents a single choice in a `ChoiceGroup`.
   */
-case class Choice(name: String, label: String, content: Seq[Block], options: Options = NoOpt)
-    extends BlockContainer {
+case class Choice(
+    name: String,
+    label: String,
+    content: Seq[Block],
+    options: Options = Options.empty
+) extends BlockContainer {
   type Self = Choice
   def withContent(newContent: Seq[Block]): Choice = copy(content = newContent)
   def withOptions(options: Options): Choice       = copy(options = options)
@@ -140,7 +151,8 @@ case class Choice(name: String, label: String, content: Seq[Block], options: Opt
   * e.g. a code sample in Scala or Java or a build setup in sbt vs. Maven.
   * In the final output these will usually be rendered in a way to allow for a convenient selection.
   */
-case class Selection(name: String, choices: Seq[Choice], options: Options = NoOpt) extends Block
+case class Selection(name: String, choices: Seq[Choice], options: Options = Options.empty)
+    extends Block
     with RewritableContainer {
   type Self = Selection
   def withOptions(options: Options): Selection = copy(options = options)
@@ -155,7 +167,7 @@ case class Selection(name: String, choices: Seq[Choice], options: Options = NoOp
   *  to the configuration of the document.
   *  During rendering these embedded configuration values will be discarded.
   */
-case class EmbeddedConfigValue(key: String, value: ConfigValue, options: Options = NoOpt)
+case class EmbeddedConfigValue(key: String, value: ConfigValue, options: Options = Options.empty)
     extends Block with Span with Hidden {
   type Self = EmbeddedConfigValue
   def withOptions(options: Options): EmbeddedConfigValue = copy(options = options)
@@ -164,7 +176,7 @@ case class EmbeddedConfigValue(key: String, value: ConfigValue, options: Options
 object EmbeddedConfigValue {
 
   def apply[T](name: String, value: T)(implicit encoder: ConfigEncoder[T]): EmbeddedConfigValue =
-    EmbeddedConfigValue(name, encoder(value), NoOpt)
+    EmbeddedConfigValue(name, encoder(value), Options.empty)
 
 }
 
@@ -172,7 +184,8 @@ object EmbeddedConfigValue {
   *  of a list of Block elements. Sections may be nested inside other sections,
   *  they are arranged in a hierarchy based on the level of their header element.
   */
-case class Section(header: Header, content: Seq[Block], options: Options = NoOpt) extends Block
+case class Section(header: Header, content: Seq[Block], options: Options = Options.empty)
+    extends Block
     with BlockContainer {
   type Self = Section
 
@@ -189,7 +202,7 @@ case class Section(header: Header, content: Seq[Block], options: Options = NoOpt
 
 /** A header element with a level, with 1 being the top level of the document.
   */
-case class Header(level: Int, content: Seq[Span], options: Options = NoOpt) extends Block
+case class Header(level: Int, content: Seq[Span], options: Options = Options.empty) extends Block
     with SpanContainer {
   type Self = Header
   def withContent(newContent: Seq[Span]): Header = copy(content = newContent)
@@ -207,7 +220,8 @@ object Header {
 
 /** The (optional) title of the document.
   */
-case class Title(content: Seq[Span], options: Options = NoOpt) extends Block with SpanContainer {
+case class Title(content: Seq[Span], options: Options = Options.empty) extends Block
+    with SpanContainer {
   type Self = Title
   def withContent(newContent: Seq[Span]): Title = copy(content = newContent)
   def withOptions(options: Options): Title      = copy(options = options)
@@ -227,7 +241,7 @@ case class DecoratedHeader(
     decoration: HeaderDecoration,
     content: Seq[Span],
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Block
     with SpanContainer
     with Unresolved {
@@ -267,7 +281,7 @@ trait HeaderDecoration
   *  Usually renderers do not treat the container as a special element and render its children
   *  as s sub flow of the parent container.
   */
-case class BlockSequence(content: Seq[Block], options: Options = NoOpt) extends Block
+case class BlockSequence(content: Seq[Block], options: Options = Options.empty) extends Block
     with BlockContainer {
   type Self = BlockSequence
   def withContent(newContent: Seq[Block]): BlockSequence = copy(content = newContent)
@@ -282,8 +296,11 @@ object BlockSequence extends BlockContainerCompanion {
 /** A quoted block consisting of a list of blocks that may contain other
   *  nested quoted blocks and an attribution which may be empty.
   */
-case class QuotedBlock(content: Seq[Block], attribution: Seq[Span] = Nil, options: Options = NoOpt)
-    extends Block
+case class QuotedBlock(
+    content: Seq[Block],
+    attribution: Seq[Span] = Nil,
+    options: Options = Options.empty
+) extends Block
     with BlockContainer {
   type Self = QuotedBlock
 
@@ -303,7 +320,7 @@ object QuotedBlock extends BlockContainerCompanion {
   *  Often combined with the the `styles` attribute of the `options` parameter to provide
   *  additional render hints.
   */
-case class TitledBlock(title: Seq[Span], content: Seq[Block], options: Options = NoOpt)
+case class TitledBlock(title: Seq[Span], content: Seq[Block], options: Options = Options.empty)
     extends Block
     with BlockContainer {
   type Self = TitledBlock
@@ -318,8 +335,12 @@ case class TitledBlock(title: Seq[Span], content: Seq[Block], options: Options =
 /** A figure consists of an image, an optional caption, and an optional legend as the `content` property.
   *  The `image` property is of type `Span` as the image might be wrapped inside a link reference.
   */
-case class Figure(image: Span, caption: Seq[Span], content: Seq[Block], options: Options = NoOpt)
-    extends Block with BlockContainer {
+case class Figure(
+    image: Span,
+    caption: Seq[Span],
+    content: Seq[Block],
+    options: Options = Options.empty
+) extends Block with BlockContainer {
 
   type Self = Figure
 
@@ -335,14 +356,15 @@ case class Figure(image: Span, caption: Seq[Span], content: Seq[Block], options:
 
 /** An explicit hard page break.
   */
-case class PageBreak(options: Options = NoOpt) extends Block {
+case class PageBreak(options: Options = Options.empty) extends Block {
   type Self = PageBreak
   def withOptions(options: Options): PageBreak = copy(options = options)
 }
 
 /** A comment that may be omitted by renderers.
   */
-case class Comment(content: String, options: Options = NoOpt) extends Block with TextContainer {
+case class Comment(content: String, options: Options = Options.empty) extends Block
+    with TextContainer {
   type Self = Comment
   def withOptions(options: Options): Comment = copy(options = options)
 }
@@ -354,7 +376,7 @@ case class Comment(content: String, options: Options = NoOpt) extends Block with
   *  Using this element as mandated by some edge cases in both the Markdown and reStructuredText
   *  markup definitions prevents this.
   */
-case class ForcedParagraph(content: Seq[Span], options: Options = NoOpt) extends Block
+case class ForcedParagraph(content: Seq[Span], options: Options = Options.empty) extends Block
     with SpanContainer with Fallback {
   type Self = ForcedParagraph
 

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -154,7 +154,7 @@ case class SectionInfo(
     id: String,
     title: SpanSequence,
     content: Seq[SectionInfo],
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Element with ElementContainer[SectionInfo] {
 
   type Self = SectionInfo

--- a/core/shared/src/main/scala/laika/ast/html/elements.scala
+++ b/core/shared/src/main/scala/laika/ast/html/elements.scala
@@ -24,7 +24,7 @@ import laika.ast.*
   * as its root element.
   * It may contain other nested HTML elements and tags, but no spans produced by standard Markdown markup.
   */
-case class HTMLBlock(root: HTMLElement, options: Options = NoOpt) extends Block {
+case class HTMLBlock(root: HTMLElement, options: Options = Options.empty) extends Block {
   type Self = HTMLBlock
   def withOptions(options: Options): HTMLBlock = copy(options = options)
 }
@@ -37,7 +37,7 @@ abstract class HTMLSpan extends Span
   * The content of this span container may contain further nested HTML elements
   * and tags as well as simple text elements.
   */
-case class HTMLElement(startTag: HTMLStartTag, content: Seq[Span], options: Options = NoOpt)
+case class HTMLElement(startTag: HTMLStartTag, content: Seq[Span], options: Options = Options.empty)
     extends HTMLSpan with SpanContainer {
   type Self = HTMLElement
   def withContent(newContent: Seq[Span]): HTMLElement = copy(content = newContent)
@@ -52,8 +52,11 @@ case class HTMLElement(startTag: HTMLStartTag, content: Seq[Span], options: Opti
   * This library however does not implement the full logic of a proper HTML parser
   * to distinguish between legal and faulty occurrences of unmatched start tags.
   */
-case class HTMLStartTag(name: String, attributes: List[HTMLAttribute], options: Options = NoOpt)
-    extends HTMLSpan with Block {
+case class HTMLStartTag(
+    name: String,
+    attributes: List[HTMLAttribute],
+    options: Options = Options.empty
+) extends HTMLSpan with Block {
   type Self = HTMLStartTag
   def withOptions(options: Options): HTMLStartTag = copy(options = options)
 }
@@ -62,22 +65,26 @@ case class HTMLStartTag(name: String, attributes: List[HTMLAttribute], options: 
   * in case it contains the explicit slash to mark it as closed.
   * Otherwise it will be classified as a start tag.
   */
-case class HTMLEmptyElement(name: String, attributes: List[HTMLAttribute], options: Options = NoOpt)
-    extends HTMLSpan with Block {
+case class HTMLEmptyElement(
+    name: String,
+    attributes: List[HTMLAttribute],
+    options: Options = Options.empty
+) extends HTMLSpan with Block {
   type Self = HTMLEmptyElement
   def withOptions(options: Options): HTMLEmptyElement = copy(options = options)
 }
 
 /** Represents an orphaned end tag without matching start tag.
   */
-case class HTMLEndTag(name: String, options: Options = NoOpt) extends HTMLSpan {
+case class HTMLEndTag(name: String, options: Options = Options.empty) extends HTMLSpan {
   type Self = HTMLEndTag
   def withOptions(options: Options): HTMLEndTag = copy(options = options)
 }
 
 /** Represents a standard HTML comment.
   */
-case class HTMLComment(content: String, options: Options = NoOpt) extends HTMLSpan with Block
+case class HTMLComment(content: String, options: Options = Options.empty) extends HTMLSpan
+    with Block
     with TextContainer {
   type Self = HTMLComment
   def withOptions(options: Options): HTMLComment = copy(options = options)
@@ -88,7 +95,7 @@ case class HTMLComment(content: String, options: Options = NoOpt) extends HTMLSp
 case class HTMLScriptElement(
     attributes: List[HTMLAttribute],
     content: String,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends HTMLSpan with TextContainer {
   type Self = HTMLScriptElement
   def withOptions(options: Options): HTMLScriptElement = copy(options = options)
@@ -96,7 +103,8 @@ case class HTMLScriptElement(
 
 /** Represents a numerical or named character reference.
   */
-case class HTMLCharacterReference(content: String, options: Options = NoOpt) extends HTMLSpan
+case class HTMLCharacterReference(content: String, options: Options = Options.empty)
+    extends HTMLSpan
     with TextContainer {
   type Self = HTMLCharacterReference
   def withOptions(options: Options): HTMLCharacterReference = copy(options = options)

--- a/core/shared/src/main/scala/laika/ast/links.scala
+++ b/core/shared/src/main/scala/laika/ast/links.scala
@@ -89,21 +89,25 @@ case class Footnote(label: String, content: Seq[Block], options: Options = NoOpt
   */
 sealed trait FootnoteLabel
 
-/** Label with automatic numbering.
-  */
-case object Autonumber extends FootnoteLabel
+object FootnoteLabel {
 
-/** Label with automatic symbol assignment.
-  */
-case object Autosymbol extends FootnoteLabel
+  /** Label with automatic numbering.
+    */
+  case object Autonumber extends FootnoteLabel
 
-/** Explicit numeric label.
-  */
-case class NumericLabel(number: Int) extends FootnoteLabel
+  /** Label with automatic symbol assignment.
+    */
+  case object Autosymbol extends FootnoteLabel
 
-/** Label using automatic numbering and explicit label names together.
-  */
-case class AutonumberLabel(label: String) extends FootnoteLabel
+  /** Explicit numeric label.
+    */
+  case class NumericLabel(number: Int) extends FootnoteLabel
+
+  /** Label using automatic numbering and explicit label names together.
+    */
+  case class AutonumberLabel(label: String) extends FootnoteLabel
+
+}
 
 /** A raw link element without associated content (text or image).
   *

--- a/core/shared/src/main/scala/laika/ast/links.scala
+++ b/core/shared/src/main/scala/laika/ast/links.scala
@@ -29,7 +29,7 @@ case class LinkDefinition(
     id: String,
     target: Target,
     title: Option[String] = None,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Definition with Hidden
     with Span {
   type Self = LinkDefinition
@@ -38,7 +38,8 @@ case class LinkDefinition(
 
 /** A link target pointing to another link target, acting like an alias.
   */
-case class LinkAlias(id: String, target: String, options: Options = NoOpt) extends Definition
+case class LinkAlias(id: String, target: String, options: Options = Options.empty)
+    extends Definition
     with Span with Hidden {
   type Self = LinkAlias
   def withOptions(options: Options): LinkAlias = copy(options = options)
@@ -50,7 +51,7 @@ case class FootnoteDefinition(
     label: FootnoteLabel,
     content: Seq[Block],
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Definition with BlockContainer with Unresolved {
   type Self = FootnoteDefinition
   def withContent(newContent: Seq[Block]): FootnoteDefinition = copy(content = newContent)
@@ -60,14 +61,16 @@ case class FootnoteDefinition(
 
 /** Points to the following block or span element, making it a target for links.
   */
-case class InternalLinkTarget(options: Options = NoOpt) extends Block with Span with LinkTarget {
+case class InternalLinkTarget(options: Options = Options.empty) extends Block with Span
+    with LinkTarget {
   type Self = InternalLinkTarget
   def withOptions(options: Options): InternalLinkTarget = copy(options = options)
 }
 
 /** A citation that can be referred to by a `CitationLink` by id.
   */
-case class Citation(label: String, content: Seq[Block], options: Options = NoOpt) extends Block
+case class Citation(label: String, content: Seq[Block], options: Options = Options.empty)
+    extends Block
     with LinkTarget
     with BlockContainer {
   type Self = Citation
@@ -77,7 +80,8 @@ case class Citation(label: String, content: Seq[Block], options: Options = NoOpt
 
 /** A footnote with resolved id and label that can be referred to by a `FootnoteLink` by id.
   */
-case class Footnote(label: String, content: Seq[Block], options: Options = NoOpt) extends Block
+case class Footnote(label: String, content: Seq[Block], options: Options = Options.empty)
+    extends Block
     with LinkTarget
     with BlockContainer {
   type Self = Footnote
@@ -116,7 +120,7 @@ object FootnoteLabel {
   *
   * Raw links participate in path translation (e.g. for versioning) like all other link node types.
   */
-case class RawLink(target: Target, options: Options = NoOpt) extends GlobalLink {
+case class RawLink(target: Target, options: Options = Options.empty) extends GlobalLink {
   type Self = RawLink
   val supportsExternalTargets: Boolean       = true
   def withTarget(newTarget: Target): RawLink = copy(target = newTarget)
@@ -149,7 +153,7 @@ case class SpanLink(
     content: Seq[Span],
     target: Target,
     title: Option[String] = None,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends GlobalLink
     with SpanContainer {
   type Self = SpanLink
@@ -192,14 +196,16 @@ object SpanLink {
 
 /** A resolved link to a footnote.
   */
-case class FootnoteLink(refId: String, label: String, options: Options = NoOpt) extends LocalLink {
+case class FootnoteLink(refId: String, label: String, options: Options = Options.empty)
+    extends LocalLink {
   type Self = FootnoteLink
   def withOptions(options: Options): FootnoteLink = copy(options = options)
 }
 
 /** A resolved link to a citation.
   */
-case class CitationLink(refId: String, label: String, options: Options = NoOpt) extends LocalLink {
+case class CitationLink(refId: String, label: String, options: Options = Options.empty)
+    extends LocalLink {
   type Self = CitationLink
   def withOptions(options: Options): CitationLink = copy(options = options)
 }
@@ -212,7 +218,7 @@ case class Image(
     height: Option[Length] = None,
     alt: Option[String] = None,
     title: Option[String] = None,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends GlobalLink {
   type Self = Image
   val supportsExternalTargets: Boolean     = false // has to be embedded for EPUB or PDF
@@ -265,8 +271,11 @@ sealed trait Icon extends Span {
   * This approach would currently not work well with Laika's PDF support which is
   * not based on an interim HTML renderer.
   */
-case class IconGlyph(codePoint: Char, title: Option[String] = None, options: Options = NoOpt)
-    extends Icon {
+case class IconGlyph(
+    codePoint: Char,
+    title: Option[String] = None,
+    options: Options = Options.empty
+) extends Icon {
   def codePointAsEntity: String = s"&#x${Integer.toHexString(codePoint.toInt)};"
   type Self = IconGlyph
   def withOptions(newOptions: Options): IconGlyph = copy(options = newOptions)
@@ -275,16 +284,22 @@ case class IconGlyph(codePoint: Char, title: Option[String] = None, options: Opt
 /** An icon defined in a style sheet, usually defining a glyph from an icon font.
   * This icon type is not supported for PDF output, when using font icons with PDF use `IconGlyph` instead.
   */
-case class IconStyle(styleName: String, title: Option[String] = None, options: Options = NoOpt)
-    extends Icon {
+case class IconStyle(
+    styleName: String,
+    title: Option[String] = None,
+    options: Options = Options.empty
+) extends Icon {
   type Self = IconStyle
   def withOptions(newOptions: Options): IconStyle = copy(options = newOptions)
 }
 
 /** An SVG icon that will render inline, supported for all output formats.
   */
-case class InlineSVGIcon(content: String, title: Option[String] = None, options: Options = NoOpt)
-    extends Icon {
+case class InlineSVGIcon(
+    content: String,
+    title: Option[String] = None,
+    options: Options = Options.empty
+) extends Icon {
   type Self = InlineSVGIcon
   def withOptions(newOptions: Options): InlineSVGIcon = copy(options = newOptions)
 }
@@ -292,8 +307,11 @@ case class InlineSVGIcon(content: String, title: Option[String] = None, options:
 /** An icon referencing an SVG shape defined in an external file or embedded SVG element.
   * This icon type is not supported for PDF output, when using SVG icons with PDF use `InlineSVGIcon` instead.
   */
-case class SVGSymbolIcon(target: Target, title: Option[String] = None, options: Options = NoOpt)
-    extends Icon {
+case class SVGSymbolIcon(
+    target: Target,
+    title: Option[String] = None,
+    options: Options = Options.empty
+) extends Icon {
   type Self = SVGSymbolIcon
   def withOptions(newOptions: Options): SVGSymbolIcon = copy(options = newOptions)
   def withTitle(title: String): SVGSymbolIcon         = copy(title = Some(title))
@@ -325,7 +343,7 @@ object SVGSymbolIcon {
   * The icon must have been registered with the global configuration to be accessible by this node type.
   * The indirection provided by this key allows to more easily swap entire icon sets without touching any code.
   */
-case class IconReference(key: String, source: SourceFragment, options: Options = NoOpt)
+case class IconReference(key: String, source: SourceFragment, options: Options = Options.empty)
     extends SpanResolver with Reference {
   type Self = IconReference
 
@@ -410,7 +428,7 @@ case class LinkPathReference(
     path: VirtualPath,
     source: SourceFragment,
     title: Option[String] = None,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends PathReference with SpanContainer {
   type Self = LinkPathReference
   def withContent(newContent: Seq[Span]): LinkPathReference = copy(content = newContent)
@@ -431,7 +449,7 @@ case class ImagePathReference(
     height: Option[Length] = None,
     alt: Option[String] = None,
     title: Option[String] = None,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends PathReference {
   type Self = ImagePathReference
   def withOptions(options: Options): ImagePathReference = copy(options = options)
@@ -446,7 +464,7 @@ case class ImageIdReference(
     text: String,
     id: String,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Reference {
   type Self = ImageIdReference
   def withOptions(options: Options): ImageIdReference = copy(options = options)
@@ -456,8 +474,11 @@ case class ImageIdReference(
 /** A reference to a footnote with a matching label.  Only part of the
   *  raw document tree and then removed by the rewrite rule that resolves link and image references.
   */
-case class FootnoteReference(label: FootnoteLabel, source: SourceFragment, options: Options = NoOpt)
-    extends Reference {
+case class FootnoteReference(
+    label: FootnoteLabel,
+    source: SourceFragment,
+    options: Options = Options.empty
+) extends Reference {
   type Self = FootnoteReference
   def withOptions(options: Options): FootnoteReference = copy(options = options)
   lazy val unresolvedMessage: String = s"Unresolved reference to footnote with label '$label'"
@@ -466,8 +487,11 @@ case class FootnoteReference(label: FootnoteLabel, source: SourceFragment, optio
 /** A reference to a citation with a matching label.  Only part of the
   *  raw document tree and then removed by the rewrite rule that resolves link and image references.
   */
-case class CitationReference(label: String, source: SourceFragment, options: Options = NoOpt)
-    extends Reference {
+case class CitationReference(
+    label: String,
+    source: SourceFragment,
+    options: Options = Options.empty
+) extends Reference {
   type Self = CitationReference
   def withOptions(options: Options): CitationReference = copy(options = options)
   lazy val unresolvedMessage: String = s"Unresolved reference to citation with label '$label'"
@@ -484,7 +508,7 @@ case class LinkIdReference(
     content: Seq[Span],
     ref: String,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Reference
     with ast.SpanContainer {
   type Self = LinkIdReference

--- a/core/shared/src/main/scala/laika/ast/lists.scala
+++ b/core/shared/src/main/scala/laika/ast/lists.scala
@@ -22,8 +22,11 @@ import laika.config.TargetFormats
 
 /** A bullet list that may contain nested lists.
   */
-case class BulletList(content: Seq[BulletListItem], format: BulletFormat, options: Options = NoOpt)
-    extends Block
+case class BulletList(
+    content: Seq[BulletListItem],
+    format: BulletFormat,
+    options: Options = Options.empty
+) extends Block
     with ListContainer
     with RewritableContainer {
   type Self = BulletList
@@ -71,7 +74,7 @@ case class EnumList(
     content: Seq[EnumListItem],
     format: EnumFormat,
     start: Int = 1,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Block
     with ListContainer
     with RewritableContainer {
@@ -180,8 +183,11 @@ object EnumType {
 
 /** A single bullet list item consisting of one or more block elements.
   */
-case class BulletListItem(content: Seq[Block], format: BulletFormat, options: Options = NoOpt)
-    extends ListItem
+case class BulletListItem(
+    content: Seq[Block],
+    format: BulletFormat,
+    options: Options = Options.empty
+) extends ListItem
     with BlockContainer {
   type Self = BulletListItem
   def withContent(newContent: Seq[Block]): BulletListItem = copy(content = newContent)
@@ -194,7 +200,7 @@ case class EnumListItem(
     content: Seq[Block],
     format: EnumFormat,
     position: Int,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ListItem
     with BlockContainer {
   type Self = EnumListItem
@@ -205,7 +211,8 @@ case class EnumListItem(
 /** A list of terms and their definitions.
   *  Not related to the `Definition` base trait.
   */
-case class DefinitionList(content: Seq[DefinitionListItem], options: Options = NoOpt) extends Block
+case class DefinitionList(content: Seq[DefinitionListItem], options: Options = Options.empty)
+    extends Block
     with ListContainer
     with RewritableContainer {
   type Self = DefinitionList
@@ -225,8 +232,11 @@ object DefinitionList {
 
 /** A single definition item, containing the term and definition (as the content property).
   */
-case class DefinitionListItem(term: Seq[Span], content: Seq[Block], options: Options = NoOpt)
-    extends ListItem
+case class DefinitionListItem(
+    term: Seq[Span],
+    content: Seq[Block],
+    options: Options = Options.empty
+) extends ListItem
     with BlockContainer {
   type Self = DefinitionListItem
 
@@ -246,7 +256,8 @@ object DefinitionListItem {
 }
 
 /** The root node of a navigation structure */
-case class NavigationList(content: Seq[NavigationItem], options: Options = NoOpt) extends Block
+case class NavigationList(content: Seq[NavigationItem], options: Options = Options.empty)
+    extends Block
     with ListContainer with RewritableContainer {
 
   type Self = NavigationList
@@ -298,7 +309,7 @@ case class NavigationItem(
     content: Seq[NavigationItem],
     link: Option[NavigationLink] = None,
     targetFormats: TargetFormats = TargetFormats.All,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Block with ListItem with ElementContainer[NavigationItem] with RewritableContainer
     with ListContainer {
 

--- a/core/shared/src/main/scala/laika/ast/lists.scala
+++ b/core/shared/src/main/scala/laika/ast/lists.scala
@@ -37,7 +37,7 @@ case class BulletList(content: Seq[BulletListItem], format: BulletFormat, option
 /** Base trait for companions that create BulletList instances. */
 trait BulletListCompanion extends BlockContainerCompanion {
   type ContainerType = BulletList
-  def bullet: BulletFormat = StringBullet("*")
+  def bullet: BulletFormat = BulletFormat.StringBullet("*")
 
   override protected def createSpanContainer(spans: Seq[Span]): ContainerType =
     createBlockContainer(spans.map(Paragraph(_)))
@@ -131,9 +131,13 @@ object EnumList extends EnumListCompanion {
   */
 trait BulletFormat
 
-/** Bullet format based on a simple string.
-  */
-case class StringBullet(bullet: String) extends BulletFormat
+object BulletFormat {
+
+  /** Bullet format based on a simple string.
+    */
+  case class StringBullet(bullet: String) extends BulletFormat
+
+}
 
 /** The format of enumerated list items.
   */

--- a/core/shared/src/main/scala/laika/ast/lists.scala
+++ b/core/shared/src/main/scala/laika/ast/lists.scala
@@ -280,7 +280,9 @@ object NavigationList {
     def apply(cursor: DocumentCursor): ConfigResult[RewriteRules] = Right {
       RewriteRules.forBlocks {
         case nl: NavigationList if !nl.hasStyle("breadcrumb") =>
-          Replace(cursor.root.outputContext.fold(nl)(ctx => nl.forFormat(ctx.formatSelector)))
+          RewriteAction.Replace(
+            cursor.root.outputContext.fold(nl)(ctx => nl.forFormat(ctx.formatSelector))
+          )
       }
     }
 

--- a/core/shared/src/main/scala/laika/ast/resolvers.scala
+++ b/core/shared/src/main/scala/laika/ast/resolvers.scala
@@ -45,7 +45,7 @@ case class BlockScope(
     content: Block,
     context: ConfigValue,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ElementScope[Block] with Block {
   type Self = BlockScope
   def withOptions(options: Options): BlockScope = copy(options = options)
@@ -61,7 +61,7 @@ case class SpanScope(
     content: Span,
     context: ConfigValue,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ElementScope[Span] with Span {
   type Self = SpanScope
   def withOptions(options: Options): SpanScope = copy(options = options)
@@ -77,7 +77,7 @@ case class TemplateScope(
     content: TemplateSpan,
     context: ConfigValue,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ElementScope[TemplateSpan] with TemplateSpan {
   type Self = TemplateScope
   def withOptions(options: Options): TemplateScope = copy(options = options)
@@ -119,7 +119,7 @@ case class TemplateContextReference(
     ref: Key,
     required: Boolean,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ContextReference[TemplateSpan](ref, source) with TemplateSpan {
   type Self = TemplateContextReference
 
@@ -148,7 +148,7 @@ case class MarkupContextReference(
     ref: Key,
     required: Boolean,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ContextReference[Span](ref, source) {
   type Self = MarkupContextReference
 

--- a/core/shared/src/main/scala/laika/ast/spans.scala
+++ b/core/shared/src/main/scala/laika/ast/spans.scala
@@ -20,14 +20,14 @@ import laika.parse.code.CodeCategory
 
 /** A simple text element.
   */
-case class Text(content: String, options: Options = NoOpt) extends Span with TextContainer {
+case class Text(content: String, options: Options = Options.empty) extends Span with TextContainer {
   type Self = Text
   def withOptions(options: Options): Text = copy(options = options)
 }
 
 /** A span of emphasized inline elements that may contain nested spans.
   */
-case class Emphasized(content: Seq[Span], options: Options = NoOpt) extends Span
+case class Emphasized(content: Seq[Span], options: Options = Options.empty) extends Span
     with SpanContainer {
   type Self = Emphasized
   def withContent(newContent: Seq[Span]): Emphasized = copy(content = newContent)
@@ -41,7 +41,8 @@ object Emphasized extends SpanContainerCompanion {
 
 /** A span of strong inline elements that may contain nested spans.
   */
-case class Strong(content: Seq[Span], options: Options = NoOpt) extends Span with SpanContainer {
+case class Strong(content: Seq[Span], options: Options = Options.empty) extends Span
+    with SpanContainer {
   type Self = Strong
   def withContent(newContent: Seq[Span]): Strong = copy(content = newContent)
   def withOptions(options: Options): Strong      = copy(options = options)
@@ -54,7 +55,8 @@ object Strong extends SpanContainerCompanion {
 
 /** A span containing plain, unparsed text.
   */
-case class Literal(content: String, options: Options = NoOpt) extends Span with TextContainer {
+case class Literal(content: String, options: Options = Options.empty) extends Span
+    with TextContainer {
   type Self = Literal
   def withOptions(options: Options): Literal = copy(options = options)
 }
@@ -63,7 +65,8 @@ case class Literal(content: String, options: Options = NoOpt) extends Span with 
   *  the integration of syntax highlighting systems. Without this support
   *  the sequence will only consist of a single `Text` element.
   */
-case class InlineCode(language: String, content: Seq[Span], options: Options = NoOpt) extends Span
+case class InlineCode(language: String, content: Seq[Span], options: Options = Options.empty)
+    extends Span
     with SpanContainer {
   type Self = InlineCode
   def withContent(newContent: Seq[Span]): InlineCode = copy(content = newContent)
@@ -72,7 +75,8 @@ case class InlineCode(language: String, content: Seq[Span], options: Options = N
 
 /** A span representing deleted inline elements that may contain nested spans.
   */
-case class Deleted(content: Seq[Span], options: Options = NoOpt) extends Span with SpanContainer {
+case class Deleted(content: Seq[Span], options: Options = Options.empty) extends Span
+    with SpanContainer {
   type Self = Deleted
   def withContent(newContent: Seq[Span]): Deleted = copy(content = newContent)
   def withOptions(options: Options): Deleted      = copy(options = options)
@@ -85,7 +89,8 @@ object Deleted extends SpanContainerCompanion {
 
 /** A span representing inserted inline elements that may contain nested spans.
   */
-case class Inserted(content: Seq[Span], options: Options = NoOpt) extends Span with SpanContainer {
+case class Inserted(content: Seq[Span], options: Options = Options.empty) extends Span
+    with SpanContainer {
   type Self = Inserted
   def withContent(newContent: Seq[Span]): Inserted = copy(content = newContent)
   def withOptions(options: Options): Inserted      = copy(options = options)
@@ -102,7 +107,8 @@ object Inserted extends SpanContainerCompanion {
   *  as s sub flow of the parent container. A span sequence is special in that in can be
   *  used as both a span and a block.
   */
-case class SpanSequence(content: Seq[Span], options: Options = NoOpt) extends Block with Span
+case class SpanSequence(content: Seq[Span], options: Options = Options.empty) extends Block
+    with Span
     with SpanContainer {
   type Self = SpanSequence
   def withContent(newContent: Seq[Span]): SpanSequence = copy(content = newContent)
@@ -117,7 +123,7 @@ object SpanSequence extends SpanContainerCompanion {
 /** Represents a section number, usually used in header elements
   *  when autonumbering is applied.
   */
-case class SectionNumber(position: Seq[Int], options: Options = NoOpt) extends Span
+case class SectionNumber(position: Seq[Int], options: Options = Options.empty) extends Span
     with TextContainer {
 
   type Self = SectionNumber
@@ -139,8 +145,11 @@ sealed trait CategorizedCode extends Span
 
 /** A span of code associated with zero or more code categories.
   */
-case class CodeSpan(content: String, categories: Set[CodeCategory], options: Options = NoOpt)
-    extends CategorizedCode with TextContainer {
+case class CodeSpan(
+    content: String,
+    categories: Set[CodeCategory],
+    options: Options = Options.empty
+) extends CategorizedCode with TextContainer {
   type Self = CodeSpan
   def withOptions(options: Options): CodeSpan = copy(options = options)
 }
@@ -149,7 +158,7 @@ object CodeSpan {
 
   def apply(content: String, category: CodeCategory): CodeSpan = apply(content, Set(category))
 
-  def apply(content: String): CodeSpan = apply(content, Set(), NoOpt)
+  def apply(content: String): CodeSpan = apply(content, Set(), Options.empty)
 
 }
 
@@ -189,7 +198,8 @@ object CodeSpans {
 
 /** A sequence of code spans where most of them are usually associated with zero or more code categories.
   */
-case class CodeSpanSequence(content: Seq[Span], options: Options = NoOpt) extends CategorizedCode
+case class CodeSpanSequence(content: Seq[Span], options: Options = Options.empty)
+    extends CategorizedCode
     with SpanContainer {
   type Self = CodeSpanSequence
   def withContent(newContent: Seq[Span]): CodeSpanSequence = copy(content = newContent)
@@ -203,12 +213,12 @@ object CodeSpanSequence extends SpanContainerCompanion {
 
 /** An explicit hard line break.
   */
-case class LineBreak(options: Options = NoOpt) extends Span {
+case class LineBreak(options: Options = Options.empty) extends Span {
   type Self = LineBreak
   def withOptions(options: Options): LineBreak = copy(options = options)
 }
 
-case class Reverse(length: Int, target: Span, fallback: Span, options: Options = NoOpt)
+case class Reverse(length: Int, target: Span, fallback: Span, options: Options = Options.empty)
     extends Span {
   type Self = Reverse
   def withOptions(options: Options): Reverse = copy(options = options)

--- a/core/shared/src/main/scala/laika/ast/templates.scala
+++ b/core/shared/src/main/scala/laika/ast/templates.scala
@@ -17,7 +17,7 @@
 package laika.ast
 
 import laika.internal.rewrite.ReferenceResolver.CursorKeys
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 
 /** The base type for all inline elements that
   *  can be found in a template.
@@ -149,7 +149,7 @@ object TemplateRoot extends TemplateSpanContainerCompanion {
     * without any surrounding decoration.
     */
   val fallback: TemplateRoot = TemplateRoot(
-    TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+    TemplateContextReference(CursorKeys.documentContent, required = true, SourceCursor.Generated)
   )
 
 }

--- a/core/shared/src/main/scala/laika/ast/templates.scala
+++ b/core/shared/src/main/scala/laika/ast/templates.scala
@@ -76,7 +76,7 @@ trait TemplateSpanContainerCompanion {
   *  a template document tree. Useful when custom tags which are placed inside
   *  a template produce non-template tree elements.
   */
-case class TemplateElement(element: Element, indent: Int = 0, options: Options = NoOpt)
+case class TemplateElement(element: Element, indent: Int = 0, options: Options = Options.empty)
     extends TemplateSpan with ElementTraversal
     with RewritableContainer {
   type Self = TemplateElement
@@ -92,7 +92,7 @@ case class TemplateElement(element: Element, indent: Int = 0, options: Options =
   *  Usually renderers do not treat the container as a special element and render its children
   *  as s sub flow of the parent container.
   */
-case class TemplateSpanSequence(content: Seq[TemplateSpan], options: Options = NoOpt)
+case class TemplateSpanSequence(content: Seq[TemplateSpan], options: Options = Options.empty)
     extends TemplateSpan with TemplateSpanContainer {
   type Self = TemplateSpanSequence
   def withContent(newContent: Seq[TemplateSpan]): TemplateSpanSequence = copy(content = newContent)
@@ -123,7 +123,7 @@ object TemplateSpanSequence extends TemplateSpanContainerCompanion {
 /** A simple string element, representing the parts of a template
   *  that are not detected as special markup constructs and treated as raw text.
   */
-case class TemplateString(content: String, options: Options = NoOpt) extends TemplateSpan
+case class TemplateString(content: String, options: Options = Options.empty) extends TemplateSpan
     with TextContainer {
   type Self = TemplateString
   def withOptions(options: Options): TemplateString = copy(options = options)
@@ -131,7 +131,7 @@ case class TemplateString(content: String, options: Options = NoOpt) extends Tem
 
 /** The root element of a template document tree.
   */
-case class TemplateRoot(content: Seq[TemplateSpan], options: Options = NoOpt) extends Block
+case class TemplateRoot(content: Seq[TemplateSpan], options: Options = Options.empty) extends Block
     with TemplateSpan with TemplateSpanContainer {
   type Self = TemplateRoot
   def withContent(newContent: Seq[TemplateSpan]): TemplateRoot = copy(content = newContent)
@@ -157,7 +157,7 @@ object TemplateRoot extends TemplateSpanContainerCompanion {
 /** The root element of a document tree (originating from text markup) inside a template.
   *  Usually created by a template reference like `\${cursor.currentDocument.content}`.
   */
-case class EmbeddedRoot(content: Seq[Block], indent: Int = 0, options: Options = NoOpt)
+case class EmbeddedRoot(content: Seq[Block], indent: Int = 0, options: Options = Options.empty)
     extends TemplateSpan with BlockContainer {
   type Self = EmbeddedRoot
   def withContent(newContent: Seq[Block]): EmbeddedRoot = copy(content = newContent)

--- a/core/shared/src/main/scala/laika/config/Selections.scala
+++ b/core/shared/src/main/scala/laika/config/Selections.scala
@@ -248,7 +248,7 @@ object Selections {
         else
           RewriteRules.forBlocks {
             case sel: Selection if selections.contains(sel.name) =>
-              Replace(select(sel, selections(sel.name)))
+              RewriteAction.Replace(select(sel, selections(sel.name)))
           }
       }
     }

--- a/core/shared/src/main/scala/laika/internal/directive/BreadcrumbDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/directive/BreadcrumbDirectives.scala
@@ -41,7 +41,7 @@ private[laika] object BreadcrumbDirectives {
     *
     * Serves as the implementation for the breadcrumb directive, but can also be inserted into the AST manually.
     */
-  case class BreadcrumbBuilder(source: SourceFragment, options: Options = NoOpt)
+  case class BreadcrumbBuilder(source: SourceFragment, options: Options = Options.empty)
       extends BlockResolver {
 
     type Self = BreadcrumbBuilder

--- a/core/shared/src/main/scala/laika/internal/directive/DirectiveSupport.scala
+++ b/core/shared/src/main/scala/laika/internal/directive/DirectiveSupport.scala
@@ -16,38 +16,11 @@
 
 package laika.internal.directive
 
-import laika.api.bundle.{
-  BlockDirectives,
-  BundleOrigin,
-  ConfigHeaderParser,
-  ConfigProvider,
-  ExtensionBundle,
-  LinkDirectives,
-  ParserBundle,
-  SpanDirectives,
-  TemplateDirectives
-}
+import laika.api.bundle.*
 import laika.api.config.ConfigParser
 import laika.ast.RewriteRules.RewritePhaseBuilder
-import laika.ast.{
-  DocumentCursor,
-  InvalidSpan,
-  LinkIdReference,
-  LinkPathReference,
-  NoOpt,
-  Options,
-  Replace,
-  RewritePhase,
-  RewriteRules,
-  Span,
-  SpanResolver
-}
-import laika.internal.parse.directive.{
-  BlockDirectiveParsers,
-  DirectiveParsers,
-  SpanDirectiveParsers,
-  TemplateParsers
-}
+import laika.ast.*
+import laika.internal.parse.directive.*
 import laika.parse.{ Parser, SourceFragment }
 import laika.parse.builders.{ delimitedBy, text, ws }
 import laika.parse.combinator.Parsers
@@ -162,8 +135,11 @@ private[laika] class DirectiveSupport(
       Seq(RewriteRules.forSpans {
         case ref: LinkPathReference if ref.path.toString.startsWith("@:") =>
           linkParser.parse(ref.path.toString.drop(2)).toEither.fold(
-            err => Replace(InvalidSpan(s"Invalid link directive: $err", ref.source)),
-            res => Replace(LinkDirectiveResolver2(ref, res._1, res._2, ref.source, ref.options))
+            err => RewriteAction.Replace(InvalidSpan(s"Invalid link directive: $err", ref.source)),
+            res =>
+              RewriteAction.Replace(
+                LinkDirectiveResolver2(ref, res._1, res._2, ref.source, ref.options)
+              )
           )
       }.asBuilder)
   }

--- a/core/shared/src/main/scala/laika/internal/directive/DirectiveSupport.scala
+++ b/core/shared/src/main/scala/laika/internal/directive/DirectiveSupport.scala
@@ -86,7 +86,7 @@ private[laika] class DirectiveSupport(
       directiveName: String,
       typeName: String,
       source: SourceFragment,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends SpanResolver {
     type Self = LinkDirectiveResolver
 
@@ -110,7 +110,7 @@ private[laika] class DirectiveSupport(
       directiveName: String,
       typeName: String,
       source: SourceFragment,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends SpanResolver {
     type Self = LinkDirectiveResolver2
 

--- a/core/shared/src/main/scala/laika/internal/directive/NavigationTreeDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/directive/NavigationTreeDirectives.scala
@@ -21,7 +21,7 @@ import cats.syntax.all.*
 import laika.api.bundle.{ BlockDirectives, TemplateDirectives }
 import laika.api.config.{ ConfigDecoder, ConfigError, Key }
 import laika.ast.*
-import laika.parse.{ GeneratedSource, SourceFragment }
+import laika.parse.{ SourceCursor, SourceFragment }
 
 /** Implementation of the navigationTree directive for templates and markup blocks.
   *
@@ -150,7 +150,7 @@ private[laika] object NavigationTreeDirectives {
         } yield {
           NavigationBuilderConfig(
             entries,
-            GeneratedSource,
+            SourceCursor.Generated,
             defaultDepth,
             itemStyles.toSet,
             excludeRoot,

--- a/core/shared/src/main/scala/laika/internal/directive/NavigationTreeDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/directive/NavigationTreeDirectives.scala
@@ -59,7 +59,7 @@ private[laika] object NavigationTreeDirectives {
       excludeRoot: Boolean = false,
       excludeSections: Boolean = false,
       excludeSelf: Boolean = false,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ) extends BlockResolver {
 
     type Self = NavigationBuilderConfig

--- a/core/shared/src/main/scala/laika/internal/directive/StandardDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/directive/StandardDirectives.scala
@@ -98,7 +98,7 @@ private[laika] object StandardDirectives extends DirectiveRegistry {
 
   override val origin: BundleOrigin = BundleOrigin.Library
 
-  private def asBlock(blocks: Seq[Block], options: Options = NoOpt): Block = blocks match {
+  private def asBlock(blocks: Seq[Block], options: Options = Options.empty): Block = blocks match {
     case block :: Nil => block.mergeOptions(options)
     case multiple     => BlockSequence(multiple, options)
   }

--- a/core/shared/src/main/scala/laika/internal/link/DocumentTargets.scala
+++ b/core/shared/src/main/scala/laika/internal/link/DocumentTargets.scala
@@ -100,17 +100,18 @@ private[link] class DocumentTargets(document: Document, slugBuilder: String => S
 
       case f: FootnoteDefinition =>
         val (docId, displayId, selector) = f.label match {
-          case Autosymbol          =>
+          case FootnoteLabel.Autosymbol          =>
             (
               s"__fns-${symbolNumbers.next()}",
               symbols.next(),
               AutosymbolSelector
             ) // TODO - move these prefix definitions somewhere else
-          case Autonumber          =>
+          case FootnoteLabel.Autonumber          =>
             val num = numbers.next(); (s"__fn-$num", num.toString, AutonumberSelector)
-          case AutonumberLabel(id) =>
+          case FootnoteLabel.AutonumberLabel(id) =>
             (slugBuilder(id), numbers.next().toString, TargetIdSelector(slugBuilder(id)))
-          case NumericLabel(num)   => (s"__fnl-$num", num.toString, TargetIdSelector(num.toString))
+          case FootnoteLabel.NumericLabel(num)   =>
+            (s"__fnl-$num", num.toString, TargetIdSelector(num.toString))
         }
         val resolver = ReferenceResolver.lift { case LinkSource(FootnoteReference(_, _, opt), _) =>
           FootnoteLink(docId, displayId, opt)

--- a/core/shared/src/main/scala/laika/internal/link/LinkResolver.scala
+++ b/core/shared/src/main/scala/laika/internal/link/LinkResolver.scala
@@ -19,9 +19,9 @@ package laika.internal.link
 import laika.api.bundle.BlockDirectives
 import laika.ast.Path.Root
 import laika.ast.RewriteRules.RewriteRulesBuilder
-import laika.ast._
+import laika.ast.*
 import laika.api.config.Config.ConfigResult
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 
 import scala.annotation.tailrec
 
@@ -70,7 +70,7 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
         case Some(b: Block) => RewriteAction.Replace(b)
         case _              =>
           RewriteAction.Replace(
-            InvalidBlock(describeUnknownTarget(block), GeneratedSource).copy(fallback =
+            InvalidBlock(describeUnknownTarget(block), SourceCursor.Generated).copy(fallback =
               block.withoutId
             )
           )
@@ -81,7 +81,7 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
         case Some(b: Span) => RewriteAction.Replace(b)
         case _             =>
           RewriteAction.Replace(
-            InvalidSpan(describeUnknownTarget(span), GeneratedSource).copy(fallback =
+            InvalidSpan(describeUnknownTarget(span), SourceCursor.Generated).copy(fallback =
               span.withoutId
             )
           )

--- a/core/shared/src/main/scala/laika/internal/link/LinkResolver.scala
+++ b/core/shared/src/main/scala/laika/internal/link/LinkResolver.scala
@@ -67,9 +67,9 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
 
     def replaceBlock(block: Block, selector: Selector): RewriteAction[Block] =
       replace(block, selector) match {
-        case Some(b: Block) => Replace(b)
+        case Some(b: Block) => RewriteAction.Replace(b)
         case _              =>
-          Replace(
+          RewriteAction.Replace(
             InvalidBlock(describeUnknownTarget(block), GeneratedSource).copy(fallback =
               block.withoutId
             )
@@ -78,9 +78,9 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
 
     def replaceSpan(span: Span, selector: Selector): RewriteAction[Span] =
       replace(span, selector) match {
-        case Some(b: Span) => Replace(b)
+        case Some(b: Span) => RewriteAction.Replace(b)
         case _             =>
-          Replace(
+          RewriteAction.Replace(
             InvalidSpan(describeUnknownTarget(span), GeneratedSource).copy(fallback =
               span.withoutId
             )
@@ -106,7 +106,7 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
               InvalidSpan(msg, ref.source)
           }
       }
-      Replace(resolvedTarget)
+      RewriteAction.Replace(resolvedTarget)
     }
 
     def resolveLocal(ref: Reference, selector: Selector, msg: => String): RewriteAction[Span] =
@@ -156,9 +156,9 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
       case h: Header             => replaceBlock(h, TargetIdSelector(slugBuilder(h.extractText)))
 
       case d: BlockDirectives.DirectiveInstance if d.directive.exists(_.name == "fragment") =>
-        Replace(d.resolve(cursor))
+        RewriteAction.Replace(d.resolve(cursor))
 
-      case _: Hidden => Remove
+      case _: Hidden => RewriteAction.Remove
 
       case elem if elem.hasId =>
         replaceBlock(elem, TargetIdSelector(slugBuilder(elem.options.id.get)))
@@ -205,7 +205,7 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
       case elem if elem.hasId =>
         replaceSpan(elem, TargetIdSelector(slugBuilder(elem.options.id.get)))
 
-      case _: Hidden => Remove
+      case _: Hidden => RewriteAction.Remove
 
     })
 

--- a/core/shared/src/main/scala/laika/internal/link/LinkResolver.scala
+++ b/core/shared/src/main/scala/laika/internal/link/LinkResolver.scala
@@ -145,10 +145,11 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
 
       case f: FootnoteDefinition =>
         f.label match {
-          case NumericLabel(num)   => replaceBlock(f, TargetIdSelector(num.toString))
-          case AutonumberLabel(id) => replaceBlock(f, TargetIdSelector(slugBuilder(id)))
-          case Autonumber          => replaceBlock(f, AutonumberSelector)
-          case Autosymbol          => replaceBlock(f, AutosymbolSelector)
+          case FootnoteLabel.NumericLabel(num)   => replaceBlock(f, TargetIdSelector(num.toString))
+          case FootnoteLabel.AutonumberLabel(id) =>
+            replaceBlock(f, TargetIdSelector(slugBuilder(id)))
+          case FootnoteLabel.Autonumber          => replaceBlock(f, AutonumberSelector)
+          case FootnoteLabel.Autosymbol          => replaceBlock(f, AutosymbolSelector)
         }
       case c: Citation           => replaceBlock(c, TargetIdSelector(slugBuilder(c.label)))
       case h: DecoratedHeader    => replaceBlock(h, TargetIdSelector(slugBuilder(h.extractText)))
@@ -173,20 +174,22 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
 
       case ref: FootnoteReference =>
         ref.label match {
-          case NumericLabel(num)   =>
+          case FootnoteLabel.NumericLabel(num)   =>
             resolveLocal(
               ref,
               TargetIdSelector(num.toString),
               s"unresolved footnote reference: $num"
             )
-          case AutonumberLabel(id) =>
+          case FootnoteLabel.AutonumberLabel(id) =>
             resolveLocal(
               ref,
               TargetIdSelector(slugBuilder(id)),
               s"unresolved footnote reference: $id"
             )
-          case Autonumber => resolveLocal(ref, AutonumberSelector, "too many autonumber references")
-          case Autosymbol => resolveLocal(ref, AutosymbolSelector, "too many autosymbol references")
+          case FootnoteLabel.Autonumber          =>
+            resolveLocal(ref, AutonumberSelector, "too many autonumber references")
+          case FootnoteLabel.Autosymbol          =>
+            resolveLocal(ref, AutosymbolSelector, "too many autosymbol references")
         }
 
       case ref: PathReference =>

--- a/core/shared/src/main/scala/laika/internal/link/TargetResolver.scala
+++ b/core/shared/src/main/scala/laika/internal/link/TargetResolver.scala
@@ -71,9 +71,9 @@ private[link] object ReferenceResolver {
   }
 
   def resolveTarget(target: Target, refPath: Path): Target = target match {
-    case it: RelativeInternalTarget => resolveTarget(it.path, refPath)
-    case it: InternalTarget         => it.relativeTo(refPath)
-    case external                   => external
+    case it: InternalTarget.Relative => resolveTarget(it.path, refPath)
+    case it: InternalTarget          => it.relativeTo(refPath)
+    case external                    => external
   }
 
 }

--- a/core/shared/src/main/scala/laika/internal/link/TargetResolver.scala
+++ b/core/shared/src/main/scala/laika/internal/link/TargetResolver.scala
@@ -16,9 +16,9 @@
 
 package laika.internal.link
 
-import laika.ast._
+import laika.ast.*
 import laika.config.TargetFormats
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 
 /** Represents the source of a link, its document path
   * and the actual inline span that is representing the link.
@@ -137,8 +137,8 @@ private[link] object TargetResolver {
 
     override def replaceTarget(rewrittenOriginal: Element): Option[Element] =
       rewrittenOriginal match {
-        case b: Block => Some(InvalidBlock(sysMsg, GeneratedSource, b.withoutId))
-        case s: Span  => Some(InvalidSpan(sysMsg, GeneratedSource, s.withoutId))
+        case b: Block => Some(InvalidBlock(sysMsg, SourceCursor.Generated, b.withoutId))
+        case s: Span  => Some(InvalidSpan(sysMsg, SourceCursor.Generated, s.withoutId))
         case _        => None
       }
 

--- a/core/shared/src/main/scala/laika/internal/markdown/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/ListParsers.scala
@@ -98,7 +98,7 @@ private[laika] object ListParsers {
     BlockParserBuilder.recursive { implicit recParsers =>
       PrefixedParser('+', '*', '-') {
         lookAhead(oneChar) >> { char =>
-          val bullet = StringBullet(char)
+          val bullet = BulletFormat.StringBullet(char)
           list(
             bulletChar,
             wsAfterItemStart,

--- a/core/shared/src/main/scala/laika/internal/markdown/github/Tables.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/github/Tables.scala
@@ -50,12 +50,12 @@ private[laika] object Tables {
       }
     }
 
-    val firstRow: PrefixedParser[Row] = "|" ~> rowRest(HeadCell)
+    val firstRow: PrefixedParser[Row] = "|" ~> rowRest(CellType.HeadCell)
 
     val bodyRow: Parser[Row] = {
       val rowStart =
         insignificantSpaces ~ not(oneOf('*', '+', '-', '>', '_', '#', '[', ' ', '\t')) ~ opt("|")
-      rowStart ~> rowRest(BodyCell)
+      rowStart ~> rowRest(CellType.BodyCell)
     }
 
     val sepRow: Parser[Seq[Options]] = {
@@ -88,7 +88,7 @@ private[laika] object Tables {
         row.copy(content =
           row.content
             .take(count)
-            .padTo(count, BodyCell.empty)
+            .padTo(count, CellType.BodyCell.empty)
             .zip(columnOptions)
             .map { case (cell, opt) =>
               cell.withOptions(opt)

--- a/core/shared/src/main/scala/laika/internal/markdown/github/Tables.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/github/Tables.scala
@@ -71,7 +71,7 @@ private[laika] object Tables {
           case Some(_) ~ Some(_) => Style.alignCenter
           case Some(_) ~ None    => Style.alignLeft
           case None ~ Some(_)    => Style.alignRight
-          case _                 => NoOpt
+          case _                 => Options.empty
         }
       }
     }

--- a/core/shared/src/main/scala/laika/internal/nav/SectionBuilder.scala
+++ b/core/shared/src/main/scala/laika/internal/nav/SectionBuilder.scala
@@ -114,7 +114,7 @@ private[laika] object SectionBuilder extends RewriteRulesBuilder {
     }
 
     val rewrite: RewriteRules = RewriteRules.forBlocks { case root: RootElement =>
-      Replace(buildSections(root))
+      RewriteAction.Replace(buildSections(root))
     }
 
   }

--- a/core/shared/src/main/scala/laika/internal/render/ASTRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/ASTRenderer.scala
@@ -53,9 +53,9 @@ private[laika] object ASTRenderer extends ((Formatter, Element) => String) {
 
     def attributes(attr: Iterator[Any], exclude: AnyRef = NoRef): String = {
       def prep(value: Any) = value match {
-        case opt: Options              => options(opt)
-        case t: ResolvedInternalTarget => s"InternalTarget(${t.relativePath},${t.internalFormats})"
-        case other                     => other
+        case opt: Options               => options(opt)
+        case t: InternalTarget.Resolved => s"InternalTarget(${t.relativePath},${t.internalFormats})"
+        case other                      => other
       }
       val it               = attr.asInstanceOf[Iterator[AnyRef]]
       val res              = it

--- a/core/shared/src/main/scala/laika/internal/render/ASTRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/ASTRenderer.scala
@@ -34,7 +34,7 @@ private[laika] object ASTRenderer extends ((Formatter, Element) => String) {
     */
   private val maxTextWidth = 50
 
-  private case class Content(content: Seq[Element], desc: String, options: Options = NoOpt)
+  private case class Content(content: Seq[Element], desc: String, options: Options = Options.empty)
       extends Element with ElementContainer[Element] {
     type Self = Content
     def withOptions(options: Options): Content = copy(options = options)
@@ -60,7 +60,7 @@ private[laika] object ASTRenderer extends ((Formatter, Element) => String) {
       val it               = attr.asInstanceOf[Iterator[AnyRef]]
       val res              = it
         .filter(_ ne exclude)
-        .filter(_ != NoOpt)
+        .filter(_ != Options.empty)
         .map(prep)
         .mkString("(", ",", ")")
       if (res == "()") "" else res

--- a/core/shared/src/main/scala/laika/internal/render/FOFormatter.scala
+++ b/core/shared/src/main/scala/laika/internal/render/FOFormatter.scala
@@ -163,7 +163,7 @@ private[laika] object FOFormatter extends (Formatter.Context[TagFormatter] => Ta
   /** A wrapper around pre-rendered content which can be used to set default
     * attributes that can be inherited by any node in the document.
     */
-  case class ContentWrapper(content: String, options: Options = NoOpt) extends Block {
+  case class ContentWrapper(content: String, options: Options = Options.empty) extends Block {
     type Self = ContentWrapper
 
     def withOptions(options: Options): ContentWrapper = copy(options = options)
@@ -172,14 +172,14 @@ private[laika] object FOFormatter extends (Formatter.Context[TagFormatter] => Ta
   /** A preamble for a document, only used in PDF output where multiple XSL-FO documents get concatenated
     * before being passed to the PDF renderer.
     */
-  case class Preamble(title: String, options: Options = NoOpt) extends Block {
+  case class Preamble(title: String, options: Options = Options.empty) extends Block {
     type Self = Preamble
     def withOptions(options: Options): Preamble = copy(options = options)
   }
 
   /** A leader element.
     */
-  case class Leader(options: Options = NoOpt) extends Span {
+  case class Leader(options: Options = Options.empty) extends Span {
     type Self = Leader
     def withOptions(options: Options): Leader = copy(options = options)
   }
@@ -189,21 +189,22 @@ private[laika] object FOFormatter extends (Formatter.Context[TagFormatter] => Ta
     *  @param target the path of the target document containing the local reference
     *  @param options optional render hints
     */
-  case class PageNumberCitation(target: InternalTarget, options: Options = NoOpt) extends Span {
+  case class PageNumberCitation(target: InternalTarget, options: Options = Options.empty)
+      extends Span {
     type Self = PageNumberCitation
     def withOptions(options: Options): PageNumberCitation = copy(options = options)
   }
 
   /** A label for a list item, represented by a single Block element.
     */
-  case class ListItemLabel(content: Block, options: Options = NoOpt) extends Block {
+  case class ListItemLabel(content: Block, options: Options = Options.empty) extends Block {
     type Self = ListItemLabel
     def withOptions(options: Options): ListItemLabel = copy(options = options)
   }
 
   /** The body of a list item containing a sequence of block elements.
     */
-  case class ListItemBody(content: Seq[Block], options: Options = NoOpt) extends Block
+  case class ListItemBody(content: Seq[Block], options: Options = Options.empty) extends Block
       with BlockContainer {
     type Self = ListItemBody
     def withContent(newContent: Seq[Block]): ListItemBody = copy(content = newContent)
@@ -212,7 +213,7 @@ private[laika] object FOFormatter extends (Formatter.Context[TagFormatter] => Ta
 
   /** The body of a footnote containing a sequence of block elements.
     */
-  case class FootnoteBody(content: Seq[Block], options: Options = NoOpt) extends Block
+  case class FootnoteBody(content: Seq[Block], options: Options = Options.empty) extends Block
       with BlockContainer {
     type Self = FootnoteBody
     def withContent(newContent: Seq[Block]): FootnoteBody = copy(content = newContent)
@@ -221,7 +222,7 @@ private[laika] object FOFormatter extends (Formatter.Context[TagFormatter] => Ta
 
   /** A bookmark title.
     */
-  case class BookmarkTitle(content: String, options: Options = NoOpt) extends Block
+  case class BookmarkTitle(content: String, options: Options = Options.empty) extends Block
       with TextContainer {
     type Self = BookmarkTitle
     def withOptions(options: Options): BookmarkTitle = copy(options = options)

--- a/core/shared/src/main/scala/laika/internal/render/FORenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/FORenderer.scala
@@ -150,7 +150,7 @@ private[laika] object FORenderer extends ((TagFormatter, Element) => String) {
               Styles("align-center", "default-space")
             )
           )
-        case BlockSequence(content, NoOpt) => fmt.childPerLine(content)
+        case BlockSequence(content, Options.empty) => fmt.childPerLine(content)
 
         case unknown => fmt.blockContainer(unknown, unknown.content)
       }
@@ -201,9 +201,9 @@ private[laika] object FORenderer extends ((TagFormatter, Element) => String) {
 
         case link: SpanLink => renderLink(link)
 
-        case WithFallback(fallback)           => fmt.child(fallback)
-        case SpanSequence(content, NoOpt)     => fmt.children(content)
-        case CodeSpanSequence(content, NoOpt) => fmt.children(content)
+        case WithFallback(fallback)                   => fmt.child(fallback)
+        case SpanSequence(content, Options.empty)     => fmt.children(content)
+        case CodeSpanSequence(content, Options.empty) => fmt.children(content)
 
         // TODO - needs to be inline if parent is not a block container
         case unknown: Block => fmt.block(unknown)
@@ -214,9 +214,9 @@ private[laika] object FORenderer extends ((TagFormatter, Element) => String) {
 
     def renderTemplateSpanContainer(con: TemplateSpanContainer): String = {
       con match {
-        case TemplateRoot(content, NoOpt)         => fmt.children(content)
-        case TemplateSpanSequence(content, NoOpt) => fmt.children(content)
-        case unknown                              => fmt.inline(unknown)
+        case TemplateRoot(content, Options.empty)         => fmt.children(content)
+        case TemplateSpanSequence(content, Options.empty) => fmt.children(content)
+        case unknown                                      => fmt.inline(unknown)
       }
     }
 
@@ -415,7 +415,7 @@ private[laika] object FORenderer extends ((TagFormatter, Element) => String) {
             content = title.content :+ Leader() :+ PageNumberCitation(target),
             target = target
           )
-          val keep = if (content.isEmpty) NoOpt else keepWithNext
+          val keep = if (content.isEmpty) Options.empty else keepWithNext
           fmt.childPerLine(Paragraph(Seq(link), Style.nav + keep + opt) +: avoidOrphan(content))
         case NavigationItem(title, content, None, _, opt) =>
           fmt.childPerLine(

--- a/core/shared/src/main/scala/laika/internal/render/FORenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/FORenderer.scala
@@ -100,8 +100,8 @@ private[laika] object FORenderer extends ((TagFormatter, Element) => String) {
       }
 
       def bulletLabel(format: BulletFormat): Span = format match {
-        case StringBullet(_) => RawContent(NonEmptySet.one("fo"), "&#x2022;")
-        case other           => Text(other.toString)
+        case BulletFormat.StringBullet(_) => RawContent(NonEmptySet.one("fo"), "&#x2022;")
+        case other                        => Text(other.toString)
       }
 
       def listItemBody(body: ListItemBody): String = {

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -57,7 +57,7 @@ private[laika] class HTMLRenderer(format: String)
 
     def navigationToBulletList(navList: NavigationList): BulletList = {
 
-      val bullet = StringBullet("*")
+      val bullet = BulletFormat.StringBullet("*")
 
       def transformItems(items: Seq[NavigationItem]): Seq[BulletListItem] = {
         items.flatMap { item =>

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -90,8 +90,8 @@ private[laika] class HTMLRenderer(format: String)
     def renderBlockContainer(con: BlockContainer): String = {
 
       def toTable(label: String, content: Seq[Block], options: Options): Table = {
-        val left  = BodyCell(SpanSequence(s"[$label]"))
-        val right = BodyCell(content)
+        val left  = CellType.BodyCell(SpanSequence(s"[$label]"))
+        val right = CellType.BodyCell(content)
         val row   = Row(List(left, right))
         Table(
           TableHead(Nil),
@@ -348,8 +348,8 @@ private[laika] class HTMLRenderer(format: String)
       case Column(opt)   => fmt.textElement("col", Text("").withOptions(opt))
       case c: Cell       =>
         val tagName    = c.cellType match {
-          case HeadCell => "th"
-          case BodyCell => "td"
+          case CellType.HeadCell => "th"
+          case CellType.BodyCell => "td"
         }
         val attributes = fmt.optAttributes(
           "colspan" -> noneIfDefault(c.colspan, 1),

--- a/core/shared/src/main/scala/laika/internal/rewrite/RecursiveResolverRules.scala
+++ b/core/shared/src/main/scala/laika/internal/rewrite/RecursiveResolverRules.scala
@@ -17,6 +17,7 @@
 package laika.internal.rewrite
 
 import laika.ast._
+import laika.ast.RewriteAction.Replace
 
 private[laika] object RecursiveResolverRules {
 

--- a/core/shared/src/main/scala/laika/internal/rewrite/TemplateFormatter.scala
+++ b/core/shared/src/main/scala/laika/internal/rewrite/TemplateFormatter.scala
@@ -17,6 +17,7 @@
 package laika.internal.rewrite
 
 import laika.ast._
+import laika.ast.RewriteAction.Replace
 import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.api.config.Config.ConfigResult
 

--- a/core/shared/src/main/scala/laika/internal/rewrite/TemplateFormatter.scala
+++ b/core/shared/src/main/scala/laika/internal/rewrite/TemplateFormatter.scala
@@ -29,10 +29,11 @@ private[laika] object TemplateFormatter extends RewriteRulesBuilder {
     if (spans.isEmpty) spans
     else
       spans.sliding(2).foldLeft(spans.take(1)) {
-        case (acc, Seq(Text(_, NoOpt), Text(txt2, NoOpt))) =>
+        case (acc, Seq(Text(_, Options.empty), Text(txt2, Options.empty))) =>
           acc.dropRight(1) :+ Text(acc.last.asInstanceOf[Text].content + txt2)
-        case (acc, Seq(_, other))                          => acc :+ other
-        case (acc, _)                                      => acc
+
+        case (acc, Seq(_, other)) => acc :+ other
+        case (acc, _)             => acc
       }
 
   private def format(spans: Seq[TemplateSpan]): Seq[TemplateSpan] = {
@@ -43,9 +44,9 @@ private[laika] object TemplateFormatter extends RewriteRulesBuilder {
     if (spans.isEmpty) spans
     else
       spans.sliding(2).foldLeft(new ListBuffer[TemplateSpan]() += spans.head) {
-        case (buffer, Seq(TemplateString(text, NoOpt), TemplateElement(elem, 0, opt))) =>
+        case (buffer, Seq(TemplateString(text, Options.empty), TemplateElement(elem, 0, opt))) =>
           buffer += TemplateElement(elem, indentFor(text), opt)
-        case (buffer, Seq(TemplateString(text, NoOpt), EmbeddedRoot(elem, 0, opt)))    =>
+        case (buffer, Seq(TemplateString(text, Options.empty), EmbeddedRoot(elem, 0, opt)))    =>
           buffer += EmbeddedRoot(elem, indentFor(text), opt)
         case (buffer, Seq(_, elem)) => buffer += elem
         case (buffer, _)            => buffer

--- a/core/shared/src/main/scala/laika/internal/rewrite/UnresolvedNodeDetector.scala
+++ b/core/shared/src/main/scala/laika/internal/rewrite/UnresolvedNodeDetector.scala
@@ -20,11 +20,11 @@ import laika.ast.{
   DocumentCursor,
   InvalidBlock,
   InvalidSpan,
-  Replace,
   RewriteRules,
   TemplateElement,
   Unresolved
 }
+import laika.ast.RewriteAction.Replace
 import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.api.config.Config.ConfigResult
 

--- a/core/shared/src/main/scala/laika/internal/rst/BaseParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/BaseParsers.scala
@@ -68,10 +68,10 @@ private[laika] object BaseParsers {
     *  See [[http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#footnote-references]].
     */
   val footnoteLabel: Parser[FootnoteLabel] = {
-    val decimal         = someOf(CharGroup.digit).map(n => NumericLabel(n.toInt))
-    val autonumber      = literal("#").as(Autonumber)
-    val autosymbol      = literal("*").as(Autosymbol)
-    val autonumberLabel = "#" ~> simpleRefName.map(AutonumberLabel.apply)
+    val decimal         = someOf(CharGroup.digit).map(n => FootnoteLabel.NumericLabel(n.toInt))
+    val autonumber      = literal("#").as(FootnoteLabel.Autonumber)
+    val autosymbol      = literal("*").as(FootnoteLabel.Autosymbol)
+    val autonumberLabel = "#" ~> simpleRefName.map(FootnoteLabel.AutonumberLabel.apply)
 
     decimal | autonumberLabel | autonumber | autosymbol
   }

--- a/core/shared/src/main/scala/laika/internal/rst/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/ListParsers.scala
@@ -94,7 +94,7 @@ private[laika] object ListParsers {
 
   lazy val bulletList: BlockParserBuilder = BlockParserBuilder.recursive { implicit recParsers =>
     lookAhead(bulletListStart <~ ws.min(1)) >> { symbol =>
-      val bullet = StringBullet(symbol)
+      val bullet = BulletFormat.StringBullet(symbol)
       listItem(literal(symbol), BulletListItem(_, bullet)).rep.min(1).map { items =>
         BulletList(
           rewriteListItems(items, (item: BulletListItem, content) => item.withContent(content)),

--- a/core/shared/src/main/scala/laika/internal/rst/TableParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/TableParsers.scala
@@ -286,12 +286,12 @@ private[laika] object TableParsers {
             case head ~ Some(body) =>
               validateLastRow(body);
               Table(
-                TableHead(buildRowList(head, HeadCell)),
-                TableBody(buildRowList(body.init, BodyCell))
+                TableHead(buildRowList(head, CellType.HeadCell)),
+                TableBody(buildRowList(body.init, CellType.BodyCell))
               )
             case body ~ None       =>
               validateLastRow(body);
-              Table(TableHead(Nil), TableBody(buildRowList(body.init, BodyCell)))
+              Table(TableHead(Nil), TableBody(buildRowList(body.init, CellType.BodyCell)))
           }
           Right(table)
         }
@@ -416,8 +416,11 @@ private[laika] object TableParsers {
 
       tablePart ~ opt(tablePart) ^^ {
         case head ~ Some(body) =>
-          Table(TableHead(buildRowList(head, HeadCell)), TableBody(buildRowList(body, BodyCell)))
-        case body ~ None       => Table(TableHead(Nil), TableBody(buildRowList(body, BodyCell)))
+          Table(
+            TableHead(buildRowList(head, CellType.HeadCell)),
+            TableBody(buildRowList(body, CellType.BodyCell))
+          )
+        case body ~ None => Table(TableHead(Nil), TableBody(buildRowList(body, CellType.BodyCell)))
       }
 
     }

--- a/core/shared/src/main/scala/laika/internal/rst/ast/elements.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/ast/elements.scala
@@ -21,7 +21,8 @@ import laika.parse.SourceFragment
 
 /** A two-column table-like structure used for bibliographic fields or directive options.
   */
-private[rst] case class FieldList(content: Seq[Field], options: Options = NoOpt) extends Block
+private[rst] case class FieldList(content: Seq[Field], options: Options = Options.empty)
+    extends Block
     with ListContainer
     with RewritableContainer {
   type Self = FieldList
@@ -37,8 +38,11 @@ private[rst] case class FieldList(content: Seq[Field], options: Options = NoOpt)
 
 /** A single entry in a field list consisting of name and body.
   */
-private[rst] case class Field(name: Seq[Span], content: Seq[Block], options: Options = NoOpt)
-    extends ListItem
+private[rst] case class Field(
+    name: Seq[Span],
+    content: Seq[Block],
+    options: Options = Options.empty
+) extends ListItem
     with BlockContainer {
 
   type Self = Field
@@ -52,7 +56,8 @@ private[rst] case class Field(name: Seq[Span], content: Seq[Block], options: Opt
 
 /** A classifier for a term in a definition list.
   */
-private[rst] case class Classifier(content: Seq[Span], options: Options = NoOpt) extends Span
+private[rst] case class Classifier(content: Seq[Span], options: Options = Options.empty)
+    extends Span
     with SpanContainer {
   type Self = Classifier
   def withContent(newContent: Seq[Span]): Classifier = copy(content = newContent)
@@ -61,7 +66,7 @@ private[rst] case class Classifier(content: Seq[Span], options: Options = NoOpt)
 
 /** A list of command line options and descriptions.
   */
-private[rst] case class OptionList(content: Seq[OptionListItem], options: Options = NoOpt)
+private[rst] case class OptionList(content: Seq[OptionListItem], options: Options = Options.empty)
     extends Block
     with ListContainer
     with RewritableContainer {
@@ -78,7 +83,7 @@ private[rst] case class OptionList(content: Seq[OptionListItem], options: Option
 private[rst] case class OptionListItem(
     programOptions: Seq[ProgramOption],
     content: Seq[Block],
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ListItem
     with BlockContainer {
   type Self = OptionListItem
@@ -91,7 +96,7 @@ private[rst] case class OptionListItem(
 private[rst] case class ProgramOption(
     name: String,
     argument: Option[OptionArgument],
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Element {
   type Self = ProgramOption
   def withOptions(options: Options): ProgramOption = copy(options = options)
@@ -99,8 +104,11 @@ private[rst] case class ProgramOption(
 
 /** A single option argument.
   */
-private[rst] case class OptionArgument(value: String, delimiter: String, options: Options = NoOpt)
-    extends Span {
+private[rst] case class OptionArgument(
+    value: String,
+    delimiter: String,
+    options: Options = Options.empty
+) extends Span {
   type Self = OptionArgument
   def withOptions(options: Options): OptionArgument = copy(options = options)
 }
@@ -111,7 +119,7 @@ private[rst] case class OptionArgument(value: String, delimiter: String, options
 private[rst] case class SubstitutionDefinition(
     name: String,
     content: Span,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Definition with Hidden {
   type Self = SubstitutionDefinition
   def withOptions(options: Options): SubstitutionDefinition = copy(options = options)
@@ -124,7 +132,7 @@ private[rst] case class SubstitutionDefinition(
 private[rst] case class SubstitutionReference(
     name: String,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Reference {
   type Self = SubstitutionReference
   def withOptions(options: Options): SubstitutionReference = copy(options = options)
@@ -135,7 +143,8 @@ private[rst] case class SubstitutionReference(
   * Somewhat unlikely to be used in the context of this library,
   * but included for the sake of completeness.
   */
-private[rst] case class DoctestBlock(content: String, options: Options = NoOpt) extends Block
+private[rst] case class DoctestBlock(content: String, options: Options = Options.empty)
+    extends Block
     with TextContainer {
   type Self = DoctestBlock
   def withOptions(options: Options): DoctestBlock = copy(options = options)
@@ -157,7 +166,7 @@ private[rst] case class InterpretedText(
     role: String,
     content: String,
     source: SourceFragment,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Reference with TextContainer {
   type Self = InterpretedText
   def withOptions(options: Options): InterpretedText = copy(options = options)
@@ -172,7 +181,7 @@ private[rst] case class InterpretedText(
 private[rst] case class CustomizedTextRole(
     name: String,
     apply: String => Span,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Definition with Hidden {
   type Self = CustomizedTextRole
   def withOptions(options: Options): CustomizedTextRole = copy(options = options)
@@ -181,8 +190,11 @@ private[rst] case class CustomizedTextRole(
 /** Temporary element representing a file inclusion.
   * The path is interpreted as relative to the path of the processed document if it is not an absolute path.
   */
-private[rst] case class Include(path: String, source: SourceFragment, options: Options = NoOpt)
-    extends Block
+private[rst] case class Include(
+    path: String,
+    source: SourceFragment,
+    options: Options = Options.empty
+) extends Block
     with BlockResolver {
 
   type Self = Include
@@ -205,7 +217,7 @@ private[rst] case class Contents(
     source: SourceFragment,
     depth: Int = Int.MaxValue,
     local: Boolean = false,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends Block with BlockResolver {
 
   type Self = Contents
@@ -233,7 +245,8 @@ private[rst] abstract class LineBlockItem extends Block with RewritableContainer
 
 /** A single line inside a line block.
   */
-private[laika] case class Line(content: Seq[Span], options: Options = NoOpt) extends LineBlockItem
+private[laika] case class Line(content: Seq[Span], options: Options = Options.empty)
+    extends LineBlockItem
     with SpanContainer {
   type Self = Line
   def withContent(newContent: Seq[Span]): Line = copy(content = newContent)
@@ -247,7 +260,7 @@ private[laika] object Line extends SpanContainerCompanion {
 
 /** A block containing lines which preserve line breaks and optionally nested line blocks.
   */
-private[laika] case class LineBlock(content: Seq[LineBlockItem], options: Options = NoOpt)
+private[laika] case class LineBlock(content: Seq[LineBlockItem], options: Options = Options.empty)
     extends LineBlockItem
     with RewritableContainer with ElementContainer[LineBlockItem] {
   type Self = LineBlock

--- a/core/shared/src/main/scala/laika/internal/rst/bundle/ExtendedHTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/bundle/ExtendedHTMLRenderer.scala
@@ -35,7 +35,8 @@ import laika.internal.rst.ast.*
   */
 private[laika] class ExtendedHTMLRenderer {
 
-  private case class ProgramOptions(content: Seq[Element], options: Options = NoOpt) extends Block
+  private case class ProgramOptions(content: Seq[Element], options: Options = Options.empty)
+      extends Block
       with ElementContainer[Element] {
     type Self = ProgramOptions
     def withOptions(options: Options): ProgramOptions = copy(options = options)

--- a/core/shared/src/main/scala/laika/internal/rst/bundle/ExtendedHTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/bundle/ExtendedHTMLRenderer.scala
@@ -48,10 +48,10 @@ private[laika] class ExtendedHTMLRenderer {
       case one :: two :: rest => one :: sep :: intersperse(two :: rest, sep)
       case short              => short
     }
-    def options(value: Seq[ProgramOption])             = BodyCell(
+    def options(value: Seq[ProgramOption])             = CellType.BodyCell(
       ProgramOptions(intersperse(value.toList, Text(", ")))
     )
-    def body(value: Seq[Block])                        = BodyCell(value)
+    def body(value: Seq[Block])                        = CellType.BodyCell(value)
     val rows = ol.content map (o => Row(List(options(o.programOptions), body(o.content))))
     Table(
       TableHead(Nil),
@@ -65,8 +65,8 @@ private[laika] class ExtendedHTMLRenderer {
   /** Converts a `FieldList` to an interim table model for rendering.
     */
   private def toTable(fl: FieldList): Table = {
-    def name(value: Seq[Span])  = HeadCell(SpanSequence(value :+ Text(":")))
-    def body(value: Seq[Block]) = BodyCell(value)
+    def name(value: Seq[Span])  = CellType.HeadCell(SpanSequence(value :+ Text(":")))
+    def body(value: Seq[Block]) = CellType.BodyCell(value)
     val rows                    = fl.content map (f => Row(List(name(f.name), body(f.content))))
     Table(
       TableHead(Nil),

--- a/core/shared/src/main/scala/laika/internal/rst/bundle/LinkTargetProcessor.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/bundle/LinkTargetProcessor.scala
@@ -32,7 +32,7 @@ private[laika] object LinkTargetProcessor extends (Seq[Block] => Seq[Block]) {
   def apply(blocks: Seq[Block]): Seq[Block] = {
 
     case object Mock extends Block {
-      val options: Options = NoOpt
+      val options: Options = Options.empty
       type Self = Mock.type
       def withOptions(options: Options): Mock.type = this
     }

--- a/core/shared/src/main/scala/laika/internal/rst/bundle/RewriteRules.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/bundle/RewriteRules.scala
@@ -54,10 +54,12 @@ private[bundle] class RewriteRules(textRoles: Seq[TextRole]) extends RewriteRule
     val rewrite: laika.ast.RewriteRules = laika.ast.RewriteRules.forSpans {
 
       case SubstitutionReference(id, source, _) =>
-        Replace(substitutions.getOrElse(id, InvalidSpan(s"unknown substitution id: $id", source)))
+        RewriteAction.Replace(
+          substitutions.getOrElse(id, InvalidSpan(s"unknown substitution id: $id", source))
+        )
 
       case InterpretedText(role, text, source, _) =>
-        Replace(
+        RewriteAction.Replace(
           textRoles.get(role).fold[Span](InvalidSpan(s"unknown text role: $role", source))(_(text))
         )
 

--- a/core/shared/src/main/scala/laika/internal/rst/ext/Directives.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/ext/Directives.scala
@@ -90,7 +90,7 @@ import ExtensionParsers.Result
   * {{{
   *  case class Note (title: String,
   *                   content: Seq[Block],
-  *                   options: Options = NoOpt) extends Block
+  *                   options: Options = Options.empty) extends Block
   *                                             with BlockContainer[Note]
   *
   *  object MyDirectives extends RstExtensionRegistry {
@@ -137,7 +137,7 @@ import ExtensionParsers.Result
   *
   *  case class Message (severity: Int,
   *                      content: Seq[Block],
-  *                      options: Options = NoOpt) extends Block
+  *                      options: Options = Options.empty) extends Block
   *                                                with BlockContainer[Message]
   *
   *  object MyDirectives extends RstExtensionRegistry {
@@ -169,7 +169,7 @@ import ExtensionParsers.Result
   * {{{
   *  case class Message (severity: Option[Int],
   *                      content: Seq[Block],
-  *                      options: Options = NoOpt) extends Block
+  *                      options: Options = Options.empty) extends Block
   *                                                with BlockContainer[Message]
   *
   *  object MyDirectives extends RstExtensionRegistry {

--- a/core/shared/src/main/scala/laika/internal/rst/ext/ExtensionParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/ext/ExtensionParsers.scala
@@ -125,8 +125,11 @@ private[rst] class ExtensionParsers(
     }
   }
 
-  private case class InvalidDirective(msg: String, source: SourceFragment, options: Options = NoOpt)
-      extends Block with Span {
+  private case class InvalidDirective(
+      msg: String,
+      source: SourceFragment,
+      options: Options = Options.empty
+  ) extends Block with Span {
     type Self = InvalidDirective
     def withOptions(options: Options): InvalidDirective = copy(options = options)
   }

--- a/core/shared/src/main/scala/laika/internal/rst/std/StandardBlockDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/std/StandardBlockDirectives.scala
@@ -304,7 +304,7 @@ private[rst] class StandardBlockDirectives {
   private def imageBlock(p: RecursiveParsers): DirectivePartBuilder[Block] = image(p) map { img =>
     val hAlign =
       Set("align-left", "align-right", "align-center") // promote horizontal align to parent block
-    val (pOpt, imgOpt) = img.options.styles.foldLeft((NoOpt: Options, Options(img.options.id))) {
+    val (pOpt, imgOpt) = img.options.styles.foldLeft((Options.empty, Options(img.options.id))) {
       case ((pOpt, imgOpt), style) =>
         if (hAlign.contains(style)) (pOpt + Styles(style), imgOpt)
         else (pOpt, imgOpt + Styles(style))

--- a/core/shared/src/main/scala/laika/internal/rst/std/StandardBlockDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/std/StandardBlockDirectives.scala
@@ -278,7 +278,7 @@ private[rst] class StandardBlockDirectives {
       case caption ~ tableBlock ~ opt =>
         val table = tableBlock match {
           case t: Table => t
-          case block    => Table(TableHead(Nil), TableBody(Seq(Row(Seq(BodyCell(block))))))
+          case block    => Table(TableHead(Nil), TableBody(Seq(Row(Seq(CellType.BodyCell(block))))))
         }
         table.copy(caption = Caption(caption.toList.flatten), options = opt)
     }

--- a/core/shared/src/main/scala/laika/internal/rst/std/StandardBlockDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/std/StandardBlockDirectives.scala
@@ -23,7 +23,7 @@ import laika.api.config.{ Field, Origin }
 import laika.config.LaikaKeys
 import laika.internal.rst.ast.{ Contents, FieldList, Include, RstStyle }
 import laika.internal.rst.ext.Directives.{ BlockDirective, Directive, DirectivePartBuilder }
-import laika.parse.{ GeneratedSource, SourceFragment }
+import laika.parse.{ SourceCursor, SourceFragment }
 import laika.parse.builders.~
 import laika.parse.markup.RecursiveParsers
 import laika.internal.rst.ext.Directives.Parts.*
@@ -189,7 +189,7 @@ private[rst] class StandardBlockDirectives {
           MessageLevel.Error,
           "The meta directive expects a FieldList as its only block content"
         ),
-        GeneratedSource
+        SourceCursor.Generated
       )
   }
 
@@ -225,7 +225,7 @@ private[rst] class StandardBlockDirectives {
     )).map { case title ~ depth ~ local ~ style =>
       Contents(
         title.getOrElse("Contents"),
-        GeneratedSource,
+        SourceCursor.Generated,
         depth.getOrElse(Int.MaxValue),
         local.isDefined,
         toOptions(None, style)
@@ -243,7 +243,7 @@ private[rst] class StandardBlockDirectives {
     *  references the previously parsed node tree. This is both simpler and more efficient when the same
     *  file gets included in multiple places.
     */
-  lazy val include: DirectivePartBuilder[Block] = argument().map(Include(_, GeneratedSource))
+  lazy val include: DirectivePartBuilder[Block] = argument().map(Include(_, SourceCursor.Generated))
 
   /** The epitaph, highlights and pull-quote directives, which are all identical apart from the style
     *  parameter, see
@@ -329,9 +329,9 @@ private[rst] class StandardBlockDirectives {
     */
   lazy val rawDirective: Directive[Block] = BlockDirective("raw") {
     (argument(withWS = true) ~ content(Right(_))).map { case formats ~ content =>
-      NonEmptySet.fromSet(TreeSet(formats.split(" ").toIndexedSeq: _*)) match {
+      NonEmptySet.fromSet(TreeSet(formats.split(" ").toIndexedSeq *)) match {
         case Some(set) => RawContent(set, content.input)
-        case None      => InvalidBlock("no format specified", GeneratedSource)
+        case None      => InvalidBlock("no format specified", SourceCursor.Generated)
       }
     }
   }

--- a/core/shared/src/main/scala/laika/internal/rst/std/StandardDirectiveParts.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/std/StandardDirectiveParts.scala
@@ -22,7 +22,7 @@ import laika.parse.builders.~
 import laika.parse.syntax.*
 import laika.parse.markup.RecursiveParsers
 import laika.parse.text.{ CharGroup, TextParsers }
-import laika.parse.{ GeneratedSource, SourceFragment }
+import laika.parse.{ SourceCursor, SourceFragment }
 import laika.internal.rst.BaseParsers.sizeAndUnit
 import laika.internal.rst.ext.Directives.Parts.*
 
@@ -82,7 +82,7 @@ private[std] object StandardDirectiveParts {
       val alignOpt     = align.getOrElse(Options.empty)
 
       val img      = Image(Target.parse(uri), width = actualWidth, height = actualHeight, alt = alt)
-      val resolver = ImageResolver(img, GeneratedSource)
+      val resolver = ImageResolver(img, SourceCursor.Generated)
 
       target
         .flatMap {

--- a/core/shared/src/main/scala/laika/internal/rst/std/StandardDirectiveParts.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/std/StandardDirectiveParts.scala
@@ -79,7 +79,7 @@ private[std] object StandardDirectiveParts {
       stdOpt).map { case uri ~ alt ~ width ~ height ~ scale ~ align ~ target ~ opt =>
       val actualWidth  = scale.fold(width)(s => width.map(_.scale(s.amount)))
       val actualHeight = scale.fold(height)(s => height.map(_.scale(s.amount)))
-      val alignOpt     = align.getOrElse(NoOpt)
+      val alignOpt     = align.getOrElse(Options.empty)
 
       val img      = Image(Target.parse(uri), width = actualWidth, height = actualHeight, alt = alt)
       val resolver = ImageResolver(img, GeneratedSource)

--- a/core/shared/src/main/scala/laika/internal/rst/std/StandardTextRoles.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/std/StandardTextRoles.scala
@@ -20,7 +20,7 @@ import cats.data.NonEmptySet
 import laika.ast.*
 import laika.internal.rst.ast.RstStyle
 import laika.internal.rst.ext.TextRoles.TextRole
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import laika.parse.builders.~
 import laika.internal.rst.ext.TextRoles.Parts.*
 
@@ -153,7 +153,7 @@ private[rst] class StandardTextRoles {
     } { case ((formats, opt), content) =>
       NonEmptySet.fromSet(TreeSet(formats: _*)) match {
         case Some(set) => RawContent(set, content, opt)
-        case None      => InvalidSpan("no format specified", GeneratedSource)
+        case None      => InvalidSpan("no format specified", SourceCursor.Generated)
       }
     }
 

--- a/core/shared/src/main/scala/laika/internal/rst/std/StandardTextRoles.scala
+++ b/core/shared/src/main/scala/laika/internal/rst/std/StandardTextRoles.scala
@@ -74,50 +74,48 @@ private[rst] class StandardTextRoles {
   private val classOption = optField(
     "class",
     opt => Right(Options(None, opt.input.split(" ").toSet))
-  ) map (_.getOrElse(NoOpt))
+  ) map (_.getOrElse(Options.empty))
 
   /** The standard emphasis text role.
     */
   lazy val emphasis: TextRole =
-    TextRole("emphasis", NoOpt: Options)(classOption)((opt, text) =>
+    TextRole("emphasis", Options.empty)(classOption)((opt, text) =>
       Emphasized(List(Text(text)), opt)
     )
 
   /** The standard strong text role.
     */
   lazy val strong: TextRole =
-    TextRole("strong", NoOpt: Options)(classOption)((opt, text) => Strong(List(Text(text)), opt))
+    TextRole("strong", Options.empty)(classOption)((opt, text) => Strong(List(Text(text)), opt))
 
   /** The standard literal text role.
     */
   lazy val literal: TextRole =
-    TextRole("literal", NoOpt: Options)(classOption)((opt, text) => Literal(text, opt))
+    TextRole("literal", Options.empty)(classOption)((opt, text) => Literal(text, opt))
 
   /** The standard subscript text role.
     */
   lazy val subscript: TextRole =
-    TextRole("subscript", NoOpt: Options)(classOption)((opt, text) =>
+    TextRole("subscript", Options.empty)(classOption)((opt, text) =>
       Text(text, opt + RstStyle.subscript)
     )
 
   /** The standard superscript text role.
     */
   lazy val superscript: TextRole =
-    TextRole("superscript", NoOpt: Options)(classOption)((opt, text) =>
+    TextRole("superscript", Options.empty)(classOption)((opt, text) =>
       Text(text, opt + RstStyle.superscript)
     )
 
   /** The sub text role, an alias for the subscript role.
     */
   lazy val sub: TextRole =
-    TextRole("sub", NoOpt: Options)(classOption)((opt, text) =>
-      Text(text, opt + RstStyle.subscript)
-    )
+    TextRole("sub", Options.empty)(classOption)((opt, text) => Text(text, opt + RstStyle.subscript))
 
   /** The sup text role, an alias for the superscript role.
     */
   lazy val sup: TextRole =
-    TextRole("sup", NoOpt: Options)(classOption)((opt, text) =>
+    TextRole("sup", Options.empty)(classOption)((opt, text) =>
       Text(text, opt + RstStyle.superscript)
     )
 
@@ -125,21 +123,21 @@ private[rst] class StandardTextRoles {
     *  with `RstExtensionRegistry.defaultTextRole`.
     */
   lazy val titleRef: TextRole =
-    TextRole("title-reference", NoOpt: Options)(classOption)((opt, text) =>
+    TextRole("title-reference", Options.empty)(classOption)((opt, text) =>
       Emphasized(List(Text(text)), opt + RstStyle.titleReference)
     )
 
   /** The title text role, an alias for the title-reference role.
     */
   lazy val title: TextRole =
-    TextRole("title", NoOpt: Options)(classOption)((opt, text) =>
+    TextRole("title", Options.empty)(classOption)((opt, text) =>
       Emphasized(List(Text(text)), opt + RstStyle.titleReference)
     )
 
   /** The standard code text role. The current implementation does not support syntax highlighting.
     */
   lazy val codeSpan: TextRole =
-    TextRole("code", ("", NoOpt: Options)) {
+    TextRole("code", ("", Options.empty)) {
       (optField("language") ~ classOption).map { case lang ~ opt => (lang.getOrElse(""), opt) }
     } { case ((lang, opt), text) =>
       InlineCode(lang, List(Text(text)), opt)
@@ -150,7 +148,7 @@ private[rst] class StandardTextRoles {
     *  It can be enabled with `Transformer.from(ReStructuredText).to(HTML).withRawContent`.
     */
   lazy val rawTextRole: TextRole =
-    TextRole("raw", (Nil: List[String], NoOpt: Options)) {
+    TextRole("raw", (Nil: List[String], Options.empty)) {
       (field("format") ~ classOption).map { case format ~ opt => (format.split(" ").toList, opt) }
     } { case ((formats, opt), content) =>
       NonEmptySet.fromSet(TreeSet(formats: _*)) match {

--- a/core/shared/src/main/scala/laika/parse/SourceCursor.scala
+++ b/core/shared/src/main/scala/laika/parse/SourceCursor.scala
@@ -381,24 +381,6 @@ object BlockSource {
 
 }
 
-/** Represents a generated source, where an AST node has been created programmatically and cannot be
-  * traced back to the corresponding input source.
-  */
-object GeneratedSource extends SourceFragment {
-  type Self = this.type
-  def input: String                     = ""
-  def offset: Int                       = 0
-  def remaining: Int                    = 0
-  def atEnd: Boolean                    = true
-  def capture(numChars: Int): String    = ""
-  def consume(numChars: Int): this.type = this
-  def root: RootSource                  = new RootSource(InputString.empty, 0, 0)
-  def position: Position                = new Position(InputString.empty, 0)
-  def nestLevel: Int                    = 0
-  def nextNestLevel: this.type          = this
-  def reverse: this.type                = this
-}
-
 /** Companion for creating new `SourceCursor` instances.
   * This type of constructor is only meant to be used for creating a root cursor for the input holding
   * the whole document (e.g. the entire markup document or the full template).
@@ -416,6 +398,35 @@ object SourceCursor {
     */
   def apply(input: String, path: Path): SourceCursor =
     new RootSource(InputString(input, Some(path)), 0, 0)
+
+  /** Represents a generated source, where an AST node has been created programmatically and cannot be
+    * traced back to the corresponding input source.
+    */
+  object Generated extends SourceFragment {
+    type Self = this.type
+
+    def input: String = ""
+
+    def offset: Int = 0
+
+    def remaining: Int = 0
+
+    def atEnd: Boolean = true
+
+    def capture(numChars: Int): String = ""
+
+    def consume(numChars: Int): this.type = this
+
+    def root: RootSource = new RootSource(InputString.empty, 0, 0)
+
+    def position: Position = new Position(InputString.empty, 0)
+
+    def nestLevel: Int = 0
+
+    def nextNestLevel: this.type = this
+
+    def reverse: this.type = this
+  }
 
 }
 

--- a/core/shared/src/main/scala/laika/parse/SourceCursor.scala
+++ b/core/shared/src/main/scala/laika/parse/SourceCursor.scala
@@ -124,8 +124,11 @@ trait SourceFragment extends SourceCursor {
   * For creating a cursor for a fragment of the input, either `BlockSource` or `LineSource` must be used
   * to preserve position tracking in relation to the root input.
   */
-class RootSource private[parse] (inputRef: InputString, val offset: Int, val nestLevel: Int)
-    extends SourceCursor {
+private[parse] class RootSource(
+    inputRef: InputString,
+    val offset: Int,
+    val nestLevel: Int
+) extends SourceCursor {
 
   type Self = RootSource
 

--- a/core/shared/src/main/scala/laika/parse/code/CodeSpanParser.scala
+++ b/core/shared/src/main/scala/laika/parse/code/CodeSpanParser.scala
@@ -21,7 +21,7 @@ import laika.parse.Parser
 import laika.parse.text.PrefixedParser
 import laika.parse.builders._
 import laika.parse.syntax._
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 
 /** A collection of code span parsers that are intended to be applied together.
   */

--- a/core/shared/src/main/scala/laika/parse/code/common/CharLiteral.scala
+++ b/core/shared/src/main/scala/laika/parse/code/common/CharLiteral.scala
@@ -20,7 +20,7 @@ import laika.ast.{ CodeSpan, CodeSpans }
 import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.text.PrefixedParser
 import laika.parse.builders._
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 import laika.parse.syntax._
 
 /** Configurable base parsers for character literals.

--- a/core/shared/src/main/scala/laika/parse/code/common/StringLiteral.scala
+++ b/core/shared/src/main/scala/laika/parse/code/common/StringLiteral.scala
@@ -19,7 +19,7 @@ package laika.parse.code.common
 import laika.ast.{ CodeSpan, CodeSpans }
 import laika.parse.Parser
 import laika.parse.builders._
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.syntax._
 import laika.parse.text.{ PrefixedParser, TextParsers }

--- a/core/shared/src/main/scala/laika/parse/code/common/TagFormats.scala
+++ b/core/shared/src/main/scala/laika/parse/code/common/TagFormats.scala
@@ -20,7 +20,7 @@ import laika.ast.{ CodeSpan, CodeSpans }
 import laika.parse.Parser
 import laika.parse.builders._
 import laika.parse.code.common.Identifier.IdParser
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.syntax._
 import laika.parse.text.PrefixedParser

--- a/core/shared/src/main/scala/laika/parse/code/languages/CSSSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/CSSSyntax.scala
@@ -25,7 +25,7 @@ import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.text.Characters
 import laika.parse.builders._
 import laika.parse.code.common.NumberLiteral.digits
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 import laika.parse.syntax._
 
 /** @author Jens Halm

--- a/core/shared/src/main/scala/laika/parse/code/languages/DhallSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/DhallSyntax.scala
@@ -21,7 +21,7 @@ import laika.api.bundle.SyntaxHighlighter
 import laika.ast.CodeSpan
 import laika.parse.code.common.NumberLiteral.digits
 import laika.parse.code.common._
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.builders.~
 import laika.parse.syntax._

--- a/core/shared/src/main/scala/laika/parse/code/languages/EBNFSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/EBNFSyntax.scala
@@ -20,7 +20,7 @@ import cats.data.NonEmptyList
 import laika.api.bundle.SyntaxHighlighter
 import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.code.common.{ Identifier, StringLiteral }
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 import laika.parse.builders._
 import laika.parse.syntax._
 

--- a/core/shared/src/main/scala/laika/parse/code/languages/HOCONSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/HOCONSyntax.scala
@@ -29,7 +29,7 @@ import laika.parse.code.common.{
   NumberLiteral,
   StringLiteral
 }
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.text.PrefixedParser
 import laika.parse.text.TextParsers.*

--- a/core/shared/src/main/scala/laika/parse/code/languages/LaikaExtensionSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/LaikaExtensionSyntax.scala
@@ -30,7 +30,7 @@ import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.text.PrefixedParser
 import laika.parse.builders.*
 import laika.parse.syntax.*
-import laika.parse.code.implicits.*
+import laika.parse.code.syntax.*
 
 /** @author Jens Halm
   */

--- a/core/shared/src/main/scala/laika/parse/code/languages/MarkdownSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/MarkdownSyntax.scala
@@ -24,7 +24,7 @@ import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.parse.text.PrefixedParser
 import laika.parse.builders._
 import laika.parse.syntax._
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 
 /** @author Jens Halm
   */

--- a/core/shared/src/main/scala/laika/parse/code/languages/ReStructuredTextSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/ReStructuredTextSyntax.scala
@@ -23,7 +23,7 @@ import laika.internal.rst.BaseParsers
 import laika.parse.Parser
 import laika.parse.builders._
 import laika.parse.syntax._
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 import laika.parse.code.common.StringLiteral
 import laika.parse.code.{ CodeCategory, CodeSpanParser }
 import laika.internal.rst.InlineParsers.{ markupEnd, markupStart }

--- a/core/shared/src/main/scala/laika/parse/code/languages/ScalaSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/ScalaSyntax.scala
@@ -32,7 +32,7 @@ import laika.parse.text.{ CharGroup, PrefixedParser }
 import laika.parse.builders._
 import laika.parse.syntax._
 import laika.parse.code.common.Identifier.IdParser
-import laika.parse.code.implicits._
+import laika.parse.code.syntax._
 
 /** @author Jens Halm
   */

--- a/core/shared/src/main/scala/laika/parse/code/syntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/syntax.scala
@@ -22,7 +22,7 @@ import laika.parse.text.PrefixedParser
 
 /** @author Jens Halm
   */
-object implicits {
+object syntax {
 
   implicit class CodeParserOps[T](val p: Parser[String]) extends AnyVal {
     def asCode(categories: CodeCategory*): Parser[CodeSpan] = p.map(CodeSpan(_, categories.toSet))

--- a/core/shared/src/main/scala/laika/parse/markup/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/InlineParsers.scala
@@ -62,7 +62,7 @@ trait InlineParsers {
     def fromString(str: String): Span = Text(str)
 
     def += (item: Span): Unit = (last, item) match {
-      case (Some(Text(text1, NoOpt)), Text(text2, NoOpt))                                =>
+      case (Some(Text(text1, Options.empty)), Text(text2, Options.empty))                =>
         last = Some(Text(text1 ++ text2))
       case (Some(Text(content, _)), Reverse(len, target, _, _)) if content.length >= len =>
         buffer += Text(content.dropRight(len))

--- a/core/shared/src/test/scala/laika/api/RenderAPISpec.scala
+++ b/core/shared/src/test/scala/laika/api/RenderAPISpec.scala
@@ -47,7 +47,7 @@ class RenderAPISpec extends FunSuite
   }
 
   test("use Document's configuration for rewrite rules") {
-    case class TestResolver(options: Options = NoOpt) extends BlockResolver {
+    case class TestResolver(options: Options = Options.empty) extends BlockResolver {
       type Self = TestResolver
       def resolve(cursor: DocumentCursor): Block      = {
         cursor.config

--- a/core/shared/src/test/scala/laika/api/RenderAPISpec.scala
+++ b/core/shared/src/test/scala/laika/api/RenderAPISpec.scala
@@ -17,10 +17,10 @@
 package laika.api
 
 import laika.ast.Path.Root
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.ParagraphCompanionShortcuts
-import laika.format._
-import laika.parse.{ GeneratedSource, SourceFragment }
+import laika.format.*
+import laika.parse.{ SourceCursor, SourceFragment }
 import munit.FunSuite
 
 class RenderAPISpec extends FunSuite
@@ -55,7 +55,7 @@ class RenderAPISpec extends FunSuite
           .fold[Block](e => InvalidBlock(e.message, source), str => Paragraph(str))
       }
       def runsIn(phase: RewritePhase): Boolean        = phase.isInstanceOf[RewritePhase.Render]
-      def source: SourceFragment                      = GeneratedSource
+      def source: SourceFragment                      = SourceCursor.Generated
       def unresolvedMessage: String                   = "unresolved test block"
       def withOptions(options: Options): TestResolver = copy(options = options)
     }

--- a/core/shared/src/test/scala/laika/api/TransformAPISpec.scala
+++ b/core/shared/src/test/scala/laika/api/TransformAPISpec.scala
@@ -17,6 +17,7 @@
 package laika.api
 
 import laika.ast._
+import laika.ast.RewriteAction.Replace
 import laika.config.LaikaKeys
 import laika.format._
 import munit.FunSuite
@@ -72,7 +73,7 @@ class TransformAPISpec extends FunSuite {
     val modifiedOutput  = output.replace("foo", "bar")
     val transformCustom = builder
       .usingSpanRule { case Text("foo", _) => Replace(Text("bar")) }
-      .usingSpanRule { case Text(_, _) => Retain }
+      .usingSpanRule { case Text(_, _) => RewriteAction.Retain }
     assertEquals(transformCustom.build.transform(input), Right(modifiedOutput))
   }
 

--- a/core/shared/src/test/scala/laika/ast/DocumentAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentAPISpec.scala
@@ -136,7 +136,7 @@ class DocumentAPISpec extends FunSuite
       _.withValue(LaikaKeys.orphan, false)
     )
     val testRule  = RewriteRules.forSpans { case Text("Some text", _) =>
-      Replace(Text("Swapped"))
+      RewriteAction.Replace(Text("Swapped"))
     }
     val rewritten = OperationConfig.default
       .rewriteRulesFor(raw, RewritePhase.Resolve)

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -22,6 +22,7 @@ import laika.api.config.{ Config, ConfigParser, Key, Origin }
 import laika.api.config.ConfigError.{ DocumentErrors, InvalidType, TreeErrors, ValidationFailed }
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
+import laika.ast.RewriteAction.Replace
 import laika.ast.sample.{
   BuilderKey,
   MunitDocumentTreeAssertions,

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -36,7 +36,7 @@ import laika.api.config.Origin.{ DocumentScope, Scope, TreeScope }
 import laika.config.MessageFilter
 import laika.format.HTML
 import laika.internal.rewrite.TemplateRewriter
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import munit.FunSuite
 
 class DocumentTreeAPISpec extends FunSuite
@@ -80,7 +80,7 @@ class DocumentTreeAPISpec extends FunSuite
       includeRuntimeMessage: Boolean = false
   ): DocumentTreeRoot = {
     val refNode                                 = contextRef.fold(Seq.empty[Span])(ref =>
-      Seq(MarkupContextReference(Key.parse(ref), required = false, GeneratedSource))
+      Seq(MarkupContextReference(Key.parse(ref), required = false, SourceCursor.Generated))
     )
     def targetRoot(key: BuilderKey): Seq[Block] = {
       val msgNode =

--- a/core/shared/src/test/scala/laika/ast/sample/TestSourceBuilders.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/TestSourceBuilders.scala
@@ -27,10 +27,10 @@ trait TestSourceBuilders {
   val defaultPath: Path = Root / "doc"
 
   def toSource(label: FootnoteLabel): String = label match {
-    case Autonumber             => "[#]_"
-    case Autosymbol             => "[*]_"
-    case AutonumberLabel(label) => s"[#$label]_"
-    case NumericLabel(label)    => s"[$label]_"
+    case FootnoteLabel.Autonumber             => "[#]_"
+    case FootnoteLabel.Autosymbol             => "[*]_"
+    case FootnoteLabel.AutonumberLabel(label) => s"[#$label]_"
+    case FootnoteLabel.NumericLabel(label)    => s"[$label]_"
   }
 
   def source(fragment: String, root: String): SourceFragment = {

--- a/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
@@ -21,6 +21,7 @@ import laika.api.format.MarkupFormat
 import laika.ast.*
 import laika.ast.DocumentType.{ Markup, Static, Template }
 import laika.ast.Path.Root
+import laika.ast.RewriteAction.Replace
 import laika.bundle.BundleProvider.TestExtensionBundle
 import laika.api.bundle.ExtensionBundle.LaikaDefaults
 import laika.bundle.BundleProvider

--- a/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
@@ -64,14 +64,14 @@ class OperationConfigSpec extends FunSuite {
     }
 
     val bundles1 = Seq(UserBundle1, LaikaDefaults, ThemeBundle, GitHubFlavor, UserBundle2)
-    val bundles2 = Seq(VerbatimHTML, UserBundle1, ExtensionBundle.Empty)
+    val bundles2 = Seq(VerbatimHTML, UserBundle1, ExtensionBundle.empty)
     val config1  = new OperationConfig(bundles1)
     val config2  = new OperationConfig(bundles2)
     assertEquals(
       config1.merge(config2).bundles,
       Seq(
         LaikaDefaults,
-        ExtensionBundle.Empty,
+        ExtensionBundle.empty,
         GitHubFlavor,
         VerbatimHTML,
         ThemeBundle,

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -94,7 +94,8 @@ class BlockParserConfigSpec extends FunSuite with ParserSetup {
       |bbb
     """.stripMargin
 
-  case class DecoratedBlock(deco: Char, content: Seq[Span], options: Options = NoOpt) extends Block
+  case class DecoratedBlock(deco: Char, content: Seq[Span], options: Options = Options.empty)
+      extends Block
       with SpanContainer {
     type Self = DecoratedBlock
     def withContent(newContent: Seq[Span]): DecoratedBlock = copy(content = newContent)
@@ -180,7 +181,7 @@ class SpanParserConfigSpec extends FunSuite with ParserSetup {
   })
 
   case class DecoratedSpan(deco: Char, text: String) extends Span {
-    val options: Options = NoOpt
+    val options: Options = Options.empty
     type Self = DecoratedSpan
     def withOptions(options: Options): DecoratedSpan = this
   }

--- a/core/shared/src/test/scala/laika/directive/BlockDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/BlockDirectiveAPISpec.scala
@@ -152,7 +152,7 @@ class BlockDirectiveAPISpec extends FunSuite
 
     trait DirectiveProducingResolver {
 
-      case class DummyResolver(options: Options = NoOpt) extends BlockResolver {
+      case class DummyResolver(options: Options = Options.empty) extends BlockResolver {
         type Self = DummyResolver
         def resolve(cursor: DocumentCursor): Block = p("foo")
         val source: SourceFragment                 = generatedSource("@:dir")

--- a/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
@@ -157,7 +157,7 @@ class SpanDirectiveAPISpec extends FunSuite with TestSourceBuilders with RenderP
 
     trait DirectiveProducingResolver {
 
-      case class DummyResolver(options: Options = NoOpt) extends SpanResolver {
+      case class DummyResolver(options: Options = Options.empty) extends SpanResolver {
         type Self = DummyResolver
         def resolve(cursor: DocumentCursor): Span = Text("foo")
         val source: SourceFragment                = generatedSource("@:dir")

--- a/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
@@ -210,7 +210,7 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts
       hasTitleDocs: Boolean = false,
       maxLevels: Int = Int.MaxValue,
       excludeSections: Boolean = false,
-      itemStyles: Options = NoOpt,
+      itemStyles: Options = Options.empty,
       includeTargetFormatConfig: Boolean = false,
       additionalDocuments: Seq[Document] = Nil
   )

--- a/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
@@ -112,7 +112,7 @@ class StandardDirectiveSpec extends FunSuite
     run(input, p(Text("aa "), SpanSequence(Nil), Text(" bb")))
   }
 
-  private val resolvedTarget = ResolvedInternalTarget(
+  private val resolvedTarget = InternalTarget.Resolved(
     absolutePath = Path.parse("/theme/theme.css"),
     relativePath = RelativePath.parse("../theme/theme.css")
   )

--- a/core/shared/src/test/scala/laika/internal/rst/ExplicitBlockParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/ExplicitBlockParsersSpec.scala
@@ -51,7 +51,11 @@ class ExplicitBlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts
     val input = ".. [#] This is a footnote"
     run(
       input,
-      FootnoteDefinition(Autonumber, List(p("This is a footnote")), generatedSource(input))
+      FootnoteDefinition(
+        FootnoteLabel.Autonumber,
+        List(p("This is a footnote")),
+        generatedSource(input)
+      )
     )
   }
 
@@ -59,7 +63,11 @@ class ExplicitBlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts
     val input = ".. [*] This is a footnote"
     run(
       input,
-      FootnoteDefinition(Autosymbol, List(p("This is a footnote")), generatedSource(input))
+      FootnoteDefinition(
+        FootnoteLabel.Autosymbol,
+        List(p("This is a footnote")),
+        generatedSource(input)
+      )
     )
   }
 
@@ -68,7 +76,7 @@ class ExplicitBlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts
     run(
       input,
       FootnoteDefinition(
-        AutonumberLabel("foo"),
+        FootnoteLabel.AutonumberLabel("foo"),
         List(p("This is a footnote")),
         generatedSource(input)
       )
@@ -79,7 +87,11 @@ class ExplicitBlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts
     val input = ".. [17] This is a footnote"
     run(
       input,
-      FootnoteDefinition(NumericLabel(17), List(p("This is a footnote")), generatedSource(input))
+      FootnoteDefinition(
+        FootnoteLabel.NumericLabel(17),
+        List(p("This is a footnote")),
+        generatedSource(input)
+      )
     )
   }
 

--- a/core/shared/src/test/scala/laika/internal/rst/InlineParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/InlineParsersSpec.scala
@@ -200,23 +200,29 @@ class InlineParsersSpec extends FunSuite with TestSourceBuilders {
 
   test("footnote reference - enclosed between [ and ]_ with autonumber label") {
     val input = "some [#]_ here"
-    runEnclosed(input, FootnoteReference(Autonumber, source(toSource(Autonumber), input)))
+    runEnclosed(
+      input,
+      FootnoteReference(FootnoteLabel.Autonumber, source(toSource(FootnoteLabel.Autonumber), input))
+    )
   }
 
   test("footnote reference - enclosed between [ and ]_ with autosymbol label") {
     val input = "some [*]_ here"
-    runEnclosed(input, FootnoteReference(Autosymbol, source(toSource(Autosymbol), input)))
+    runEnclosed(
+      input,
+      FootnoteReference(FootnoteLabel.Autosymbol, source(toSource(FootnoteLabel.Autosymbol), input))
+    )
   }
 
   test("footnote reference - enclosed between [ and ]_ with an autonumber named label") {
     val input = "some [#foo]_ here"
-    val label = AutonumberLabel("foo")
+    val label = FootnoteLabel.AutonumberLabel("foo")
     runEnclosed(input, FootnoteReference(label, source(toSource(label), input)))
   }
 
   test("footnote reference - enclosed between [ and ]_ with a numeric label") {
     val input = "some [17]_ here"
-    val label = NumericLabel(17)
+    val label = FootnoteLabel.NumericLabel(17)
     runEnclosed(input, FootnoteReference(label, source(toSource(label), input)))
   }
 

--- a/core/shared/src/test/scala/laika/internal/rst/ListParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/ListParsersSpec.scala
@@ -392,7 +392,7 @@ class DefinitionListSpec extends FunSuite with ListParserRunner with TestSourceB
       DefinitionListItem("term 1", p("aaa")),
       DefinitionListItem("term 2", p("bbb"))
     )
-    run(input, list, Table(Row(BodyCell("a"), BodyCell("b"))))
+    run(input, list, Table(Row(CellType.BodyCell("a"), CellType.BodyCell("b"))))
   }
 
   test("ignore subsequent directives") {

--- a/core/shared/src/test/scala/laika/internal/rst/ListParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/ListParsersSpec.scala
@@ -61,7 +61,7 @@ class BulletListSpec extends FunSuite with ListParserRunner {
       """+ aaa
         |+ bbb
         |+ ccc""".stripMargin
-    run(input, BulletList(StringBullet("+"))("aaa", "bbb", "ccc"))
+    run(input, BulletList(BulletFormat.StringBullet("+"))("aaa", "bbb", "ccc"))
   }
 
   test("list items starting with '-' treated the same way as those starting with a '*'") {
@@ -69,7 +69,7 @@ class BulletListSpec extends FunSuite with ListParserRunner {
       """- aaa
         |- bbb
         |- ccc""".stripMargin
-    run(input, BulletList(StringBullet("-"))("aaa", "bbb", "ccc"))
+    run(input, BulletList(BulletFormat.StringBullet("-"))("aaa", "bbb", "ccc"))
   }
 
   test("list items containing multiple paragraphs in a single item") {

--- a/core/shared/src/test/scala/laika/internal/rst/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/RewriteRulesSpec.scala
@@ -23,7 +23,7 @@ import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.api.config.Config.ConfigResult
 import laika.config.LaikaKeys
 import laika.internal.rst.ast.Underline
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import munit.FunSuite
 
 class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with TestSourceBuilders {
@@ -55,7 +55,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
   test("link id refs - resolve references when some parent element also gets rewritten") {
     val rootElem = RootElement(
-      DecoratedHeader(Underline('#'), List(Text("text "), linkIdRef()), GeneratedSource),
+      DecoratedHeader(Underline('#'), List(Text("text "), linkIdRef()), SourceCursor.Generated),
       LinkDefinition("name", ExternalTarget("http://foo/"))
     )
     val resolved =
@@ -65,9 +65,9 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
   test("decorated headers - set the level of the header in a flat list of headers") {
     val rootElem = RootElement(
-      DecoratedHeader(Underline('#'), List(Text("Title")), GeneratedSource),
-      DecoratedHeader(Underline('#'), List(Text("Header 1")), GeneratedSource),
-      DecoratedHeader(Underline('#'), List(Text("Header 2")), GeneratedSource)
+      DecoratedHeader(Underline('#'), List(Text("Title")), SourceCursor.Generated),
+      DecoratedHeader(Underline('#'), List(Text("Header 1")), SourceCursor.Generated),
+      DecoratedHeader(Underline('#'), List(Text("Header 2")), SourceCursor.Generated)
     )
     val expected = RootElement(
       Title(List(Text("Title")), Id("title") + Style.title),
@@ -79,10 +79,10 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
   test("decorated headers - set the level of the header in a nested list of headers") {
     val rootElem = RootElement(
-      DecoratedHeader(Underline('#'), List(Text("Title")), GeneratedSource),
-      DecoratedHeader(Underline('#'), List(Text("Header 1")), GeneratedSource),
-      DecoratedHeader(Underline('-'), List(Text("Header 2")), GeneratedSource),
-      DecoratedHeader(Underline('#'), List(Text("Header 3")), GeneratedSource)
+      DecoratedHeader(Underline('#'), List(Text("Title")), SourceCursor.Generated),
+      DecoratedHeader(Underline('#'), List(Text("Header 1")), SourceCursor.Generated),
+      DecoratedHeader(Underline('-'), List(Text("Header 2")), SourceCursor.Generated),
+      DecoratedHeader(Underline('#'), List(Text("Header 3")), SourceCursor.Generated)
     )
     val expected = RootElement(
       Title(List(Text("Title")), Id("title") + Style.title),
@@ -99,9 +99,9 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     "decorated headers - do not create title nodes in the default configuration for orphan documents"
   ) {
     val rootElem = RootElement(
-      DecoratedHeader(Underline('#'), List(Text("Title")), GeneratedSource),
-      DecoratedHeader(Underline('#'), List(Text("Header 1")), GeneratedSource),
-      DecoratedHeader(Underline('#'), List(Text("Header 2")), GeneratedSource)
+      DecoratedHeader(Underline('#'), List(Text("Title")), SourceCursor.Generated),
+      DecoratedHeader(Underline('#'), List(Text("Header 1")), SourceCursor.Generated),
+      DecoratedHeader(Underline('#'), List(Text("Header 2")), SourceCursor.Generated)
     )
     val expected = RootElement(
       Section(Header(1, List(Text("Title")), Id("title") + Style.section), Nil),

--- a/core/shared/src/test/scala/laika/internal/rst/TableParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/TableParsersSpec.scala
@@ -29,10 +29,10 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
   val rootParser = new RootParser(ReStructuredText, new ParserBundle().markupExtensions)
   val defaultParser: Parser[RootElement] = rootParser.rootElement
 
-  def textRow(cells: String*): Row = Row(cells.map(BodyCell(_)))
+  def textRow(cells: String*): Row = Row(cells.map(CellType.BodyCell(_)))
 
   def cell(content: String, colspan: Int, rowspan: Int): Cell =
-    Cell(BodyCell, List(p(Text(content))), colspan, rowspan)
+    Cell(CellType.BodyCell, List(p(Text(content))), colspan, rowspan)
 
   def run(input: String, blocks: Block*)(implicit loc: munit.Location): Unit =
     assertEquals(defaultParser.parse(input).toEither, Right(RootElement(blocks)))
@@ -70,7 +70,7 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
                   |+ b +---+
                   || c | e |
                   |+---+---+""".stripMargin
-    run(input, Table(Row(cell("a\nb\nc", 1, 2), BodyCell("d")), textRow("e")))
+    run(input, Table(Row(cell("a\nb\nc", 1, 2), CellType.BodyCell("d")), textRow("e")))
   }
 
   test("grid table - vertically merged cells in the right column") {
@@ -79,7 +79,7 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
                   |+---+ c +
                   || e | d |
                   |+---+---+""".stripMargin
-    run(input, Table(Row(BodyCell("a"), cell("b\nc\nd", 1, 2)), textRow("e")))
+    run(input, Table(Row(CellType.BodyCell("a"), cell("b\nc\nd", 1, 2)), textRow("e")))
   }
 
   test("grid table - vertically and horizontally merged cells") {
@@ -94,7 +94,7 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
       input,
       Table(
         textRow("a", "b", "c"),
-        Row(cell("1-1\n2-2\n3-3", 2, 2), BodyCell("d")),
+        Row(cell("1-1\n2-2\n3-3", 2, 2), CellType.BodyCell("d")),
         textRow("e")
       )
     )
@@ -109,8 +109,8 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
     run(
       input,
       Table(
-        Row(BodyCell.empty, BodyCell.empty),
-        Row(BodyCell.empty, BodyCell.empty)
+        Row(CellType.BodyCell.empty, CellType.BodyCell.empty),
+        Row(CellType.BodyCell.empty, CellType.BodyCell.empty)
       )
     )
   }
@@ -165,7 +165,10 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
     run(
       input,
       Table(
-        Row(BodyCell("a"), BodyCell(p("Text"), BulletList("Line1\nLine2", "Line3"))),
+        Row(
+          CellType.BodyCell("a"),
+          CellType.BodyCell(p("Text"), BulletList("Line1\nLine2", "Line3"))
+        ),
         textRow("c", "d")
       )
     )
@@ -180,7 +183,7 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
     run(
       input,
       Table(
-        TableHead(List(Row(HeadCell("a"), HeadCell("b")))),
+        TableHead(List(Row(CellType.HeadCell("a"), CellType.HeadCell("b")))),
         TableBody(List(textRow("c", "d")))
       )
     )
@@ -219,8 +222,8 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
     run(
       input,
       Table(
-        Row(BodyCell("a"), BodyCell.empty),
-        Row(BodyCell("c"), BodyCell.empty)
+        Row(CellType.BodyCell("a"), CellType.BodyCell.empty),
+        Row(CellType.BodyCell("c"), CellType.BodyCell.empty)
       )
     )
   }
@@ -239,7 +242,10 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
     run(
       input,
       Table(
-        Row(BodyCell("a"), BodyCell(p("Text"), BulletList("Line1\nLine2", "Line3"))),
+        Row(
+          CellType.BodyCell("a"),
+          CellType.BodyCell(p("Text"), BulletList("Line1\nLine2", "Line3"))
+        ),
         textRow("c", "d")
       )
     )
@@ -254,7 +260,7 @@ class TableParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
     run(
       input,
       Table(
-        TableHead(List(Row(HeadCell("a"), HeadCell("b")))),
+        TableHead(List(Row(CellType.HeadCell("a"), CellType.HeadCell("b")))),
         TableBody(List(textRow("c", "d")))
       )
     )

--- a/core/shared/src/test/scala/laika/internal/rst/bundle/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/bundle/RewriteRulesSpec.scala
@@ -17,7 +17,7 @@
 package laika.internal.rst.bundle
 
 import laika.api.builder.OperationConfig
-import laika.ast._
+import laika.ast.*
 import laika.ast.sample.ParagraphCompanionShortcuts
 import laika.api.config.Config.ConfigResult
 import laika.format.ReStructuredText
@@ -27,7 +27,7 @@ import laika.internal.rst.ast.{
   SubstitutionDefinition,
   SubstitutionReference
 }
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import munit.FunSuite
 
 class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts {
@@ -41,14 +41,14 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts {
       .map(_.content)
   }
 
-  def invalidSpan(message: String): InvalidSpan = InvalidSpan(message, GeneratedSource)
+  def invalidSpan(message: String): InvalidSpan = InvalidSpan(message, SourceCursor.Generated)
 
   def run(input: RootElement, expected: RootElement)(implicit loc: munit.Location): Unit =
     assertEquals(rewritten(input), Right(expected))
 
   test("substitutions - replace a single reference with the target span") {
     val input    = RootElement(
-      p(SubstitutionReference("id", GeneratedSource)),
+      p(SubstitutionReference("id", SourceCursor.Generated)),
       SubstitutionDefinition("id", Text("subst"))
     )
     val expected = RootElement(p("subst"))
@@ -60,9 +60,9 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts {
   ) {
     val input    = RootElement(
       p(
-        SubstitutionReference("id", GeneratedSource),
+        SubstitutionReference("id", SourceCursor.Generated),
         Text(" foo "),
-        SubstitutionReference("id", GeneratedSource)
+        SubstitutionReference("id", SourceCursor.Generated)
       ),
       SubstitutionDefinition("id", Text("subst"))
     )
@@ -72,7 +72,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts {
 
   test("substitutions - replace a reference with an unknown substitution id with an invalid span") {
     val input    = RootElement(
-      p(SubstitutionReference("id1", GeneratedSource)),
+      p(SubstitutionReference("id1", SourceCursor.Generated)),
       SubstitutionDefinition("id2", Text("subst"))
     )
     val expected = RootElement(p(invalidSpan("unknown substitution id: id1")))
@@ -83,7 +83,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts {
     "interpreted text roles - replace a single reference with the result of applying the role function"
   ) {
     val input    = RootElement(
-      p(InterpretedText("id", "foo", GeneratedSource)),
+      p(InterpretedText("id", "foo", SourceCursor.Generated)),
       CustomizedTextRole("id", s => Text(s":$s:"))
     )
     val expected = RootElement(p(":foo:"))
@@ -95,9 +95,9 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts {
   ) {
     val input    = RootElement(
       p(
-        InterpretedText("id1", "foo", GeneratedSource),
-        InterpretedText("id2", "bar", GeneratedSource),
-        InterpretedText("id1", "baz", GeneratedSource)
+        InterpretedText("id1", "foo", SourceCursor.Generated),
+        InterpretedText("id2", "bar", SourceCursor.Generated),
+        InterpretedText("id1", "baz", SourceCursor.Generated)
       ),
       CustomizedTextRole("id1", s => Text(":" + s + ":")),
       CustomizedTextRole("id2", s => Text(s".$s."))
@@ -108,7 +108,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts {
 
   test("interpreted text roles - replace an unknown text role with an invalid span") {
     val input    = RootElement(
-      p(InterpretedText("id1", "foo", GeneratedSource)),
+      p(InterpretedText("id1", "foo", SourceCursor.Generated)),
       CustomizedTextRole("id2", s => Text(s".$s."))
     )
     val expected = RootElement(p(invalidSpan("unknown text role: id1")))

--- a/core/shared/src/test/scala/laika/internal/rst/ext/DirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/ext/DirectiveSpec.scala
@@ -585,7 +585,7 @@ class DirectiveSpec extends FunSuite with ParagraphCompanionShortcuts with TestS
 
   val docWithTextRoles: Parser[RootElement] = defaultParser.map { root =>
     root.rewriteBlocks { case CustomizedTextRole(name, f, _) =>
-      Replace(p(f(name)))
+      RewriteAction.Replace(p(f(name)))
     }
   }
 

--- a/core/shared/src/test/scala/laika/internal/rst/std/StandardBlockDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/std/StandardBlockDirectivesSpec.scala
@@ -24,6 +24,7 @@ import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
 import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, SampleTrees }
+import laika.ast.CellType.BodyCell
 import laika.config.LaikaKeys
 import laika.api.config.ConfigValue.{ ObjectValue, StringValue }
 import laika.format.{ AST, HTML, ReStructuredText }

--- a/core/shared/src/test/scala/laika/internal/rst/std/StandardBlockDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/std/StandardBlockDirectivesSpec.scala
@@ -58,8 +58,9 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
           .document
           .content
           .rewriteBlocks({ case _: Hidden with Block =>
-            Remove
-          }) // removing the noise of rst TextRoles which are not the focus of this spec
+            RewriteAction.Remove
+          })
+          // removing the noise of rst TextRoles which are not the focus of this spec
       )
 
     assertEquals(res, Right(RootElement(expected)))

--- a/core/shared/src/test/scala/laika/internal/rst/std/StandardBlockDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/std/StandardBlockDirectivesSpec.scala
@@ -29,7 +29,7 @@ import laika.config.LaikaKeys
 import laika.api.config.ConfigValue.{ ObjectValue, StringValue }
 import laika.format.{ AST, HTML, ReStructuredText }
 import laika.internal.rst.ast.{ Contents, Include, RstStyle }
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import laika.internal.rewrite.ReferenceResolver.CursorKeys
 import munit.FunSuite
 
@@ -615,13 +615,14 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
 
   test("include - creates a placeholder in the document") {
     val input = """.. include:: other.rst"""
-    runRaw(input, Include("other.rst", GeneratedSource))
+    runRaw(input, Include("other.rst", SourceCursor.Generated))
   }
 
   test("include rewriter replaces the node with the corresponding document") {
-    val ref = TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+    val ref  =
+      TemplateContextReference(CursorKeys.documentContent, required = true, SourceCursor.Generated)
     val tree = SampleTrees.twoDocuments
-      .doc1.content(Include("doc-2", GeneratedSource))
+      .doc1.content(Include("doc-2", SourceCursor.Generated))
       .doc2.content(p("text"))
       .root.template(DefaultTemplatePath.forHTML.name, ref)
       .build
@@ -688,7 +689,7 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
     val input = """.. contents:: This is the title
                   | :depth: 3
                   | :local: true""".stripMargin
-    val elem  = Contents("This is the title", GeneratedSource, depth = 3, local = true)
+    val elem  = Contents("This is the title", SourceCursor.Generated, depth = 3, local = true)
     runRaw(input, elem)
   }
 
@@ -708,7 +709,7 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
 
     val sectionsWithTitle = RootElement(
       header(1, 1, "title") ::
-        Contents("This is the title", GeneratedSource, 3) ::
+        Contents("This is the title", SourceCursor.Generated, 3) ::
         header(2, 2) ::
         header(3, 3) ::
         header(2, 4) ::
@@ -734,7 +735,11 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
     val template = TemplateDocument(
       DefaultTemplatePath.forHTML,
       TemplateRoot(
-        TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+        TemplateContextReference(
+          CursorKeys.documentContent,
+          required = true,
+          SourceCursor.Generated
+        )
       )
     )
     val tree     = DocumentTree.builder.addDocument(document).addTemplate(template).build

--- a/core/shared/src/test/scala/laika/internal/rst/std/StandardSpanDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/std/StandardSpanDirectivesSpec.scala
@@ -158,7 +158,7 @@ class StandardSpanDirectivesSpec extends FunSuite with ParagraphCompanionShortcu
      */
     def stripMinutesAndSeconds(root: RootElement): RootElement =
       root.rewriteSpans { case Text(str, opt) =>
-        Replace(Text(str.replaceFirst("[:]\\d\\d:\\d\\d", ":00:00"), opt))
+        RewriteAction.Replace(Text(str.replaceFirst("[:]\\d\\d:\\d\\d", ":00:00"), opt))
       }
 
     val format = "yyyy-MM-dd HH:mm:ss"

--- a/core/shared/src/test/scala/laika/markdown/BlockParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/BlockParsersSpec.scala
@@ -84,7 +84,7 @@ class BlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
     val input = """+ aaa
                   |+ bbb
                   |+ ccc""".stripMargin
-    run(input, BulletList(StringBullet("+"))("aaa", "bbb", "ccc"))
+    run(input, BulletList(BulletFormat.StringBullet("+"))("aaa", "bbb", "ccc"))
   }
 
   test(
@@ -93,7 +93,7 @@ class BlockParsersSpec extends FunSuite with ParagraphCompanionShortcuts {
     val input = """- aaa
                   |- bbb
                   |- ccc""".stripMargin
-    run(input, BulletList(StringBullet("-"))("aaa", "bbb", "ccc"))
+    run(input, BulletList(BulletFormat.StringBullet("-"))("aaa", "bbb", "ccc"))
   }
 
   test("bullet lists - items prefixed by numbers as items of an enumerated list") {

--- a/core/shared/src/test/scala/laika/markdown/GitHubFlavorSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/GitHubFlavorSpec.scala
@@ -239,7 +239,7 @@ class GitHubFlavorSpec extends FunSuite with ParagraphCompanionShortcuts {
         |    code
         |    ~~~
       """.stripMargin
-    val result = BulletList(StringBullet("-"))(
+    val result = BulletList(BulletFormat.StringBullet("-"))(
       Seq(
         Paragraph("list item:"),
         CodeBlock("foo", Seq(Text("code\n  indent\ncode")))

--- a/core/shared/src/test/scala/laika/markdown/GitHubFlavorSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/GitHubFlavorSpec.scala
@@ -35,18 +35,18 @@ class GitHubFlavorSpec extends FunSuite with ParagraphCompanionShortcuts {
   val defaultParser: Parser[RootElement] = rootParser.rootElement
 
   def headerRow(cells: String*): TableHead =
-    TableHead(Seq(Row(cells.map(c => HeadCell(c)))))
+    TableHead(Seq(Row(cells.map(c => CellType.HeadCell(c)))))
 
   def bodyRow(cells: String*): Row =
-    Row(cells.map(c => BodyCell(c)))
+    Row(cells.map(c => CellType.BodyCell(c)))
 
   def paddedBodyRow(count: Int, cells: String*): Row = {
-    val cellsWithText = bodyRow(cells: _*).content
-    Row(cellsWithText.padTo(count, BodyCell.empty))
+    val cellsWithText = bodyRow(cells *).content
+    Row(cellsWithText.padTo(count, CellType.BodyCell.empty))
   }
 
   def bodyRowSpans(cells: Seq[Span]*): Row =
-    Row(cells.map(c => BodyCell(Paragraph(c))))
+    Row(cells.map(c => CellType.BodyCell(Paragraph(c))))
 
   def runBlocks(input: String, blocks: Block*)(implicit loc: munit.Location): Unit =
     assertEquals(defaultParser.parse(input).toEither, Right(RootElement(blocks)))

--- a/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
+++ b/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
@@ -31,7 +31,7 @@ import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.ast.styles.StyleDeclarationSet
 import laika.config.{ MessageFilter, MessageFilters, TargetFormats, Version, Versions }
 import laika.format.HTML
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import laika.parse.code.CodeCategory
 import munit.FunSuite
 
@@ -806,7 +806,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   test("render an invalid block without the runtime message in default mode") {
     val elem = InvalidBlock(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       p("fallback")
     )
     val html = "<p>fallback</p>"
@@ -818,7 +818,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   ) {
     val elem = InvalidBlock(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       p("fallback")
     )
     val html = "<p>fallback</p>"
@@ -830,7 +830,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   ) {
     val elem = InvalidBlock(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       p("fallback")
     )
     val html = """<p><span class="runtime-message warning">some message</span></p><p>fallback</p>"""
@@ -840,7 +840,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   test("render an invalid span without the runtime message in default mode") {
     val elem = InvalidSpan(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       Text("fallback")
     )
     run(elem, "fallback")
@@ -851,7 +851,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   ) {
     val elem = InvalidSpan(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       Text("fallback")
     )
     runWithFilter(elem, MessageFilter.Error, "fallback")
@@ -862,7 +862,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   ) {
     val elem = InvalidSpan(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       Text("fallback")
     )
     val html = """<span class="runtime-message warning">some message</span> fallback"""

--- a/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
+++ b/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
@@ -625,7 +625,7 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   test(
     "render a paragraph containing an internal link while ignoring the restricted type parameter"
   ) {
-    val target = ResolvedInternalTarget(
+    val target = InternalTarget.Resolved(
       Path.parse("/doc.html#foo"),
       RelativePath.parse("#foo"),
       TargetFormats.Selected("html")

--- a/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
+++ b/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
@@ -25,6 +25,7 @@ import laika.api.bundle.{
   TranslatorConfig
 }
 import laika.ast.Path.Root
+import laika.ast.CellType.BodyCell
 import laika.ast.*
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.ast.styles.StyleDeclarationSet

--- a/core/shared/src/test/scala/laika/rewrite/LinkValidatorSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/LinkValidatorSpec.scala
@@ -120,7 +120,7 @@ class LinkValidatorSpec extends FunSuite {
     val relPath  = absPath.relativeTo(Root / "tree-2" / "doc-6.md")
     val expected = RecoveredTarget(
       msg(relPath.toString),
-      ResolvedInternalTarget(absPath, relPath, TargetFormats.Selected("html"))
+      InternalTarget.Resolved(absPath, relPath, TargetFormats.Selected("html"))
     )
     val config   = LinkValidation.Global()
     assertEquals(testCursor(config).validate(testTarget("../tree-1/doc-4.md")), expected)
@@ -131,7 +131,7 @@ class LinkValidatorSpec extends FunSuite {
     val relPath  = absPath.relativeTo(Root / "tree-2" / "doc-6.md")
     val expected = RecoveredTarget(
       msg(relPath.toString),
-      ResolvedInternalTarget(absPath, relPath, TargetFormats.Selected("html"))
+      InternalTarget.Resolved(absPath, relPath, TargetFormats.Selected("html"))
     )
     val config   = LinkValidation.Global()
     assertEquals(testCursor(config).validate(testTarget("../static-2/doc-8.txt")), expected)
@@ -156,7 +156,7 @@ class LinkValidatorSpec extends FunSuite {
     val absPath         = Path.parse("/tree-1/doc-4.md")
     val relPath         = absPath.relativeTo(Root / "tree-2" / "doc-6.md")
     val link            = SpanLink.internal(relPath)("text")
-    val recoveredTarget = ResolvedInternalTarget(absPath, relPath, TargetFormats.Selected("html"))
+    val recoveredTarget = InternalTarget.Resolved(absPath, relPath, TargetFormats.Selected("html"))
     assertEquals(testCursor(config).validate(link), Right(link.copy(target = recoveredTarget)))
   }
 

--- a/core/shared/src/test/scala/laika/rewrite/PathTranslatorSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/PathTranslatorSpec.scala
@@ -73,15 +73,18 @@ class PathTranslatorSpec extends FunSuite {
   )
 
   test("between two unversioned documents") {
-    val input    = ResolvedInternalTarget(Root / "doc-2.md", CurrentTree / "doc-2.md")
-    val expected = ResolvedInternalTarget(Root / "doc-2.html", CurrentTree / "doc-2.html")
+    val input    = InternalTarget.Resolved(Root / "doc-2.md", CurrentTree / "doc-2.md")
+    val expected = InternalTarget.Resolved(Root / "doc-2.html", CurrentTree / "doc-2.html")
     assertEquals(unversionedRef.translate(input), expected)
   }
 
   test("between two versioned documents") {
     val input    =
-      ResolvedInternalTarget(Root / "tree-2" / "doc-5.md", RelativePath.parse("../tree-2/doc-5.md"))
-    val expected = ResolvedInternalTarget(
+      InternalTarget.Resolved(
+        Root / "tree-2" / "doc-5.md",
+        RelativePath.parse("../tree-2/doc-5.md")
+      )
+    val expected = InternalTarget.Resolved(
       Root / "0.42" / "tree-2" / "doc-5.html",
       RelativePath.parse("../tree-2/doc-5.html")
     )
@@ -89,16 +92,16 @@ class PathTranslatorSpec extends FunSuite {
   }
 
   test("versioned to unversioned document") {
-    val input    = ResolvedInternalTarget(Root / "doc-2.md", RelativePath.parse("../doc-2.md"))
+    val input    = InternalTarget.Resolved(Root / "doc-2.md", RelativePath.parse("../doc-2.md"))
     val expected =
-      ResolvedInternalTarget(Root / "doc-2.html", RelativePath.parse("../../doc-2.html"))
+      InternalTarget.Resolved(Root / "doc-2.html", RelativePath.parse("../../doc-2.html"))
     assertEquals(versionedRef.translate(input), expected)
   }
 
   test("unversioned to versioned document") {
     val input    =
-      ResolvedInternalTarget(Root / "tree-2" / "doc-5.md", RelativePath.parse("tree-2/doc-5.md"))
-    val expected = ResolvedInternalTarget(
+      InternalTarget.Resolved(Root / "tree-2" / "doc-5.md", RelativePath.parse("tree-2/doc-5.md"))
+    val expected = InternalTarget.Resolved(
       Root / "0.42" / "tree-2" / "doc-5.html",
       RelativePath.parse("0.42/tree-2/doc-5.html")
     )
@@ -106,11 +109,11 @@ class PathTranslatorSpec extends FunSuite {
   }
 
   test("static unversioned document") {
-    val input    = ResolvedInternalTarget(
+    val input    = InternalTarget.Resolved(
       Root / "static-1" / "doc-7.txt",
       RelativePath.parse("../static-1/doc-7.txt")
     )
-    val expected = ResolvedInternalTarget(
+    val expected = InternalTarget.Resolved(
       Root / "static-1" / "doc-7.txt",
       RelativePath.parse("../../static-1/doc-7.txt")
     )
@@ -118,11 +121,11 @@ class PathTranslatorSpec extends FunSuite {
   }
 
   test("static versioned document") {
-    val input    = ResolvedInternalTarget(
+    val input    = InternalTarget.Resolved(
       Root / "static-2" / "doc-8.txt",
       RelativePath.parse("../static-2/doc-8.txt")
     )
-    val expected = ResolvedInternalTarget(
+    val expected = InternalTarget.Resolved(
       Root / "0.42" / "static-2" / "doc-8.txt",
       RelativePath.parse("../static-2/doc-8.txt")
     )
@@ -131,8 +134,11 @@ class PathTranslatorSpec extends FunSuite {
 
   test("ignore versions when output format is not HTML") {
     val input    =
-      ResolvedInternalTarget(Root / "tree-2" / "doc-5.md", RelativePath.parse("../tree-2/doc-5.md"))
-    val expected = ResolvedInternalTarget(
+      InternalTarget.Resolved(
+        Root / "tree-2" / "doc-5.md",
+        RelativePath.parse("../tree-2/doc-5.md")
+      )
+    val expected = InternalTarget.Resolved(
       Root / "tree-2" / "doc-5.fo",
       RelativePath.parse("../tree-2/doc-5.fo")
     )
@@ -140,7 +146,7 @@ class PathTranslatorSpec extends FunSuite {
   }
 
   test("apply versions when substituting an internal target with an external one") {
-    val input    = ResolvedInternalTarget(
+    val input    = InternalTarget.Resolved(
       Root / "tree-2" / "doc-5.md",
       RelativePath.parse("../tree-2/doc-5.md"),
       TargetFormats.Selected("html")

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -30,7 +30,7 @@ import laika.ast.sample.{
 }
 import laika.api.config.Config.ConfigResult
 import laika.config.{ LaikaKeys, LinkConfig, TargetDefinition, TargetFormats }
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import munit.FunSuite
 
 class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with TestSourceBuilders {
@@ -52,10 +52,10 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     InvalidSpan(message, source(fallback, fallback))
 
   def invalidBlock(message: String, fallback: Block): InvalidBlock =
-    InvalidBlock(RuntimeMessage(MessageLevel.Error, message), GeneratedSource, fallback)
+    InvalidBlock(RuntimeMessage(MessageLevel.Error, message), SourceCursor.Generated, fallback)
 
   def invalidSpan(message: String, fallback: Span): InvalidSpan =
-    InvalidSpan(RuntimeMessage(MessageLevel.Error, message), GeneratedSource, fallback)
+    InvalidSpan(RuntimeMessage(MessageLevel.Error, message), SourceCursor.Generated, fallback)
 
   def fnRefs(labels: FootnoteLabel*): Paragraph = Paragraph(labels.map { label =>
     FootnoteReference(label, generatedSource(toSource(label)))
@@ -66,7 +66,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   }: _*)
 
   def fn(label: FootnoteLabel, num: Any) =
-    FootnoteDefinition(label, List(p(s"footnote$num")), GeneratedSource)
+    FootnoteDefinition(label, List(p(s"footnote$num")), SourceCursor.Generated)
 
   def fn(id: String, label: String) = Footnote(label, List(p(s"footnote$label")), Id(id))
 
@@ -465,7 +465,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   test("internal links - resolve internal link references to an image") {
     val relPath    = Parent(1) / "images" / "frog.jpg"
     val absPath    = Root / "images" / "frog.jpg"
-    val imgPathRef = ImagePathReference(relPath, GeneratedSource, alt = Some("text"))
+    val imgPathRef = ImagePathReference(relPath, SourceCursor.Generated, alt = Some("text"))
     val target     = InternalTarget(relPath).relativeTo(refPath)
 
     InternalLinks.run(

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -150,10 +150,10 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     "footnote rules - retain a group of footnotes with a mix of explicit numeric and autonumber labels"
   ) {
     val rootElem = RootElement(
-      fnRefs(Autonumber, NumericLabel(1), Autonumber),
-      fn(Autonumber, 1),
-      fn(NumericLabel(1), 1),
-      fn(Autonumber, 2)
+      fnRefs(FootnoteLabel.Autonumber, FootnoteLabel.NumericLabel(1), FootnoteLabel.Autonumber),
+      fn(FootnoteLabel.Autonumber, 1),
+      fn(FootnoteLabel.NumericLabel(1), 1),
+      fn(FootnoteLabel.Autonumber, 2)
     )
     val resolved = RootElement(
       fnLinks(("__fn-1", "1"), ("__fnl-1", "1"), ("__fn-2", "2")),
@@ -168,10 +168,14 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     "footnote rules - retain a group of footnotes with a mix of explicit numeric, autonumber and autonumber-labeled footnotes"
   ) {
     val rootElem = RootElement(
-      fnRefs(NumericLabel(2), Autonumber, AutonumberLabel("label")),
-      fn(NumericLabel(2), 2),
-      fn(AutonumberLabel("label"), 1),
-      fn(Autonumber, 2)
+      fnRefs(
+        FootnoteLabel.NumericLabel(2),
+        FootnoteLabel.Autonumber,
+        FootnoteLabel.AutonumberLabel("label")
+      ),
+      fn(FootnoteLabel.NumericLabel(2), 2),
+      fn(FootnoteLabel.AutonumberLabel("label"), 1),
+      fn(FootnoteLabel.Autonumber, 2)
     )
     val resolved = RootElement(
       fnLinks(("__fnl-2", "2"), ("__fn-2", "2"), ("label", "1")),
@@ -184,10 +188,10 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
   test("footnote rules - retain a group of footnotes with autosymbol labels") {
     val rootElem = RootElement(
-      fnRefs(Autosymbol, Autosymbol, Autosymbol),
-      fn(Autosymbol, "*"),
-      fn(Autosymbol, "\u2020"),
-      fn(Autosymbol, "\u2021")
+      fnRefs(FootnoteLabel.Autosymbol, FootnoteLabel.Autosymbol, FootnoteLabel.Autosymbol),
+      fn(FootnoteLabel.Autosymbol, "*"),
+      fn(FootnoteLabel.Autosymbol, "\u2020"),
+      fn(FootnoteLabel.Autosymbol, "\u2021")
     )
     val resolved = RootElement(
       fnLinks(("__fns-1", "*"), ("__fns-2", "\u2020"), ("__fns-3", "\u2021")),
@@ -202,9 +206,9 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     "footnote rules - replace references with unresolvable autonumber or numeric labels with invalid spans"
   ) {
     val rootElem = RootElement(
-      fnRefs(NumericLabel(2), AutonumberLabel("labelA")),
-      fn(NumericLabel(3), 3),
-      fn(AutonumberLabel("labelB"), 1)
+      fnRefs(FootnoteLabel.NumericLabel(2), FootnoteLabel.AutonumberLabel("labelA")),
+      fn(FootnoteLabel.NumericLabel(3), 3),
+      fn(FootnoteLabel.AutonumberLabel("labelB"), 1)
     )
     val resolved = RootElement(
       p(
@@ -218,7 +222,10 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   }
 
   test("footnote rules - replace surplus autonumber references with invalid spans") {
-    val rootElem = RootElement(fnRefs(Autonumber, Autonumber), fn(Autonumber, 1))
+    val rootElem = RootElement(
+      fnRefs(FootnoteLabel.Autonumber, FootnoteLabel.Autonumber),
+      fn(FootnoteLabel.Autonumber, 1)
+    )
     val resolved = RootElement(
       p(FootnoteLink("__fn-1", "1"), invalidSpan("too many autonumber references", "[#]_")),
       fn("__fn-1", "1")
@@ -227,7 +234,10 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   }
 
   test("footnote rules - replace surplus autosymbol references with invalid spans") {
-    val rootElem = RootElement(fnRefs(Autosymbol, Autosymbol), fn(Autosymbol, "*"))
+    val rootElem = RootElement(
+      fnRefs(FootnoteLabel.Autosymbol, FootnoteLabel.Autosymbol),
+      fn(FootnoteLabel.Autosymbol, "*")
+    )
     val resolved = RootElement(
       p(FootnoteLink("__fns-1", "*"), invalidSpan("too many autosymbol references", "[*]_")),
       fn("__fns-1", "*")

--- a/core/shared/src/test/scala/laika/rewrite/RewriteSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteSpec.scala
@@ -18,6 +18,7 @@ package laika.rewrite
 
 import laika.ast._
 import laika.ast.CellType.BodyCell
+import laika.ast.RewriteAction.Replace
 import laika.ast.sample.ParagraphCompanionShortcuts
 import munit.FunSuite
 
@@ -47,21 +48,27 @@ class RewriteSpec extends FunSuite with ParagraphCompanionShortcuts {
   test("remove the first element of the children in a container") {
     val input    = RootElement(p("a"), p("b"), p("c"))
     val expected = RootElement(p("b"), p("c"))
-    val actual   = input.rewriteBlocks { case Paragraph(Seq(Text("a", _)), _) => Remove }
+    val actual   = input.rewriteBlocks { case Paragraph(Seq(Text("a", _)), _) =>
+      RewriteAction.Remove
+    }
     assertEquals(actual, expected)
   }
 
   test("remove an element in the middle of the list of children in a container") {
     val input    = RootElement(p("a"), p("b"), p("c"))
     val expected = RootElement(p("a"), p("c"))
-    val actual   = input.rewriteBlocks { case Paragraph(Seq(Text("b", _)), _) => Remove }
+    val actual   = input.rewriteBlocks { case Paragraph(Seq(Text("b", _)), _) =>
+      RewriteAction.Remove
+    }
     assertEquals(actual, expected)
   }
 
   test("remove the last element of the children in a container") {
     val input    = RootElement(p("a"), p("b"), p("c"))
     val expected = RootElement(p("a"), p("b"))
-    val actual   = input.rewriteBlocks { case Paragraph(Seq(Text("c", _)), _) => Remove }
+    val actual   = input.rewriteBlocks { case Paragraph(Seq(Text("c", _)), _) =>
+      RewriteAction.Remove
+    }
     assertEquals(actual, expected)
   }
 
@@ -99,7 +106,7 @@ class RewriteSpec extends FunSuite with ParagraphCompanionShortcuts {
   test("rewrite main content and attribution in a QuotedBlock") {
     val before   = RootElement(QuotedBlock(Seq(p("a"), p("b")), Seq(Text("a"), Text("c"))))
     val expected = RootElement(QuotedBlock(Seq(Paragraph.empty, p("b")), Seq(Text("c"))))
-    val after    = before.rewriteSpans { case Text("a", _) => Remove }
+    val after    = before.rewriteSpans { case Text("a", _) => RewriteAction.Remove }
     assertEquals(after, expected)
   }
 

--- a/core/shared/src/test/scala/laika/rewrite/RewriteSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteSpec.scala
@@ -17,6 +17,7 @@
 package laika.rewrite
 
 import laika.ast._
+import laika.ast.CellType.BodyCell
 import laika.ast.sample.ParagraphCompanionShortcuts
 import munit.FunSuite
 

--- a/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
@@ -22,7 +22,7 @@ import laika.ast.Path.Root
 import laika.ast.sample.{ BuilderKey, DocumentTreeAssertions, SampleTrees }
 import laika.api.config.Config.ConfigResult
 import laika.api.config.{ ConfigParser, Origin }
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import munit.FunSuite
 
 class SectionNumberSpec extends FunSuite with DocumentTreeAssertions {
@@ -114,7 +114,7 @@ class SectionNumberSpec extends FunSuite with DocumentTreeAssertions {
   trait SectionsWithConfigError extends TreeModel {
 
     override def resultContent(docNum: List[Int]): List[Block] = List(
-      InvalidBlock("Invalid value for autonumbering.scope: xxx", GeneratedSource),
+      InvalidBlock("Invalid value for autonumbering.scope: xxx", SourceCursor.Generated),
       Title(numberedHeader(1, 1, docNum, "title").content, Id("title-1") + Style.title),
       numberedSection(2, 2, docNum :+ 1, numberedSection(3, 3, docNum :+ 1 :+ 1)),
       numberedSection(2, 4, docNum :+ 2, numberedSection(3, 5, docNum :+ 2 :+ 1))

--- a/docs/src/04-customizing-laika/04-document-ast.md
+++ b/docs/src/04-customizing-laika/04-document-ast.md
@@ -345,7 +345,7 @@ If you create a custom element type you can use these base traits to get all the
 ```scala mdoc
 import laika.ast._
 
-case class MyElement(content: Seq[Block], options: Options = NoOpt) extends Block
+case class MyElement(content: Seq[Block], options: Options = Options.empty) extends Block
     with BlockContainer {
   type Self = MyElement
   def withContent(newContent: Seq[Block]): MyElement = copy(content = newContent)

--- a/docs/src/04-customizing-laika/05-ast-rewriting.md
+++ b/docs/src/04-customizing-laika/05-ast-rewriting.md
@@ -60,7 +60,7 @@ import laika.sbt.LaikaPlugin.autoImport._
 import laika.ast._
 
 laikaExtensions += laikaSpanRewriteRule { 
-  case Emphasized(content, opts) => Replace(Strong(content, opts))
+  case Emphasized(content, opts) => RewriteAction.Replace(Strong(content, opts))
 }
 ```
 
@@ -82,7 +82,7 @@ val transformer = Transformer
   .from(ReStructuredText)
   .to(HTML)
   .usingSpanRule {
-    case Emphasized(content, opts) => Replace(Strong(content, opts))
+    case Emphasized(content, opts) => RewriteAction.Replace(Strong(content, opts))
   }.build
 ```
 
@@ -105,7 +105,7 @@ import laika.ast._
 def doc: Document = ??? // obtained through the Parser API
 
 val newDoc = doc.rewrite(RewriteRules.forSpans {
-  case Emphasized(content, opts) => Replace(Strong(content, opts))
+  case Emphasized(content, opts) => RewriteAction.Replace(Strong(content, opts))
 })
 ```
 
@@ -118,8 +118,8 @@ import laika.ast._
 def doc: Document = ??? // obtained through the Parser API
 
 val newDoc = doc.rewrite(RewriteRules.forBlocks {
-  case h: Header => Replace(h.rewriteSpans {
-    case Emphasized(content, opts) => Replace(Strong(content, opts))
+  case h: Header => RewriteAction.Replace(h.rewriteSpans {
+    case Emphasized(content, opts) => RewriteAction.Replace(Strong(content, opts))
   })
 })
 ```

--- a/docs/src/05-extending-laika/04-writing-parser-extensions.md
+++ b/docs/src/05-extending-laika/04-writing-parser-extensions.md
@@ -173,7 +173,7 @@ import laika.parse.SourceFragment
 
 case class TicketResolver (num: String, 
                            source: SourceFragment, 
-                           options: Options = NoOpt) extends SpanResolver {
+                           options: Options = Options.empty) extends SpanResolver {
 
   type Self = TicketResolver
 

--- a/io/src/main/scala/laika/helium/config/ThemeLink.scala
+++ b/io/src/main/scala/laika/helium/config/ThemeLink.scala
@@ -71,7 +71,7 @@ sealed abstract case class IconLink(
     target: Target,
     icon: Icon,
     text: Option[String] = None,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends SingleTargetLink {
   type Self = IconLink
 
@@ -96,7 +96,7 @@ object IconLink {
       url: String,
       icon: Icon,
       text: Option[String] = None,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ): IconLink =
     new IconLink(ExternalTarget(url), icon, text, options) {}
 
@@ -105,7 +105,7 @@ object IconLink {
       path: Path,
       icon: Icon,
       text: Option[String] = None,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ): IconLink =
     new IconLink(InternalTarget(path), icon, text, options) {}
 
@@ -117,7 +117,7 @@ sealed abstract case class ButtonLink(
     target: Target,
     text: String,
     icon: Option[Icon] = None,
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends SingleTargetLink {
   type Self = ButtonLink
 
@@ -136,7 +136,7 @@ object ButtonLink {
       url: String,
       text: String,
       icon: Option[Icon] = None,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ): ButtonLink =
     new ButtonLink(ExternalTarget(url), text, icon, options) {}
 
@@ -145,7 +145,7 @@ object ButtonLink {
       path: Path,
       text: String,
       icon: Option[Icon] = None,
-      options: Options = NoOpt
+      options: Options = Options.empty
   ): ButtonLink =
     new ButtonLink(InternalTarget(path), text, icon, options) {}
 
@@ -153,7 +153,7 @@ object ButtonLink {
 
 /** A simple text link.
   */
-sealed abstract case class TextLink(target: Target, text: String, options: Options = NoOpt)
+sealed abstract case class TextLink(target: Target, text: String, options: Options = Options.empty)
     extends SingleTargetLink {
   type Self = TextLink
 
@@ -166,18 +166,18 @@ sealed abstract case class TextLink(target: Target, text: String, options: Optio
 object TextLink {
 
   /** Creates a simple text link to an external target. */
-  def external(url: String, text: String, options: Options = NoOpt): TextLink =
+  def external(url: String, text: String, options: Options = Options.empty): TextLink =
     new TextLink(ExternalTarget(url), text, options) {}
 
   /** Creates a simple text link to an internal target. */
-  def internal(path: Path, text: String, options: Options = NoOpt): TextLink =
+  def internal(path: Path, text: String, options: Options = Options.empty): TextLink =
     new TextLink(InternalTarget(path), text, options) {}
 
 }
 
 /** A simple image link.
   */
-sealed abstract case class ImageLink(target: Target, image: Image, options: Options = NoOpt)
+sealed abstract case class ImageLink(target: Target, image: Image, options: Options = Options.empty)
     extends SingleTargetLink {
   type Self = ImageLink
 
@@ -192,11 +192,11 @@ sealed abstract case class ImageLink(target: Target, image: Image, options: Opti
 object ImageLink {
 
   /** Creates a simple image link to an external target. */
-  def external(url: String, image: Image, options: Options = NoOpt): ImageLink =
+  def external(url: String, image: Image, options: Options = Options.empty): ImageLink =
     new ImageLink(ExternalTarget(url), image, options) {}
 
   /** Creates a simple image link to an internal target. */
-  def internal(path: Path, image: Image, options: Options = NoOpt): ImageLink =
+  def internal(path: Path, image: Image, options: Options = Options.empty): ImageLink =
     new ImageLink(InternalTarget(path), image, options) {}
 
 }
@@ -204,7 +204,7 @@ object ImageLink {
 /** A home link that inserts a link to the title page of the root document tree (if available)
   * or otherwise an invalid element.
   */
-final case class DynamicHomeLink(options: Options = NoOpt) extends ThemeLinkSpan {
+final case class DynamicHomeLink(options: Options = Options.empty) extends ThemeLinkSpan {
   type Self = DynamicHomeLink
 
   def resolve(cursor: DocumentCursor): Span = {
@@ -229,7 +229,7 @@ object DynamicHomeLink {
   *
   * Can be used to create structures like a row of icon links in a vertical column of text links.
   */
-sealed abstract case class LinkGroup(links: Seq[SingleTargetLink], options: Options = NoOpt)
+sealed abstract case class LinkGroup(links: Seq[SingleTargetLink], options: Options = Options.empty)
     extends ThemeLinkSpan with MultiTargetLink {
   type Self = LinkGroup
 
@@ -252,7 +252,7 @@ object LinkGroup {
 sealed abstract case class Menu(
     label: Seq[Span],
     links: Seq[SingleTargetLink],
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ThemeLinkBlock with MultiTargetLink {
   type Self = Menu
 
@@ -288,7 +288,7 @@ sealed abstract case class VersionMenu(
     versionedLabelPrefix: String,
     unversionedLabel: String,
     links: Seq[SingleTargetLink],
-    options: Options = NoOpt
+    options: Options = Options.empty
 ) extends ThemeLinkBlock with MultiTargetLink {
   type Self = VersionMenu
 

--- a/io/src/main/scala/laika/helium/config/ThemeLink.scala
+++ b/io/src/main/scala/laika/helium/config/ThemeLink.scala
@@ -21,13 +21,13 @@ import laika.ast.RelativePath.CurrentDocument
 import laika.ast.*
 import laika.config.{ LaikaKeys, Versions }
 import laika.helium.internal.config.HeliumStyles
-import laika.parse.{ GeneratedSource, SourceFragment }
+import laika.parse.{ SourceCursor, SourceFragment }
 
 /** A Helium link type available for navigation bars and the landing page.
   */
 sealed trait ThemeLink extends Unresolved {
 
-  val source: SourceFragment = GeneratedSource
+  val source: SourceFragment = SourceCursor.Generated
 
   type Self <: ThemeLink
 
@@ -214,7 +214,7 @@ final case class DynamicHomeLink(options: Options = Options.empty) extends Theme
       case None           =>
         val message =
           "No target for home link found - for options see 'Theme Settings / Top Navigation Bar' in the manual"
-        InvalidSpan(message, GeneratedSource)
+        InvalidSpan(message, SourceCursor.Generated)
     }
   }
 

--- a/io/src/main/scala/laika/helium/internal/builder/HeliumInputBuilder.scala
+++ b/io/src/main/scala/laika/helium/internal/builder/HeliumInputBuilder.scala
@@ -25,7 +25,7 @@ import laika.config.{ LaikaKeys, TargetFormats }
 import laika.helium.Helium
 import laika.helium.internal.generate.{ CSSVarGenerator, FOStyles, MergedCSSGenerator }
 import laika.io.model.{ InputTree, InputTreeBuilder }
-import laika.theme.config.{ EmbeddedFontFile, EmbeddedFontResource }
+import laika.theme.config.EmbeddedFont
 
 /** @author Jens Halm
   */
@@ -53,8 +53,8 @@ private[helium] object HeliumInputBuilder {
 
     val fontInputs = fontResources.foldLeft(InputTree[F]) { case (tree, embedResource) =>
       embedResource match {
-        case res: EmbeddedFontFile     => tree.addFile(res.file, res.path)
-        case res: EmbeddedFontResource => tree.addClassLoaderResource(res.name, res.path)
+        case res: EmbeddedFont.FontFile     => tree.addFile(res.file, res.path)
+        case res: EmbeddedFont.FontResource => tree.addClassLoaderResource(res.name, res.path)
       }
     }
 

--- a/io/src/main/scala/laika/helium/internal/builder/HeliumRenderOverrides.scala
+++ b/io/src/main/scala/laika/helium/internal/builder/HeliumRenderOverrides.scala
@@ -26,17 +26,18 @@ import laika.format.XSLFO.formatterSyntax.*
   */
 private[helium] object HeliumRenderOverrides {
 
-  case class Tabs(tabs: Seq[Tab], options: Options = NoOpt) extends Block {
+  case class Tabs(tabs: Seq[Tab], options: Options = Options.empty) extends Block {
     type Self = Tabs
     def withOptions(options: Options): Tabs = copy(options = options)
   }
 
-  case class Tab(name: String, label: String, options: Options = NoOpt) extends Span {
+  case class Tab(name: String, label: String, options: Options = Options.empty) extends Span {
     type Self = Tab
     def withOptions(options: Options): Tab = copy(options = options)
   }
 
-  case class TabContent(name: String, content: Seq[Block], options: Options = NoOpt) extends Block
+  case class TabContent(name: String, content: Seq[Block], options: Options = Options.empty)
+      extends Block
       with BlockContainer {
     type Self = TabContent
     def withOptions(options: Options): TabContent       = copy(options = options)

--- a/io/src/main/scala/laika/helium/internal/builder/HeliumRewriteRules.scala
+++ b/io/src/main/scala/laika/helium/internal/builder/HeliumRewriteRules.scala
@@ -48,8 +48,11 @@ private[helium] object HeliumRewriteRules {
       if (count <= helium.pdfSettings.layout.keepTogetherDecoratedLines) Some("pdf") else None
     val epub =
       if (count <= helium.epubSettings.layout.keepTogetherDecoratedLines) Some("epub") else None
-    if (pdf.isEmpty && epub.isEmpty) Retain
-    else Replace(block.mergeOptions(Style.keepTogether + Styles(pdf.toSet ++ epub.toSet)))
+    if (pdf.isEmpty && epub.isEmpty) RewriteAction.Retain
+    else
+      RewriteAction.Replace(
+        block.mergeOptions(Style.keepTogether + Styles(pdf.toSet ++ epub.toSet))
+      )
   }
 
   def build(helium: Helium): RewriteRules = RewriteRules.forBlocks {

--- a/io/src/main/scala/laika/helium/internal/config/layout.scala
+++ b/io/src/main/scala/laika/helium/internal/config/layout.scala
@@ -128,7 +128,7 @@ private[helium] case class LandingPage(
 
 /** In contrast to the public `LinkGroup` this UI component allows all types of links as children, including menus.
   */
-private[helium] case class GenericLinkGroup(links: Seq[ThemeLink], options: Options = NoOpt)
+private[helium] case class GenericLinkGroup(links: Seq[ThemeLink], options: Options = Options.empty)
     extends BlockResolver {
   type Self = GenericLinkGroup
   val source: SourceFragment = GeneratedSource

--- a/io/src/main/scala/laika/helium/internal/config/layout.scala
+++ b/io/src/main/scala/laika/helium/internal/config/layout.scala
@@ -3,7 +3,7 @@ package laika.helium.internal.config
 import laika.ast.Path.Root
 import laika.ast.*
 import laika.helium.config.*
-import laika.parse.{ GeneratedSource, SourceFragment }
+import laika.parse.{ SourceCursor, SourceFragment }
 
 private[helium] sealed trait CommonLayout {
   def defaultBlockSpacing: Length
@@ -131,7 +131,7 @@ private[helium] case class LandingPage(
 private[helium] case class GenericLinkGroup(links: Seq[ThemeLink], options: Options = Options.empty)
     extends BlockResolver {
   type Self = GenericLinkGroup
-  val source: SourceFragment = GeneratedSource
+  val source: SourceFragment = SourceCursor.Generated
 
   def resolve(cursor: DocumentCursor): Block = {
     val resolvedLinks = links.map {

--- a/io/src/main/scala/laika/io/internal/runtime/VersionedLinkTargets.scala
+++ b/io/src/main/scala/laika/io/internal/runtime/VersionedLinkTargets.scala
@@ -23,7 +23,7 @@ import cats.syntax.all.*
 import laika.internal.collection.TransitionalCollectionOps.*
 import laika.ast.DocumentType.{ Ignored, Static }
 import laika.ast.Path.Root
-import laika.ast.{ DocumentType, Path, SegmentedPath }
+import laika.ast.{ DocumentType, Path }
 import laika.api.config.Config.ConfigResult
 import laika.api.config.{ ConfigDecoder, ConfigParser }
 import laika.config.{ VersionScannerConfig, Versions }
@@ -52,17 +52,17 @@ private[runtime] object VersionedLinkTargets {
       !excluded.exists(ex => path.isSubPath(ex))
     }
     val docTypeMather: Path => DocumentType                            = {
-      case p @ SegmentedPath(segments, _, _) if included(p, segments) => Static()
+      case p @ Path.Segments(segments, _, _) if included(p, segments) => Static()
       case _                                                          => Ignored
     }
     val input = DirectoryInput(Seq(FilePath.parse(config.rootDirectory)), Codec.UTF8, docTypeMather)
     DirectoryScanner.scanDirectories(input).map { tree =>
       tree.binaryInputs.map(_.path)
         .collect {
-          case path: SegmentedPath if path.depth > 1 =>
+          case path: Path.Segments if path.depth > 1 =>
             (
               path.segments.head,
-              SegmentedPath(NonEmptyChain.fromChainUnsafe(path.segments.tail), path.suffix, None)
+              Path.Segments(NonEmptyChain.fromChainUnsafe(path.segments.tail), path.suffix, None)
             )
         }
         .groupBy(_._1)

--- a/io/src/main/scala/laika/io/model/FilePath.scala
+++ b/io/src/main/scala/laika/io/model/FilePath.scala
@@ -18,7 +18,7 @@ package laika.io.model
 
 import cats.data.NonEmptyChain
 import laika.ast.Path.Root
-import laika.ast.{ GenericPath, Path, RelativePath, SegmentedPath }
+import laika.ast.{ GenericPath, Path, RelativePath }
 import laika.internal.collection.TransitionalCollectionOps.JIteratorWrapper
 
 import java.nio.file.Paths
@@ -68,7 +68,7 @@ class FilePath private (private val root: Option[String], private[FilePath] val 
   ): FilePath =
     underlying match {
       case Root              => this
-      case sp: SegmentedPath =>
+      case sp: Path.Segments =>
         new FilePath(
           root,
           sp.copy(
@@ -93,7 +93,7 @@ class FilePath private (private val root: Option[String], private[FilePath] val 
     */
   def toNioPath: java.nio.file.Path = underlying match {
     case Root              => Paths.get(root.getOrElse(""))
-    case sp: SegmentedPath =>
+    case sp: Path.Segments =>
       val last     = sp.name + fragment.fold("")("#" + _)
       val segments = root.toList ++: sp.segments.init.append(last).toList
       Paths.get(segments.head, segments.tail: _*)

--- a/io/src/main/scala/laika/io/syntax.scala
+++ b/io/src/main/scala/laika/io/syntax.scala
@@ -69,7 +69,7 @@ import laika.io.ops.IOBuilderOps
   */
 object syntax {
 
-  implicit class ImplicitParserOps(builder: ParserBuilder)
+  implicit class ParserSyntax(builder: ParserBuilder)
       extends IOBuilderOps[TreeParser.Builder] {
 
     protected def build[F[_]: Async: Batch]: TreeParser.Builder[F] =
@@ -77,7 +77,7 @@ object syntax {
 
   }
 
-  implicit class ImplicitTextRendererOps(builder: RendererBuilder[_])
+  implicit class TextRendererSyntax(builder: RendererBuilder[_])
       extends IOBuilderOps[TreeRenderer.Builder] {
 
     protected def build[F[_]: Async: Batch]: TreeRenderer.Builder[F] =
@@ -85,7 +85,7 @@ object syntax {
 
   }
 
-  implicit class ImplicitTextTransformerOps(builder: TransformerBuilder[_])
+  implicit class TextTransformerSyntax(builder: TransformerBuilder[_])
       extends IOBuilderOps[TreeTransformer.Builder] {
 
     protected def build[F[_]: Async: Batch]: TreeTransformer.Builder[F] = {
@@ -100,7 +100,7 @@ object syntax {
 
   }
 
-  implicit class ImplicitBinaryRendererOps(
+  implicit class BinaryRendererSyntax(
       builder: TwoPhaseRendererBuilder[_, BinaryPostProcessor.Builder]
   ) extends IOBuilderOps[BinaryTreeRenderer.Builder] {
 
@@ -114,7 +114,7 @@ object syntax {
 
   }
 
-  implicit class ImplicitBinaryTransformerOps(
+  implicit class BinaryTransformerSyntax(
       builder: TwoPhaseTransformerBuilder[_, BinaryPostProcessor.Builder]
   ) extends IOBuilderOps[BinaryTreeTransformer.Builder] {
 

--- a/io/src/test/scala/laika/epub/internal/XHTMLRendererSpec.scala
+++ b/io/src/test/scala/laika/epub/internal/XHTMLRendererSpec.scala
@@ -93,7 +93,7 @@ class XHTMLRendererSpec extends CatsEffectSuite with ParagraphCompanionShortcuts
   }
 
   test("translate to external URL when an internal link is not defined for EPUB as a target") {
-    val target     = ResolvedInternalTarget(
+    val target     = InternalTarget.Resolved(
       Path.parse("/foo#ref"),
       RelativePath.parse("foo#ref"),
       TargetFormats.Selected("html")

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -613,7 +613,7 @@ class TreeParserSpec
     import laika.parse.syntax._
 
     case class DecoratedSpan(deco: Char, text: String) extends Span {
-      val options: Options = NoOpt
+      val options: Options = Options.empty
       type Self = DecoratedSpan
       def withOptions(options: Options): DecoratedSpan = this
     }

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -45,7 +45,7 @@ import laika.io.api.{ BinaryTreeRenderer, TreeRenderer }
 import laika.io.helper.{ InputBuilder, RenderResult, TestThemeBuilder }
 import laika.io.syntax.*
 import laika.io.model.*
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import laika.internal.rewrite.ReferenceResolver.CursorKeys
 import laika.io.internal.errors.{ DuplicatePath, RendererErrors }
 import laika.io.internal.runtime.VersionInfoGenerator
@@ -415,7 +415,11 @@ class TreeRendererSpec extends CatsEffectSuite
     val template = TemplateDocument(
       DefaultTemplatePath.forHTML,
       Results.betweenBrackets(
-        TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+        TemplateContextReference(
+          CursorKeys.documentContent,
+          required = true,
+          SourceCursor.Generated
+        )
       )
     )
     val input    = HTMLRenderer.defaultTree.addTemplate(template)
@@ -522,7 +526,7 @@ class TreeRendererSpec extends CatsEffectSuite
 
   test("tree with a single document to HTML using a custom template in an extension bundle") {
     val template = Results.betweenBrackets(
-      TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+      TemplateContextReference(CursorKeys.documentContent, required = true, SourceCursor.Generated)
     )
     val inputs   = new TestThemeBuilder.Inputs {
       def build[F[_]: Async] = InputTree[F]
@@ -649,7 +653,11 @@ class TreeRendererSpec extends CatsEffectSuite
     val template = TemplateDocument(
       DefaultTemplatePath.forEPUB,
       Results.betweenBrackets(
-        TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+        TemplateContextReference(
+          CursorKeys.documentContent,
+          required = true,
+          SourceCursor.Generated
+        )
       )
     )
     val input    = EPUB_XHTMLRenderer.defaultTree.addTemplate(template)
@@ -670,7 +678,7 @@ class TreeRendererSpec extends CatsEffectSuite
 
   test("tree with a single document to EPUB.XHTML using a custom template in a theme") {
     val template = Results.betweenBrackets(
-      TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+      TemplateContextReference(CursorKeys.documentContent, required = true, SourceCursor.Generated)
     )
     val inputs   = new TestThemeBuilder.Inputs {
       def build[F[_]: Async] = InputTree[F]
@@ -694,7 +702,7 @@ class TreeRendererSpec extends CatsEffectSuite
     "tree with a single document to EPUB.XHTML using a custom template in a theme extension overriding a template in the base theme"
   ) {
     val contentRef           =
-      TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+      TemplateContextReference(CursorKeys.documentContent, required = true, SourceCursor.Generated)
     val baseThemeInputs      = new TestThemeBuilder.Inputs {
       def build[F[_]: Async] = InputTree[F]
         .addTemplate(
@@ -742,7 +750,11 @@ class TreeRendererSpec extends CatsEffectSuite
     val template = TemplateDocument(
       DefaultTemplatePath.forFO,
       Results.betweenBrackets(
-        TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+        TemplateContextReference(
+          CursorKeys.documentContent,
+          required = true,
+          SourceCursor.Generated
+        )
       )
     )
     val input    = FORenderer.defaultTree.addTemplate(template)

--- a/io/src/test/scala/laika/render/fo/TestTheme.scala
+++ b/io/src/test/scala/laika/render/fo/TestTheme.scala
@@ -22,7 +22,7 @@ import laika.ast.{ TemplateContextReference, TemplateRoot, styles }
 import laika.helium.Helium
 import laika.helium.internal.generate.FOStyles
 import laika.internal.parse.css.CSSParsers
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import laika.internal.rewrite.ReferenceResolver.CursorKeys
 import laika.theme.config.{ Font, FontDefinition, FontStyle, FontWeight }
 
@@ -36,8 +36,12 @@ object TestTheme {
     .getOrElse(StyleDeclarationSet.empty)
 
   lazy val foTemplate = TemplateRoot(
-    TemplateContextReference(CursorKeys.fragment("bookmarks"), required = false, GeneratedSource),
-    TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
+    TemplateContextReference(
+      CursorKeys.fragment("bookmarks"),
+      required = false,
+      SourceCursor.Generated
+    ),
+    TemplateContextReference(CursorKeys.documentContent, required = true, SourceCursor.Generated)
   )
 
   lazy val htmlTemplate = TemplateRoot.fallback

--- a/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
+++ b/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
@@ -833,7 +833,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   }
 
   test("translate to external URL when an internal link is not defined for PDF as a target") {
-    val target     = ResolvedInternalTarget(
+    val target     = InternalTarget.Resolved(
       Path.parse("/foo#ref"),
       RelativePath.parse("foo#ref"),
       TargetFormats.Selected("html")

--- a/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
+++ b/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
@@ -34,7 +34,7 @@ import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.ast.styles.{ StyleDeclaration, StyleDeclarationSet, StylePredicate, StyleSelector }
 import laika.config.{ LaikaKeys, MessageFilter, MessageFilters, TargetFormats }
 import laika.format.XSLFO
-import laika.parse.GeneratedSource
+import laika.parse.SourceCursor
 import laika.parse.code.CodeCategory
 import munit.FunSuite
 
@@ -1012,7 +1012,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   test("render an invalid block without the runtime message in default mode") {
     val elem = InvalidBlock(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       p("fallback")
     )
     val fo   = s"""<fo:block $defaultParagraphStyles>fallback</fo:block>"""
@@ -1024,7 +1024,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   ) {
     val elem = InvalidBlock(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       p("fallback")
     )
     val fo   = s"""<fo:block $defaultParagraphStyles>fallback</fo:block>"""
@@ -1036,7 +1036,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   ) {
     val elem = InvalidBlock(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       p("fallback")
     )
     val fo   = s"""<fo:block $defaultParagraphStyles>""" +
@@ -1048,7 +1048,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   test("render an invalid span without the runtime message in default mode") {
     val elem = InvalidSpan(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       Text("fallback")
     )
     run(elem, "fallback")
@@ -1059,7 +1059,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   ) {
     val elem = InvalidSpan(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       Text("fallback")
     )
     run(elem, MessageFilter.Error, "fallback")
@@ -1070,7 +1070,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   ) {
     val elem = InvalidSpan(
       RuntimeMessage(MessageLevel.Warning, "some message"),
-      GeneratedSource,
+      SourceCursor.Generated,
       Text("fallback")
     )
     val fo   = s"""<fo:inline $warningProps>some message</fo:inline> fallback"""

--- a/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
+++ b/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
@@ -29,6 +29,7 @@ import laika.api.errors.RendererError
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
 import laika.ast.*
+import laika.ast.CellType.BodyCell
 import laika.ast.sample.{ ParagraphCompanionShortcuts, TestSourceBuilders }
 import laika.ast.styles.{ StyleDeclaration, StyleDeclarationSet, StylePredicate, StyleSelector }
 import laika.config.{ LaikaKeys, MessageFilter, MessageFilters, TargetFormats }

--- a/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
@@ -126,10 +126,10 @@ class ThemeBundleSpec extends FunSuite {
 
   test("rewrite rules - merged from a markup extension and an app extension") {
     val themeBundles = Seq(BundleProvider.forSpanRewriteRule(BundleOrigin.Theme) { case s: Strong =>
-      Replace(Literal(s.extractText))
+      RewriteAction.Replace(Literal(s.extractText))
     })
     val appBundles   = Seq(BundleProvider.forSpanRewriteRule(BundleOrigin.User) {
-      case s: Emphasized => Replace(Literal(s.extractText))
+      case s: Emphasized => RewriteAction.Replace(Literal(s.extractText))
     })
 
     val doc = Document(Root, RootElement(Strong("foo"), Emphasized("bar")))
@@ -148,10 +148,10 @@ class ThemeBundleSpec extends FunSuite {
     "rewrite rules - apply a rule from an app config and a rule from a markup extension successively"
   ) {
     val themeBundles = Seq(BundleProvider.forSpanRewriteRule(BundleOrigin.Theme) {
-      case Literal(text, _) => Replace(Literal(text + "!"))
+      case Literal(text, _) => RewriteAction.Replace(Literal(text + "!"))
     })
     val appBundles   = Seq(BundleProvider.forSpanRewriteRule(BundleOrigin.User) {
-      case Literal(text, _) => Replace(Literal(text + "?"))
+      case Literal(text, _) => RewriteAction.Replace(Literal(text + "?"))
     })
 
     val doc      = Document(Root, RootElement(Literal("foo")))

--- a/project/ScaladocCleanup.scala
+++ b/project/ScaladocCleanup.scala
@@ -4,20 +4,23 @@ object ScaladocCleanup {
 
   def removeUnwantedEntries(
       mappings: Seq[(File, String)],
-      basePath: sbt.File
-  ): Seq[(File, String)] = {
+      basePath: sbt.File,
+      scalaBinaryVersion: String
+  ): Seq[(File, String)] =
+    if (scalaBinaryVersion != "2.12") mappings
+    else {
 
-    // remove unwanted folders
-    val filtered = mappings.filterNot { case (_, mapping) =>
-      mapping.startsWith("org") || mapping.startsWith("sbt") || mapping.startsWith("scodec")
+      // remove unwanted folders
+      val filtered = mappings.filterNot { case (_, mapping) =>
+        mapping.startsWith("org") || mapping.startsWith("sbt") || mapping.startsWith("scodec")
+      }
+
+      // replace root index to remove unwanted entries from navigation
+      filtered.map { case (file, mapping) =>
+        if (mapping == "index.html") (new File(basePath, "docs/api/index.html"), mapping)
+        else (file, mapping)
+      }
+
     }
-
-    // replace root index to remove unwanted entries from navigation
-    filtered.map { case (file, mapping) =>
-      if (mapping == "index.html") (new File(basePath, "docs/api/index.html"), mapping)
-      else (file, mapping)
-    }
-
-  }
 
 }

--- a/sbt/src/sbt-test/site/rewriteRules/build.sbt
+++ b/sbt/src/sbt-test/site/rewriteRules/build.sbt
@@ -1,6 +1,6 @@
 import laika.ast.Emphasized
 import laika.ast.Strong
-import laika.ast.Replace
+import laika.ast.RewriteAction.Replace
 
 name := "site-rewriteRules"
 


### PR DESCRIPTION
While browsing API docs I spotted a few more ADT member types which should move into their companion for better documentation structure. They are all in the `laika.ast` package:

* `InternalTarget`
* `Path`
* `RewriteAction`
* `FootnoteLabel`
* `BulletFormat`
* `CellType`

It also revamps the ancient design for `ast.Options`, removing the `SomeOpt` and `NoOpt` subtypes for a simpler implementation in the shape of other modified former case classes. The `Options.empty` value replaces the former `NoOpt` object.