### PR TITLE
apply workaround for scaladoc bugs only for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,8 @@ lazy val api = project
     Compile / packageDoc / mappings            :=
       ScaladocCleanup.removeUnwantedEntries(
         (ScalaUnidoc / packageDoc / mappings).value,
-        (ThisBuild / baseDirectory).value
+        (ThisBuild / baseDirectory).value,
+        scalaBinaryVersion.value
       )
   )
 

--- a/project/ScaladocCleanup.scala
+++ b/project/ScaladocCleanup.scala
@@ -4,20 +4,23 @@ object ScaladocCleanup {
 
   def removeUnwantedEntries(
       mappings: Seq[(File, String)],
-      basePath: sbt.File
-  ): Seq[(File, String)] = {
+      basePath: sbt.File,
+      scalaBinaryVersion: String
+  ): Seq[(File, String)] =
+    if (scalaBinaryVersion != "2.12") mappings
+    else {
 
-    // remove unwanted folders
-    val filtered = mappings.filterNot { case (_, mapping) =>
-      mapping.startsWith("org") || mapping.startsWith("sbt") || mapping.startsWith("scodec")
+      // remove unwanted folders
+      val filtered = mappings.filterNot { case (_, mapping) =>
+        mapping.startsWith("org") || mapping.startsWith("sbt") || mapping.startsWith("scodec")
+      }
+
+      // replace root index to remove unwanted entries from navigation
+      filtered.map { case (file, mapping) =>
+        if (mapping == "index.html") (new File(basePath, "docs/api/index.html"), mapping)
+        else (file, mapping)
+      }
+
     }
-
-    // replace root index to remove unwanted entries from navigation
-    filtered.map { case (file, mapping) =>
-      if (mapping == "index.html") (new File(basePath, "docs/api/index.html"), mapping)
-      else (file, mapping)
-    }
-
-  }
 
 }


### PR DESCRIPTION
The bug which adds navigation entries for transitive dependencies only exists in Scala 2.12.