### PR TITLE
Update group ids after switch to typelevel org

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,7 +1,3 @@
-updates.ignore = [
-  { groupId = "org.planet42" }
-]
-
 pullRequests.frequency = "7 days"
 
 updates.limit = 3

--- a/docs/src/02-running-laika/01-sbt-plugin.md
+++ b/docs/src/02-running-laika/01-sbt-plugin.md
@@ -21,7 +21,7 @@ supporting that sbt version.
 First add the plugin to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.planet42" % "laika-sbt" % "@LAIKA_VERSION@")
+addSbtPlugin("org.typelevel" % "laika-sbt" % "@LAIKA_VERSION@")
 ```
 
 Then enable the plugin in your project's `build.sbt`:

--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -19,21 +19,21 @@ If you want to stick to pure transformations from string to string and don't nee
 any of the binary output formats like EPUB or PDF, you are fine with just using the `laika-core` module:
 
 ```scala
-libraryDependencies += "org.planet42" %% "laika-core" % "@LAIKA_VERSION@" 
+libraryDependencies += "org.typelevel" %% "laika-core" % "@LAIKA_VERSION@" 
 ```
 
 This module is also 100% supported for Scala.js, so you can alternatively use the triple `%%%` syntax
 if you want to cross-build for Scala.js and the JVM:
 
 ```scala
-libraryDependencies += "org.planet42" %%% "laika-core" % "@LAIKA_VERSION@" 
+libraryDependencies += "org.typelevel" %%% "laika-core" % "@LAIKA_VERSION@" 
 ```
 
 If you want to add support for file and stream IO and/or output in the EPUB format, 
 you need to depend on the `laika-io` module instead:
 
 ```scala
-libraryDependencies += "org.planet42" %% "laika-io" % "@LAIKA_VERSION@" 
+libraryDependencies += "org.typelevel" %% "laika-io" % "@LAIKA_VERSION@" 
 ```
 
 This depends on `laika-core` in turn, so you always only need to add one module as a dependency and will get
@@ -43,7 +43,7 @@ are in JVM land here.
 Finally PDF support comes with its own module as it adds a whole range of additional dependencies:
 
 ```scala
-libraryDependencies += "org.planet42" %% "laika-pdf" % "@LAIKA_VERSION@" 
+libraryDependencies += "org.typelevel" %% "laika-pdf" % "@LAIKA_VERSION@" 
 ```
 
 Again, this builds on top of the other modules, so adding just this one dependency is sufficient.


### PR DESCRIPTION
Since the 1.0 release, if you copy the maven coordinates from the docs, you'll get an invalid dependency.

I'm not completely sure about the scala-steward conf, but I'm assuming it should be changed too.