### PR TITLE
CI - do not run mdoc with Java 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Build manual
-        if: matrix.scala == '2.12' && matrix.project == 'rootJVM'
+        if: matrix.scala == '2.12' && matrix.project == 'rootJVM' && matrix.java == 'temurin@17'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' docs/mdoc docs/laikaSite
 
       - name: sbt scripted tests

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,9 @@ inThisBuild(
       WorkflowStep.Sbt(
         List("docs/mdoc", "docs/laikaSite"),
         name = Some("Build manual"),
-        cond = Some("matrix.scala == '2.12' && matrix.project == 'rootJVM'")
+        cond = Some(
+          "matrix.scala == '2.12' && matrix.project == 'rootJVM' && matrix.java == 'temurin@17'"
+        )
       ),
       WorkflowStep.Sbt(
         List("plugin/scripted"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.4.0")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.1")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.2")
 


### PR DESCRIPTION
mdoc does no longer support Java 8 and the "Build Manual" step previously ran twice anyway (with Java 8 + 17) which is not necessary. This PR changes CI to run mdoc only with Java 17.