### PR TITLE
Helium CSS - code spans in links should always use the link color

### DIFF
--- a/io/src/main/resources/laika/helium/css/code.css
+++ b/io/src/main/resources/laika/helium/css/code.css
@@ -17,6 +17,9 @@ code {
   white-space: nowrap;
   padding: 0 0.1em;
 }
+a code {
+  color: inherit;
+}
 pre code {
   color: var(--syntax-base5);
   background-color: transparent;

--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -185,10 +185,6 @@ header .row.links .row.links {
   font-weight: normal;
 }
 
-.nav-list li a code {
-  color: var(--primary-color); /* ensures that code is the same colour as the rest of the text, for consistency */
-}
-
 /* left navigation bar =========================================== */
 
 #sidebar {
@@ -330,10 +326,8 @@ ul.nav-list, #page-nav ul {
 }
 
 .nav-list .active a,
-.nav-list .active code,
 .nav-list .active a:hover,
 #page-nav .header a,
-#page-nav .header code,
 #page-nav .header a:hover {
   color: var(--bg-color);
   background-color: var(--primary-color);


### PR DESCRIPTION
Also removes all workarounds that had previously been applied to more narrow scenarios, since the new solution applies universally to all code spans within links