### PR TITLE
Helium: add CSS for custom content on landing page

### DIFF
--- a/io/src/main/resources/laika/helium/css/landing.css
+++ b/io/src/main/resources/laika/helium/css/landing.css
@@ -63,7 +63,7 @@ p {
   margin: 0;
   padding: 0;
 }
-ul {
+#header ul {
   list-style: none;
   display: block;
   margin: 0;
@@ -82,7 +82,7 @@ ul {
   background-color: var(--subtle-highlight);
   margin-bottom: 5px;
 }
-li {
+#header li {
   padding: 0 10px 0 10px;
   display: block;
   font-size: 16px;
@@ -306,4 +306,29 @@ li {
   left: 0;
   right: 0;
   margin: auto;
+}
+
+/* content from landing-page.md =================================================== */
+
+main {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  margin-bottom: 70px;
+  padding: 15px;
+}
+
+@media (min-width: 1020px) {
+  main {
+    max-width: var(--content-width);
+    padding: 15px 30px;
+  }
+}
+
+h1.title {
+  padding-top: 30px;
+}
+
+main p {
+  margin: 0 0 var(--block-spacing);
 }

--- a/io/src/main/resources/laika/helium/templates/landing.template.html
+++ b/io/src/main/resources/laika/helium/templates/landing.template.html
@@ -68,7 +68,11 @@
         @:@
       </div>
     @:@
-    ${cursor.currentDocument.content}
+    @:if(helium.site.landingPage.hasCustomContent)
+    <main>
+      ${cursor.currentDocument.content}
+    </main>
+    @:@
 
   </body>
 </html>

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -232,7 +232,9 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
          |</div>
          |<p class="header">Some <em>Header</em></p>
          |$teaserHTML
+         |<main>
          |<p>Some <em>markup</em> here.</p>
+         |</main>
          |</body>""".stripMargin
     val imagePath          = Root / "home.png"
     val helium             = Helium.defaults


### PR DESCRIPTION
Adds CSS for custom user content added to the theme-generated landing page (which users can do by adding a `landing-page.md` to the root directory).

Lots of the styles for the main content area were not carried over to the custom content area of the landing page, specifically the content width, block spacing and list styles.

Fixes #566