### PR TITLE
Helium CSS - fix background color of version menu

### DIFF
--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -119,7 +119,7 @@ header .row.links .row.links {
   z-index: 5000;
   left: 20px;
   top: calc(var(--top-bar-height) - 10px);
-  background-color: white;
+  background-color: var(--bg-color);
   border: 1px solid var(--component-border);
   border-radius: 5px;
   white-space: nowrap;


### PR DESCRIPTION
The background color was previously hard-coded to be white, which conflicts with dark mode.

Closes #567 