### PR TITLE
AST - merge fragments with the same name instead of silently dropping one of them

### DIFF
--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -347,9 +347,7 @@ class DocumentCursor private (
       case block                             => block
     }
 
-    val newFragments = rewrittenRoot.content.collect { case DocumentFragment(name, content, _) =>
-      (name, content)
-    }.toMap
+    val newFragments = DocumentFragment.collect(rewrittenRoot)
 
     target.withContent(
       content = rewrittenRoot.withContent(

--- a/core/shared/src/main/scala/laika/ast/blocks.scala
+++ b/core/shared/src/main/scala/laika/ast/blocks.scala
@@ -20,6 +20,8 @@ import cats.data.NonEmptySet
 import laika.api.config.{ ConfigEncoder, ConfigValue }
 import laika.parse.SourceFragment
 
+import scala.runtime.AbstractFunction3
+
 /** The root element of a document tree.
   */
 case class RootElement(content: Seq[Block], options: Options = Options.empty) extends Block
@@ -123,7 +125,7 @@ case class DocumentFragment(name: String, root: Element, options: Options = Opti
   def withOptions(options: Options): DocumentFragment = copy(options = options)
 }
 
-object DocumentFragment {
+object DocumentFragment extends AbstractFunction3[String, Element, Options, DocumentFragment] {
 
   import laika.internal.collection.TransitionalCollectionOps.*
 

--- a/core/shared/src/main/scala/laika/internal/parse/markup/DocumentParser.scala
+++ b/core/shared/src/main/scala/laika/internal/parse/markup/DocumentParser.scala
@@ -84,8 +84,9 @@ private[laika] object DocumentParser {
       configProvider: ConfigProvider
   ): DocumentInput => Either[ParserError, UnresolvedDocument] =
     create(rootParser, configProvider.markupConfigHeader) { (path, config, root) =>
-      val fragments = root.collect { case f: DocumentFragment => (f.name, f.root) }.toMap
-      UnresolvedDocument(Document(path, root).withFragments(fragments), config)
+      val doc = Document(path, root)
+        .withFragments(DocumentFragment.collect(root))
+      UnresolvedDocument(doc, config)
     }
 
   /** Combines the specified parsers for the root element and for (optional) configuration


### PR DESCRIPTION
When a document contains multiple fragments with the same name, all but one of them will be silently dropped. This has been the case for many years, but has never been reported and is most likely not what users would expect.

This PR concatenates all fragments with the same name into a single AST node. It is also a prerequisite for solving #595 properly right from the start.