### PR TITLE
PDF - support fragment references in templates

### DIFF
--- a/core/shared/src/main/scala/laika/ast/blocks.scala
+++ b/core/shared/src/main/scala/laika/ast/blocks.scala
@@ -153,6 +153,18 @@ object DocumentFragment extends AbstractFunction3[String, Element, Options, Docu
       .mapValuesStrict(combine)
   }
 
+  /** Collects the fragment elements from all documents the specified root contains
+    * and assembles them into a map with the fragment name serving as the key.
+    * In case the root contains multiple fragments with the same name
+    * they will be concatenated into a single fragment.
+    */
+  def collect(root: DocumentTreeRoot): Map[String, Element] = {
+    root.allDocuments.toList
+      .flatMap { _.fragments.map(f => DocumentFragment(f._1, f._2)) }
+      .groupBy(_.name)
+      .mapValuesStrict(combine)
+  }
+
 }
 
 /** An element that only gets rendered for a specific output format.

--- a/io/src/test/scala/laika/render/fo/TestTheme.scala
+++ b/io/src/test/scala/laika/render/fo/TestTheme.scala
@@ -44,6 +44,20 @@ object TestTheme {
     TemplateContextReference(CursorKeys.documentContent, required = true, SourceCursor.Generated)
   )
 
+  def foTemplateWithFragment(fragmentName: String): TemplateRoot = TemplateRoot(
+    TemplateContextReference(
+      CursorKeys.fragment(fragmentName),
+      required = true,
+      SourceCursor.Generated
+    ),
+    TemplateContextReference(
+      CursorKeys.fragment("bookmarks"),
+      required = false,
+      SourceCursor.Generated
+    ),
+    TemplateContextReference(CursorKeys.documentContent, required = true, SourceCursor.Generated)
+  )
+
   lazy val htmlTemplate = TemplateRoot.fallback
 
   val fontPaths = Seq(

--- a/pdf/src/main/scala/laika/pdf/internal/FOConcatenation.scala
+++ b/pdf/src/main/scala/laika/pdf/internal/FOConcatenation.scala
@@ -62,8 +62,10 @@ private[laika] object FOConcatenation {
     def applyTemplate(foString: String, template: TemplateDocument): Either[Throwable, String] = {
       val finalConfig     = ensureAbsoluteCoverImagePath
       val virtualPath     = Path.Root / "merged.fo"
+      val fragments       = DocumentFragment.collect(result.input)
       val finalDoc        = Document(virtualPath, RootElement(ContentWrapper(foString)))
-        .withFragments(PDFNavigation.generateBookmarks(result, config.navigationDepth))
+        .withFragments(fragments)
+        .addFragments(PDFNavigation.generateBookmarks(result, config.navigationDepth))
         .withConfig(finalConfig)
       val renderer        = Renderer.of(XSLFO).withConfig(opConfig).build
       val templateApplied = for {


### PR DESCRIPTION
Previously fragments were simply ignored in PDF output.

Fixes #595 