### PR TITLE
Preserve explicitly assigned header ids

### DIFF
--- a/core/shared/src/main/scala/laika/internal/link/DocumentTargets.scala
+++ b/core/shared/src/main/scala/laika/internal/link/DocumentTargets.scala
@@ -126,7 +126,7 @@ private[link] class DocumentTargets(document: Document, slugBuilder: String => S
         linkDefinitionResolver(selector, ld.target, ld.title)
 
       case h @ DecoratedHeader(deco, _, _, _) =>
-        val selector    = TargetIdSelector(slugBuilder(h.extractText))
+        val selector    = TargetIdSelector(slugBuilder(h.options.id.getOrElse(h.extractText)))
         val level       = levels.levelFor(deco)
         val finalHeader = TargetReplacer.lift { case DecoratedHeader(_, content, _, opt) =>
           Header(level, content, opt + Id(selector.id))
@@ -140,7 +140,7 @@ private[link] class DocumentTargets(document: Document, slugBuilder: String => S
         )
 
       case h @ Header(level, _, _) =>
-        val selector = TargetIdSelector(slugBuilder(h.extractText))
+        val selector = TargetIdSelector(slugBuilder(h.options.id.getOrElse(h.extractText)))
         TargetResolver.create(
           selector,
           internalResolver(selector),

--- a/core/shared/src/main/scala/laika/internal/link/LinkResolver.scala
+++ b/core/shared/src/main/scala/laika/internal/link/LinkResolver.scala
@@ -152,8 +152,10 @@ private[laika] class LinkResolver(root: DocumentTreeRoot, slugBuilder: String =>
           case FootnoteLabel.Autosymbol          => replaceBlock(f, AutosymbolSelector)
         }
       case c: Citation           => replaceBlock(c, TargetIdSelector(slugBuilder(c.label)))
-      case h: DecoratedHeader    => replaceBlock(h, TargetIdSelector(slugBuilder(h.extractText)))
-      case h: Header             => replaceBlock(h, TargetIdSelector(slugBuilder(h.extractText)))
+      case h: DecoratedHeader    =>
+        replaceBlock(h, TargetIdSelector(slugBuilder(h.options.id.getOrElse(h.extractText))))
+      case h: Header             =>
+        replaceBlock(h, TargetIdSelector(slugBuilder(h.options.id.getOrElse(h.extractText))))
 
       case d: BlockDirectives.DirectiveInstance if d.directive.exists(_.name == "fragment") =>
         RewriteAction.Replace(d.resolve(cursor))

--- a/core/shared/src/test/scala/laika/internal/rst/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/RewriteRulesSpec.scala
@@ -111,4 +111,18 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     runRootWithoutTitles(rootElem, expected)
   }
 
+  test(
+    "decorated headers - respect explicitly assigned ids"
+  ) {
+    val rootElem = RootElement(
+      DecoratedHeader(Underline('#'), List(Text("Title")), SourceCursor.Generated).withId(
+        "explicit"
+      )
+    )
+    val expected = RootElement(
+      Section(Header(1, List(Text("Title")), Id("explicit") + Style.section), Nil)
+    )
+    runRootWithoutTitles(rootElem, expected)
+  }
+
 }

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -621,6 +621,12 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     runRoot(rootElem, expected)
   }
 
+  test("header ids - respect explicitly assigned ids") {
+    val rootElem = RootElement(Header(1, List(Text("Header"))).withId("explicit"))
+    val expected = RootElement(Title(List(Text("Header")), Id("explicit") + Style.title))
+    runRoot(rootElem, expected)
+  }
+
   test("duplicate ids - append auto-increment numbers") {
     val header   = Header(1, "Header")
     val rootElem = RootElement(header, header)

--- a/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
@@ -37,7 +37,7 @@ class SectionNumberSpec extends FunSuite with DocumentTreeAssertions {
     def isIncluded(level: Int): Boolean = depth.forall(_ >= level)
 
     def header(level: Int, title: Int, style: String = "section"): Header =
-      Header(level, List(Text(s"Title $title")), Id(s"title$title") + Styles(style))
+      Header(level, List(Text(s"Title $title")), Id(s"title-$title") + Styles(style))
 
     def tree(content: RootElement): DocumentTree = {
       val autonumberConfig = ConfigParser


### PR DESCRIPTION
Fixes #613.

Also fixes one test which relied on the buggy behaviour.