### PR TITLE
remove duplicate imports

### DIFF
--- a/core/shared/src/main/scala/laika/internal/markdown/HTMLParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/HTMLParsers.scala
@@ -21,7 +21,6 @@ import laika.api.bundle.{ BlockParserBuilder, SpanParserBuilder }
 import laika.ast.*
 import laika.ast.html.*
 import laika.parse.Parser
-import laika.parse.markup.InlineParsers.spans
 import laika.parse.markup.RecursiveSpanParsers
 import laika.parse.text.{ CharGroup, DelimitedText, PrefixedParser }
 import laika.parse.builders.*

--- a/core/shared/src/main/scala/laika/internal/markdown/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/InlineParsers.scala
@@ -19,7 +19,6 @@ package laika.internal.markdown
 import laika.api.bundle.SpanParserBuilder
 import laika.ast.*
 import laika.parse.{ LineSource, Parser, SourceFragment }
-import laika.parse.markup.InlineParsers.text
 import laika.parse.markup.RecursiveSpanParsers
 import laika.parse.builders.*
 import laika.parse.syntax.*

--- a/core/shared/src/main/scala/laika/internal/markdown/ListParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/ListParsers.scala
@@ -19,7 +19,6 @@ package laika.internal.markdown
 import laika.api.bundle.BlockParserBuilder
 import laika.ast.*
 import laika.parse.Parser
-import laika.parse.combinator.Parsers.opt
 import laika.parse.markup.RecursiveParsers
 import laika.parse.text.{ CharGroup, PrefixedParser }
 import laika.parse.builders.*

--- a/core/shared/src/main/scala/laika/parse/code/languages/HTMLSyntax.scala
+++ b/core/shared/src/main/scala/laika/parse/code/languages/HTMLSyntax.scala
@@ -18,7 +18,6 @@ package laika.parse.code.languages
 
 import cats.data.NonEmptyList
 import laika.api.bundle.SyntaxHighlighter
-import laika.parse.code.common.TagFormats.TagParser
 import laika.parse.code.common.{ Keywords, TagFormats }
 import laika.parse.code.common.TagFormats.*
 import laika.parse.code.{ CodeCategory, CodeSpanParser }


### PR DESCRIPTION
Apparently 3.3.4 is the first compiler in any series to detect these, which is why they remained unnoticed for so long.