### PR TITLE
prevent invalid XSL-FO when rendering mermaid warning

### DIFF
--- a/io/src/main/scala/laika/helium/internal/builder/HeliumRenderOverrides.scala
+++ b/io/src/main/scala/laika/helium/internal/builder/HeliumRenderOverrides.scala
@@ -137,13 +137,16 @@ private[helium] object HeliumRenderOverrides {
       )
   }
 
+  private def mermaidWarning(format: String): Block = {
+    val msg = s"Mermaid diagrams are not supported for $format output"
+    Paragraph(RuntimeMessage(MessageLevel.Warning, msg))
+  }
+
   def forPDF: PartialFunction[(TagFormatter, Element), String] = {
     case (fmt, b @ BlockSequence(content, opt)) if opt.styles.contains("callout") =>
       fmt.blockContainer(b, SpanSequence(icon(opt).toSeq, Styles("icon")) +: content)
     case (fmt, CodeBlock("mermaid", _, _, _))                                     =>
-      fmt.child(
-        RuntimeMessage(MessageLevel.Warning, "Mermaid diagrams are not supported for PDF output")
-      )
+      fmt.child(mermaidWarning("PDF"))
   }
 
   def forEPUB: PartialFunction[(TagFormatter, Element), String] = {
@@ -151,9 +154,7 @@ private[helium] object HeliumRenderOverrides {
       val callout = icon(opt).map(SpanSequence(_)).toSeq ++ content
       fmt.indentedElement("div", BlockSequence(callout).withOptions(opt))
     case (fmt, CodeBlock("mermaid", _, _, _))                                 =>
-      fmt.child(
-        RuntimeMessage(MessageLevel.Warning, "Mermaid diagrams are not supported for EPUB output")
-      )
+      fmt.child(mermaidWarning("EPUB"))
   }
 
 }


### PR DESCRIPTION
Fixes a regression introduced in 0.19.4

This bug only affects a very specific scenario: testing PDF downloads in the preview server, while using the Helium theme and input sources containing one or more Mermaid diagrams. The `laikaSite` task of the plugin and all other use cases were unaffected.

The bug was caused by issuing a warning (since Mermaid diagrams are unsupported in PDF) as a span in block position which leads to invalid XSL-FO (the interim format for PDF).