### PR TITLE
Helium - fix .site.addFontResources

### DIFF
--- a/io/src/main/scala/laika/helium/config/api.scala
+++ b/io/src/main/scala/laika/helium/config/api.scala
@@ -39,8 +39,6 @@ private[helium] trait CommonConfigOps {
     *
     * E-book formats like EPUB or PDF require a local font file to be available for embedding.
     * A web font URL can only be used for website generation.
-    *
-    * When using this method, all default fonts of the Helium theme will be de-registered.
     */
   def addFontResources(defn: FontDefinition*): Helium
 
@@ -403,7 +401,7 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
   protected def currentColors: ColorSet           = helium.siteSettings.colors
 
   def addFontResources(defn: FontDefinition*): Helium = copyWith(
-    helium.siteSettings.copy(fontResources = defn)
+    helium.siteSettings.copy(fontResources = helium.siteSettings.fontResources ++ defn)
   )
 
   def clearFontResources: Helium = copyWith(

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -115,6 +115,21 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
 
   val heliumBase = Helium.defaults.site.landingPage()
 
+  private val testFonts = Seq(
+    FontDefinition(
+      Font.withWebCSS("http://fonts.com/font-1.css"),
+      "Font-1",
+      FontWeight.Normal,
+      FontStyle.Normal
+    ),
+    FontDefinition(
+      Font.withWebCSS("http://fonts.com/font-2.css"),
+      "Font-2",
+      FontWeight.Normal,
+      FontStyle.Normal
+    )
+  )
+
   def transformAndExtractHead(inputs: Seq[(Path, String)]): IO[String] =
     transformAndExtractHead(inputs, Helium.defaults)
 
@@ -419,21 +434,24 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
     transformAndExtractHead(inputs, helium, pathUnderTest).assertEquals(expected)
   }
 
-  test("custom web fonts") {
-    val helium   = heliumBase.site.addFontResources(
-      FontDefinition(
-        Font.withWebCSS("http://fonts.com/font-1.css"),
-        "Font-1",
-        FontWeight.Normal,
-        FontStyle.Normal
-      ),
-      FontDefinition(
-        Font.withWebCSS("http://fonts.com/font-2.css"),
-        "Font-2",
-        FontWeight.Normal,
-        FontStyle.Normal
-      )
-    )
+  test("custom web fonts - added to default fonts") {
+    val helium   = heliumBase.site.addFontResources(testFonts *)
+    val expected =
+      meta ++ """
+                |<title></title>
+                |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
+                |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
+                |<link rel="stylesheet" href="http://fonts.com/font-1.css">
+                |<link rel="stylesheet" href="http://fonts.com/font-2.css">
+                |<link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />
+                |<link rel="stylesheet" type="text/css" href="helium/site/laika-helium.css" />
+                |<script src="helium/site/laika-helium.js"></script>
+                |<script> /* for avoiding page load transitions */ </script>""".stripMargin
+    transformAndExtractHead(singleDoc, helium).assertEquals(expected)
+  }
+
+  test("custom web fonts - replacing default fonts") {
+    val helium   = heliumBase.site.clearFontResources.site.addFontResources(testFonts *)
     val expected =
       meta ++ """
                 |<title></title>

--- a/sbt/src/sbt-test/site/theme/expected.html
+++ b/sbt/src/sbt-test/site/theme/expected.html
@@ -14,6 +14,10 @@
   
   
   
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
+  
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono:500">
+  
   <link rel="stylesheet" href="http://home.com/myFont.css">
   
   <link rel="stylesheet" type="text/css" href="helium/site/icofont.min.css" />


### PR DESCRIPTION
The `.pdf` and `.epub` selectors were behaving as expected, but the `.site` selector removed all default fonts when calling `addFontResources`. 

Users who were unknowingly relying on the bug need to switch to `.site.clearFontResources.site.addFontResources(...)` instead.