### PR TITLE
core - fix apiPath & downloadPath constants in LaikaKeys

### DIFF
--- a/core/shared/src/main/scala/laika/config/LaikaKeys.scala
+++ b/core/shared/src/main/scala/laika/config/LaikaKeys.scala
@@ -70,8 +70,8 @@ object LaikaKeys {
   }
 
   object site {
-    val apiPath: Key      = root.child(Key("site", "downloadPath"))
-    val downloadPath: Key = root.child(Key("site", "apiPath"))
+    val apiPath: Key      = root.child(Key("site", "apiPath"))
+    val downloadPath: Key = root.child(Key("site", "downloadPath"))
     val metadata: Key     = root.child(Key("site", "metadata"))
   }
 


### PR DESCRIPTION
The values for `LaikaKeys.downloadPath` and `LaikaKeys.apiPath` had been swapped. Users doing programmatic configuration (the majority) were not affected by this bug, as having the wrong values on the reading and the writing side canceled each other out. Only users doing HOCON configuration were affected, which appears to be zero since it was never reported.