### PR TITLE
Helium - minor tweaks for default colours

### DIFF
--- a/io/src/main/scala/laika/helium/internal/config/HeliumDefaults.scala
+++ b/io/src/main/scala/laika/helium/internal/config/HeliumDefaults.scala
@@ -85,7 +85,7 @@ private[helium] object HeliumDefaults {
     info = Color.hex("ebf6f7"),
     infoLight = Color.hex("007c99"),
     warning = Color.hex("fcfacd"),
-    warningLight = Color.hex("b1a400"),
+    warningLight = Color.hex("817800"),
     error = Color.hex("ffe9e3"),
     errorLight = Color.hex("d83030")
   )
@@ -128,7 +128,7 @@ private[helium] object HeliumDefaults {
     primary = Color.hex("007c99"),
     secondary = Color.hex("931813"),
     primaryMedium = Color.hex("a7d4de"),
-    primaryLight = Color.hex("ebf6f7"),
+    primaryLight = Color.hex("eef5f6"),
     text = Color.hex("5f5f5f"),
     background = Color.hex("ffffff"),
     bgGradient = (Color.hex("095269"), Color.hex("007c99"))

--- a/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
@@ -71,7 +71,7 @@ class HeliumEPUBCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
 
   test("defaults") {
     val expected = s"""--primary-color: #007c99;
-                      |--primary-light: #ebf6f7;
+                      |--primary-light: #eef5f6;
                       |--primary-medium: #a7d4de;
                       |--secondary-color: #931813;
                       |--text-color: #5f5f5f;
@@ -160,7 +160,7 @@ class HeliumEPUBCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   }
 
   private val customFonts = s"""--primary-color: #007c99;
-                               |--primary-light: #ebf6f7;
+                               |--primary-light: #eef5f6;
                                |--primary-medium: #a7d4de;
                                |--secondary-color: #931813;
                                |--text-color: #5f5f5f;
@@ -422,7 +422,7 @@ class HeliumEPUBCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
 
   test("layout") {
     val expected = s"""--primary-color: #007c99;
-                      |--primary-light: #ebf6f7;
+                      |--primary-light: #eef5f6;
                       |--primary-medium: #a7d4de;
                       |--secondary-color: #931813;
                       |--text-color: #5f5f5f;

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -565,7 +565,7 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
           |theme: "base",
           |themeVariables: {
           |'darkMode': dark,
-          |'primaryColor': dark ? '#125d75' : '#ebf6f7',
+          |'primaryColor': dark ? '#125d75' : '#eef5f6',
           |'primaryTextColor': dark ? '#a7d4de' : '#007c99',
           |'primaryBorderColor': dark ? '#a7d4de' : '#a7d4de',
           |'lineColor': dark ? '#a7d4de' : '#007c99',

--- a/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
@@ -60,7 +60,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   }
 
   private val defaultColors = """--primary-color: #007c99;
-                                |--primary-light: #ebf6f7;
+                                |--primary-light: #eef5f6;
                                 |--primary-medium: #a7d4de;
                                 |--secondary-color: #931813;
                                 |--text-color: #5f5f5f;


### PR DESCRIPTION
This PR introduces changes for two of the default colours in the Helium theme:

1) For better readability of white text the background colour for callouts with level `WARNING` in dark mode changed from `#b1a400` to `#817800`.

2) The light background (`primaryLight`) for the main theme colours has been made a tiny bit more neutral (for purely aesthetic reasons) - changed from `#ebf6f7` to `#eef5f6`.