### PR TITLE
verbatim HTML - support <script> as root element

### DIFF
--- a/core/shared/src/main/scala/laika/ast/html/elements.scala
+++ b/core/shared/src/main/scala/laika/ast/html/elements.scala
@@ -96,7 +96,7 @@ case class HTMLScriptElement(
     attributes: List[HTMLAttribute],
     content: String,
     options: Options = Options.empty
-) extends HTMLSpan with TextContainer {
+) extends HTMLSpan with TextContainer with Block {
   type Self = HTMLScriptElement
   def withOptions(options: Options): HTMLScriptElement = copy(options = options)
 }

--- a/core/shared/src/main/scala/laika/internal/markdown/HTMLParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/HTMLParsers.scala
@@ -252,6 +252,6 @@ private[laika] object HTMLParsers {
     "<" ~> (htmlComment | htmlEmptyElement | htmlStartTag) <~ wsEol ~ blankLine
 
   lazy val htmlBlockFragment: BlockParserBuilder =
-    BlockParserBuilder.standalone(htmlBlock | htmlBlockElement).rootOnly // TODO - keep separate
+    BlockParserBuilder.standalone("<" ~> htmlScriptElement | htmlBlock | htmlBlockElement).rootOnly
 
 }

--- a/core/shared/src/test/scala/laika/markdown/HTMLBlockParserSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/HTMLBlockParserSpec.scala
@@ -104,6 +104,25 @@ class HTMLBlockParserSpec extends FunSuite
     run(input, p("aaa"), html.HTMLBlock(outer), p("bbb"))
   }
 
+  test("recognize a script tag as a root element") {
+    val input  = """aaa
+                  |
+                  |<script type="text/javascript" defer>
+                  |  var x = [1, 2, 3];
+                  |  var y = 'foo';
+                  |</script>
+                  |
+                  |bbb""".stripMargin
+    val script = HTMLScriptElement(
+      List(
+        HTMLAttribute("type", List(Text("text/javascript")), Some('"')),
+        HTMLAttribute("defer", List(), None)
+      ),
+      "\n  var x = [1, 2, 3];\n  var y = 'foo';\n"
+    )
+    run(input, p("aaa"), script, p("bbb"))
+  }
+
   test("ignore elements which are not listed as block-level elements") {
     val input = """aaa
                   |


### PR DESCRIPTION
Oddly enough, previously `<script>` tags only worked as nested elements in verbatim HTML for Markdown.