### PR TITLE
core: run @:include and @:embed directives in RewritePhase.Build to allow headers in included fragments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel" %%% "cats-core" % versions.catsCore
     ),
     scalacOptions ++= inferOverrideFor2_13(scalaVersion.value),
-    Test / scalacOptions ~= disableMissingInterpolatorWarning
+    Test / scalacOptions ~= disableMissingInterpolatorWarning,
+    mimaBinaryIssueFilters ++= MimaFilters.internalDirectiveAPI
   )
   .jvmSettings(
     libraryDependencies += jTidy

--- a/core/shared/src/main/scala/laika/api/bundle/directives.scala
+++ b/core/shared/src/main/scala/laika/api/bundle/directives.scala
@@ -570,16 +570,23 @@ trait DirectiveBuilderContext[E <: Element] {
 
   /** Represents a directive, its name and its (combined) parts.
     */
-  class Directive private[bundle] (val name: String, part: DirectivePart[E]) {
+  class Directive private[bundle] (
+      val name: String,
+      part: DirectivePart[E],
+      allowsCursorInBuildPhase: Boolean = false
+  ) {
     private[bundle] def apply(context: DirectiveContext): Result[E] = part(context)
     def hasBody: Boolean                                            = part.hasBody
     def separators: Set[String]                                     = part.separators
 
-    def runsIn(phase: RewritePhase): Boolean = phase match {
-      case RewritePhase.Render(_) => true
-      case _                      => !part.needsCursor
+    def runsIn(phase: RewritePhase): Boolean = {
+      phase match {
+        case RewritePhase.Render(_) => true
+        case _                      => allowsCursorInBuildPhase || !part.needsCursor
+      }
     }
 
+    def allowCursorInBuildPhase: Directive = new Directive(name, part, true)
   }
 
   /** Represents a separator directive, its name and its (combined) parts.

--- a/core/shared/src/main/scala/laika/internal/directive/IncludeDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/directive/IncludeDirectives.scala
@@ -87,7 +87,7 @@ private[laika] object IncludeDirectives {
         val content = BlockSequence(doc.content.content)
         BlockScope(content, context, source)
       }
-      .toRight(s"Unresolved reference to template '${path.toString}'")
+      .toRight(s"Unresolved reference to document '${path.toString}'")
   }
 
   /** Implementation of the `include` directive for templates.
@@ -133,7 +133,7 @@ private[laika] object IncludeDirectives {
         resolvePath(literalPath, pathKey, cursor.config)
           .flatMap(resolveDocumentReference(_, attributes, cursor, source))
     }
-  }
+  }.allowCursorInBuildPhase
 
   /** Implementation of the `embed` directive for text markup documents.
     */
@@ -152,6 +152,6 @@ private[laika] object IncludeDirectives {
       resolvePath(literalPath, pathKey, cursor.config)
         .flatMap(resolveDocumentReference(_, attributes, cursor, source, Some(body)))
     }
-  }
+  }.allowCursorInBuildPhase
 
 }

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -1,4 +1,9 @@
-import com.typesafe.tools.mima.core.{ MissingClassProblem, ProblemFilter, ProblemFilters }
+import com.typesafe.tools.mima.core.{
+  MissingClassProblem,
+  ProblemFilter,
+  ProblemFilters,
+  ReversedMissingMethodProblem
+}
 
 object MimaFilters {
 
@@ -25,6 +30,12 @@ object MimaFilters {
     ProblemFilters.exclude[MissingClassProblem]("laika.helium.internal.config.InternalJS$"),
     ProblemFilters.exclude[MissingClassProblem]("laika.helium.internal.config.InlineJS"),
     ProblemFilters.exclude[MissingClassProblem]("laika.helium.internal.config.InlineJS$")
+  )
+
+  val internalDirectiveAPI: Seq[ProblemFilter] = Seq(
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+      "laika.api.bundle.DirectiveBuilderContext.Directive"
+    )
   )
 
 }


### PR DESCRIPTION
The `@:include` and `@:embed` directives previously ran in the final rewrite phase which is the default for all directives with access to the cursor. This is the most reasonable default in most cases, but here it prevented some very basic use cases like having headers (or anything else with an id) inside the included fragments.

This PR overrides the default phase for these two directives to prevent those issues.