### PR TITLE
Recursively flatten document when building sections

### DIFF
--- a/core/shared/src/main/scala/laika/internal/nav/SectionBuilder.scala
+++ b/core/shared/src/main/scala/laika/internal/nav/SectionBuilder.scala
@@ -63,10 +63,14 @@ private[laika] object SectionBuilder extends RewriteRulesBuilder {
 
     def buildSections(document: RootElement): RootElement = {
 
-      val flattenedDocument = document.content.flatMap {
-        case seq: BlockSequence if seq.options.styles.isEmpty => seq.content
-        case b: Block                                         => Seq(b)
-      }
+      def flattenDocument(blocks: Seq[Block]): Seq[Block] =
+        blocks.flatMap {
+          case seq: BlockSequence if seq.options.styles.isEmpty => flattenDocument(seq.content)
+          case b: Block                                         => Seq(b)
+        }
+
+
+      val flattenedDocument = flattenDocument(document.content)
 
       val docPosition = if (autonumberConfig.documents) position else TreePosition.root
 

--- a/core/shared/src/main/scala/laika/internal/rewrite/RecursiveResolverRules.scala
+++ b/core/shared/src/main/scala/laika/internal/rewrite/RecursiveResolverRules.scala
@@ -32,27 +32,25 @@ private[laika] object RecursiveResolverRules {
       phase: RewritePhase
   ): RewriteRules = {
 
-    val removeScopes = phase.isInstanceOf[RewritePhase.Render]
-
     def rulesForScope(scope: ElementScope[_]): RewriteRules =
       applyTo(cursor.withReferenceContext(scope.context), baseRules, phase)
 
     lazy val rules: RewriteRules = RewriteRules.forBlocks {
       case ph: BlockResolver if ph.runsIn(phase) => Replace(rules.rewriteBlock(ph.resolve(cursor)))
-      case scope: BlockScope if removeScopes     =>
+      case scope: BlockScope     =>
         Replace(rulesForScope(scope).rewriteBlock(scope.content))
       case scope: BlockScope                     =>
         Replace(scope.copy(content = rulesForScope(scope).rewriteBlock(scope.content)))
     } ++ RewriteRules.forSpans {
       case ph: SpanResolver if ph.runsIn(phase) => Replace(rules.rewriteSpan(ph.resolve(cursor)))
-      case scope: SpanScope if removeScopes     =>
+      case scope: SpanScope     =>
         Replace(rulesForScope(scope).rewriteSpan(scope.content))
       case scope: SpanScope                     =>
         Replace(scope.copy(content = rulesForScope(scope).rewriteSpan(scope.content)))
     } ++ RewriteRules.forTemplates {
       case ph: SpanResolver if ph.runsIn(phase) =>
         Replace(rules.rewriteTemplateSpan(asTemplateSpan(ph.resolve(cursor))))
-      case scope: TemplateScope if removeScopes =>
+      case scope: TemplateScope =>
         Replace(rulesForScope(scope).rewriteTemplateSpan(scope.content))
       case scope: TemplateScope                 =>
         Replace(scope.copy(content = rulesForScope(scope).rewriteTemplateSpan(scope.content)))


### PR DESCRIPTION
Idk how to really describe this, but this makes it so directives, `include` and `embed` can add Headers that will get included in the page nav.

Based off the fix/section-builder branch but I seem to have broken it when forking so this targets main