### PR TITLE
fix ElementContainer.toString

### DIFF
--- a/core/shared/src/main/scala/laika/ast/containers.scala
+++ b/core/shared/src/main/scala/laika/ast/containers.scala
@@ -18,6 +18,7 @@ package laika.ast
 
 import laika.api.Renderer
 import laika.format.AST
+import cats.syntax.all.*
 
 /** A generic container.
   *  Usually not mixed in directly, instead one of the sub-traits
@@ -163,5 +164,8 @@ trait BlockContainerCompanion extends SpanContainerCompanion {
 
 private[ast] object FormattedElementString {
   private lazy val renderer: Renderer = Renderer.of(AST).build.skipRewritePhase
-  def render(elem: Element): String   = "\n" + renderer.render(elem) + "\n"
+
+  def render(elem: Element): String =
+    renderer.render(elem).leftMap(err => s"<${err.message}>").merge
+
 }

--- a/core/shared/src/test/scala/laika/ast/ElementContainerToStringSpec.scala
+++ b/core/shared/src/test/scala/laika/ast/ElementContainerToStringSpec.scala
@@ -1,0 +1,17 @@
+package laika.ast
+
+import munit.FunSuite
+
+class ElementContainerToStringSpec extends FunSuite {
+
+  test("toString for ElementContainer") {
+    val element  = Paragraph(Text("some"), Emphasized("em"), Text("text"))
+    val expected = """Paragraph - Spans: 3
+                     |. Text - 'some'
+                     |. Emphasized - Spans: 1
+                     |. . Text - 'em'
+                     |. Text - 'text'""".stripMargin
+    assertEquals(element.toString, expected)
+  }
+
+}


### PR DESCRIPTION
AST nodes were wrapping the rendered node in an Either when calling `toString`