### PR TITLE
SectionBuilder flattens BlockSequence without id or styles

### DIFF
--- a/core/shared/src/main/scala/laika/internal/nav/SectionBuilder.scala
+++ b/core/shared/src/main/scala/laika/internal/nav/SectionBuilder.scala
@@ -63,21 +63,28 @@ private[laika] object SectionBuilder extends RewriteRulesBuilder {
 
     def buildSections(document: RootElement): RootElement = {
 
+      def flatten(blocks: Seq[Block]): Seq[Block] = blocks.flatMap {
+        case seq: BlockSequence if seq.options.styles.isEmpty && !seq.hasId => flatten(seq.content)
+        case b: Block                                                       => Seq(b)
+      }
+
+      val flattenedDocument = flatten(document.content)
+
       val docPosition = if (autonumberConfig.documents) position else TreePosition.root
 
       val (titleSection, rest) =
-        if (!extractTitle) (Nil, document.content)
+        if (!extractTitle) (Nil, flattenedDocument)
         else {
 
-          val title = document.content.collectFirst { case h: Header =>
+          val title = flattenedDocument.collectFirst { case h: Header =>
             if (autonumberConfig.documents)
               Title(addNumber(h.content, docPosition), h.options + Style.title)
             else Title(h.content, h.options + Style.title)
           }
 
-          title.fold((document.content, Seq.empty[Block])) { titleBlock =>
+          title.fold((flattenedDocument, Seq.empty[Block])) { titleBlock =>
             val (preface, rest) =
-              document.content.splitAt(document.content.indexWhere(_.isInstanceOf[Header]))
+              flattenedDocument.splitAt(flattenedDocument.indexWhere(_.isInstanceOf[Header]))
             (preface :+ titleBlock, rest.tail)
           }
         }

--- a/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
@@ -132,7 +132,7 @@ class StandardDirectiveSpec extends FunSuite
                   |@:todo(FIXME LATER)
                   |
                   |bb""".stripMargin
-    run(input, p("aa"), BlockSequence(Nil), p("bb"))
+    run(input, p("aa"), p("bb"))
   }
 
   test("todo directive as span") {

--- a/core/shared/src/test/scala/laika/internal/rst/std/StandardBlockDirectivesSpec.scala
+++ b/core/shared/src/test/scala/laika/internal/rst/std/StandardBlockDirectivesSpec.scala
@@ -112,7 +112,7 @@ class StandardBlockDirectivesSpec extends FunSuite with ParagraphCompanionShortc
                   | 1st Para
                   |
                   | 2nd Para""".stripMargin
-    run(input, BlockSequence(simplePars))
+    run(input, simplePars *)
   }
 
   test("container - sequence of two paragraphs with two custom styles") {


### PR DESCRIPTION
When a BlockSequence neither has an id assigned nor a style, it does not carry any semantics we need to preserve.
In this case we can flatten the structure into the parent container. Previously this cleanup step was performed by all renderers, but by moving it into the `SectionBuilder` rewrite step we are able to detect headers nested in such a container when building the section structure. 

This PR is one of two building blocks to make the bug fix in #670 actually useful.