### PR TITLE
run resolvers for substitution references in all phases

### DIFF
--- a/core/shared/src/main/scala/laika/ast/resolvers.scala
+++ b/core/shared/src/main/scala/laika/ast/resolvers.scala
@@ -164,8 +164,7 @@ case class MarkupContextReference(
 
   def withOptions(options: Options): MarkupContextReference = copy(options = options)
 
-  def runsIn(phase: RewritePhase): Boolean =
-    phase.isInstanceOf[RewritePhase.Render] // TODO - test earlier phases
+  def runsIn(phase: RewritePhase): Boolean = true
 
   lazy val unresolvedMessage: String =
     s"Unresolved markup context reference with key '${ref.toString}'"

--- a/core/shared/src/main/scala/laika/internal/rewrite/RecursiveResolverRules.scala
+++ b/core/shared/src/main/scala/laika/internal/rewrite/RecursiveResolverRules.scala
@@ -32,30 +32,22 @@ private[laika] object RecursiveResolverRules {
       phase: RewritePhase
   ): RewriteRules = {
 
-    val removeScopes = phase.isInstanceOf[RewritePhase.Render]
-
     def rulesForScope(scope: ElementScope[_]): RewriteRules =
       applyTo(cursor.withReferenceContext(scope.context), baseRules, phase)
 
     lazy val rules: RewriteRules = RewriteRules.forBlocks {
       case ph: BlockResolver if ph.runsIn(phase) => Replace(rules.rewriteBlock(ph.resolve(cursor)))
-      case scope: BlockScope if removeScopes     =>
-        Replace(rulesForScope(scope).rewriteBlock(scope.content))
       case scope: BlockScope                     =>
-        Replace(scope.copy(content = rulesForScope(scope).rewriteBlock(scope.content)))
+        Replace(rulesForScope(scope).rewriteBlock(scope.content))
     } ++ RewriteRules.forSpans {
       case ph: SpanResolver if ph.runsIn(phase) => Replace(rules.rewriteSpan(ph.resolve(cursor)))
-      case scope: SpanScope if removeScopes     =>
-        Replace(rulesForScope(scope).rewriteSpan(scope.content))
       case scope: SpanScope                     =>
-        Replace(scope.copy(content = rulesForScope(scope).rewriteSpan(scope.content)))
+        Replace(rulesForScope(scope).rewriteSpan(scope.content))
     } ++ RewriteRules.forTemplates {
       case ph: SpanResolver if ph.runsIn(phase) =>
         Replace(rules.rewriteTemplateSpan(asTemplateSpan(ph.resolve(cursor))))
-      case scope: TemplateScope if removeScopes =>
-        Replace(rulesForScope(scope).rewriteTemplateSpan(scope.content))
       case scope: TemplateScope                 =>
-        Replace(scope.copy(content = rulesForScope(scope).rewriteTemplateSpan(scope.content)))
+        Replace(rulesForScope(scope).rewriteTemplateSpan(scope.content))
     } ++ baseRules
 
     rules

--- a/io/src/test/scala/laika/directive/std/IncludeDirectiveSpec.scala
+++ b/io/src/test/scala/laika/directive/std/IncludeDirectiveSpec.scala
@@ -25,7 +25,7 @@ import laika.format.{ HTML, Markdown }
 import laika.io.api.TreeParser
 import laika.io.helper.InputBuilder
 import laika.io.internal.errors.ConfigException
-import laika.io.syntax._
+import laika.io.syntax.*
 import laika.theme.Theme
 import munit.CatsEffectSuite
 
@@ -84,7 +84,7 @@ class IncludeDirectiveSpec extends CatsEffectSuite with InputBuilder {
       ),
       Paragraph("ccc")
     )
-    Seq(BlockSequence(composedBlocks))
+    composedBlocks
   }
 
   def parseAndExtract(input: String, template: Option[String] = None): IO[Seq[Block]] = {
@@ -112,19 +112,19 @@ class IncludeDirectiveSpec extends CatsEffectSuite with InputBuilder {
 
   test("block include without attributes") {
     val markup = "@:include(../inc/inc-1.md)"
-    parseAndExtract(markup).assertEquals(Seq(BlockSequence(Paragraph("aaa () bbb"))))
+    parseAndExtract(markup).assertEquals(Seq(Paragraph("aaa () bbb")))
   }
 
   test("block include with header") {
     val markup = "@:include(../inc/header.md)"
     parseAndExtract(markup).assertEquals(
-      Seq(BlockSequence(Header(1, "Header").withId("header"), Paragraph("aaa () bbb")))
+      Seq(Title("Header").withId("header").withStyle("title"), Paragraph("aaa () bbb"))
     )
   }
 
   test("block include with attributes") {
     val markup = "@:include(../inc/inc-1.md) { key = foo }"
-    parseAndExtract(markup).assertEquals(Seq(BlockSequence(Paragraph("aaa (foo) bbb"))))
+    parseAndExtract(markup).assertEquals(Seq(Paragraph("aaa (foo) bbb")))
   }
 
   test("block embed without attributes") {
@@ -151,7 +151,9 @@ class IncludeDirectiveSpec extends CatsEffectSuite with InputBuilder {
         |@:@
       """.stripMargin
     parseAndExtract(markup).assertEquals(
-      embedResult(Seq(Header(1, "Header").withId("header"), Paragraph("aaa () bbb")))
+      embedResult(
+        Seq(Title("Header").withId("header").withStyle("title"), Paragraph("aaa () bbb"))
+      )
     )
   }
 


### PR DESCRIPTION
Substitution references in markup blocks (in the syntax `${some.ref}`) were previously only resolved in the last rewrite step.
This PR allows them to be resolved in any phase, meaning the first time they are encountered.

This is the 2nd step to make the fix in #670 actually useful, as the late resolving step prevented the section builder from seeing headers in the AST that were inserted by directives.