### PR TITLE
PDF/XSL-FO: don't render verbatim HTML nodes

### DIFF
--- a/core/shared/src/main/scala/laika/internal/markdown/bundle/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/bundle/HTMLRenderer.scala
@@ -70,4 +70,11 @@ private[bundle] object HTMLRenderer {
     case (fmt, HTMLBlock(root, _))                  => fmt.child(root)
   }
 
+  val foFilter: PartialFunction[(TagFormatter, Element), String] = {
+
+    case (_, _: HTMLBlock) => ""
+    case (_, _: HTMLSpan)  => ""
+
+  }
+
 }

--- a/core/shared/src/main/scala/laika/internal/markdown/bundle/VerbatimHTML.scala
+++ b/core/shared/src/main/scala/laika/internal/markdown/bundle/VerbatimHTML.scala
@@ -17,7 +17,7 @@
 package laika.internal.markdown.bundle
 
 import laika.api.bundle.{ BundleOrigin, ExtensionBundle, ParserBundle, RenderOverrides }
-import laika.format.HTML
+import laika.format.{ HTML, XSLFO }
 import laika.internal.markdown.HTMLParsers
 
 /** Markdown extension that also parses verbatim HTML elements alongside the standard Markdown markup.
@@ -48,7 +48,8 @@ private[laika] object VerbatimHTML extends ExtensionBundle {
   )
 
   override val renderOverrides: Seq[RenderOverrides] = Seq(
-    HTML.Overrides(value = HTMLRenderer.custom)
+    HTML.Overrides(value = HTMLRenderer.custom),
+    XSLFO.Overrides(value = HTMLRenderer.foFilter)
   )
 
 }


### PR DESCRIPTION
These nodes are specific to their output formats (HTML, EPUB) and should not appear in PDF or XSL-FO output.