### PR TITLE
remove documents excluded from output earlier

### DIFF
--- a/io/src/test/scala/laika/directive/std/IncludeDirectiveSpec.scala
+++ b/io/src/test/scala/laika/directive/std/IncludeDirectiveSpec.scala
@@ -38,6 +38,12 @@ class IncludeDirectiveSpec extends CatsEffectSuite with InputBuilder {
     .withTheme(Theme.empty)
     .build
 
+  private val excludeFromOutputHOCON =
+    """|{%
+       |laika.targetFormats = []
+       |%}
+       |""".stripMargin
+
   def inputs(docUnderTest: String): Seq[(Path, String)] = {
     Seq(
       Root / "dir1" / "doc-1.md"           -> "# Ref",
@@ -45,29 +51,29 @@ class IncludeDirectiveSpec extends CatsEffectSuite with InputBuilder {
       Root / "dir2" / "doc-3.md"           -> "# Ref",
       Root / "dir2" / "doc-4.md"           -> docUnderTest,
       Root / "inc" / "inc-1.md"            -> "aaa (${?_.key}) bbb",
-      Root / "inc" / "inc-2.md"            ->
+      Root / "inc" / "inc-2.md"            -> (excludeFromOutputHOCON +
         """aaa (${?_.key}) bbb
           |
-          |${?_.embeddedBody}
+          |${_.embeddedBody}
           |
           |ccc
-        """.stripMargin,
+        """.stripMargin),
       Root / "inc" / "header.md"           ->
         """# Header
           |
           |aaa (${?_.key}) bbb
           |""".stripMargin,
-      Root / "inc" / "header-embed.md"     ->
+      Root / "inc" / "header-embed.md"     -> (excludeFromOutputHOCON +
         """# Header
           |
           |aaa (${?_.key}) bbb
           |
-          |${?_.embeddedBody}
+          |${_.embeddedBody}
           |
           |ccc
-          |""".stripMargin,
+          |""".stripMargin),
       Root / "inc" / "inc-1.template.html" -> "aaa (${?_.key}) bbb",
-      Root / "inc" / "inc-2.template.html" -> """aaa (${?_.key}) bbb <${?_.embeddedBody}> ccc"""
+      Root / "inc" / "inc-2.template.html" -> """aaa (${?_.key}) bbb <${_.embeddedBody}> ccc"""
     )
   }
 


### PR DESCRIPTION
Since `@:include` and `@:embed` now execute earlier as well as their related substitution references (e.g. `${_.embeddedBody}`), those references can now lead to errors. They are only valid in the parent document the markup snippet gets included in, they are not valid if the included document gets validated on its own.

Previously that never happened, as validation ran late, where documents configured as excluded from output had already been removed. Now it runs early where they were still present in the tree. This PR adds an extra step where the filtering happens earlier