### PR TITLE
HOCON: substitution references need to be resolved lazily

### DIFF
--- a/core/shared/src/main/scala/laika/api/bundle/directives.scala
+++ b/core/shared/src/main/scala/laika/api/bundle/directives.scala
@@ -225,8 +225,8 @@ trait DirectiveBuilderContext[E <: Element] {
         factory.toRight(Seq(s"No $typeName directive registered with name: $name"))
 
       def attributes: Result[Config] = ConfigResolver
-        .resolve(parsedResult.attributes, origin, cursor.config, Map.empty)
-        .map(new ObjectConfig(_, origin, cursor.config))
+        .resolve(parsedResult.attributes, origin, Map.empty)
+        .map(new ObjectConfig(_, cursor.config))
         .left.map(e => Seq(e.message))
 
       val body = parsedResult.body.map(BodyContent.Source.apply)
@@ -263,8 +263,8 @@ trait DirectiveBuilderContext[E <: Element] {
         .fold(
           messages =>
             createInvalidElement(
-              s"One or more errors processing directive '$name': "
-                + messages.mkString(", ")
+              s"One or more errors processing directive '$name': " +
+                messages.mkString(", ")
             ),
           identity
         )

--- a/core/shared/src/main/scala/laika/api/config/ConfigBuilder.scala
+++ b/core/shared/src/main/scala/laika/api/config/ConfigBuilder.scala
@@ -18,6 +18,7 @@ package laika.api.config
 
 import laika.internal.collection.TransitionalCollectionOps.*
 import ConfigValue.ObjectValue
+import laika.internal.parse.hocon.ResolvedRef
 
 /** A builder for creating a Config instance programmatically.
   *
@@ -79,7 +80,11 @@ class ConfigBuilder private (fields: Seq[Field], origin: Origin, fallback: Confi
     */
   def build(newFallback: Config): Config =
     if (fields.isEmpty && origin == Origin.root && fallback == EmptyConfig) newFallback
-    else new ObjectConfig(asObjectValue, origin, fallback.withFallback(newFallback))
+    else
+      new ObjectConfig(
+        ResolvedRef.fromRoot(asObjectValue, origin),
+        fallback.withFallback(newFallback)
+      )
 
   private[laika] def asObjectValue: ObjectValue = mergeObjects(ObjectValue(fields))
 

--- a/core/shared/src/main/scala/laika/api/config/ConfigValue.scala
+++ b/core/shared/src/main/scala/laika/api/config/ConfigValue.scala
@@ -18,6 +18,7 @@ package laika.api.config
 
 import laika.api.config.Origin.Scope
 import laika.ast.{ Element, Path }
+import laika.internal.parse.hocon.ResolvedRef
 
 /** The base trait for all configuration values.
   *
@@ -95,7 +96,7 @@ object ConfigValue {
       val origin =
         if (values.isEmpty) Origin.root
         else values.groupBy(_.origin).toSeq.maxBy(_._2.size)._1
-      new ObjectConfig(this, origin)
+      new ObjectConfig(ResolvedRef.fromRoot(this, origin))
     }
 
   }

--- a/core/shared/src/main/scala/laika/api/config/Key.scala
+++ b/core/shared/src/main/scala/laika/api/config/Key.scala
@@ -30,6 +30,9 @@ case class Key(segments: Seq[String]) {
 
   def local: Key = if (segments.isEmpty) this else Key(segments.last)
 
+  private[laika] def separateNextLevel: Option[(String, Key)] =
+    if (segments.isEmpty) None else Some((segments.head, Key(segments.tail)))
+
   override def toString: String = if (segments.isEmpty) "<RootKey>" else segments.mkString(".")
 }
 

--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -439,10 +439,9 @@ class DocumentCursor private (
   ): Either[ConfigError, DocumentCursor] =
     template.config.resolve(
       Origin(Origin.TemplateScope, template.path),
-      config,
       root.target.includes
     ).map { templateConfig =>
-      val mergedTarget = target.withTemplateConfig(templateConfig.withoutFallback)
+      val mergedTarget = target.withTemplateConfig(templateConfig)
       new DocumentCursor(
         mergedTarget,
         parent,

--- a/core/shared/src/main/scala/laika/internal/directive/IncludeDirectives.scala
+++ b/core/shared/src/main/scala/laika/internal/directive/IncludeDirectives.scala
@@ -19,7 +19,7 @@ package laika.internal.directive
 import cats.syntax.all.*
 import laika.api.bundle.{ BlockDirectives, TemplateDirectives }
 import laika.api.config.ConfigValue.{ ASTValue, ObjectValue }
-import laika.api.config.{ Config, Field, ObjectConfig, Origin }
+import laika.api.config.{ Config, ConfigValue, Field, Key, Origin }
 import laika.ast.*
 import laika.parse.SourceFragment
 
@@ -36,11 +36,11 @@ import laika.parse.SourceFragment
   */
 private[laika] object IncludeDirectives {
 
-  private def config(attributes: Config, body: Option[Element], path: Path): ObjectValue = {
-    val attributeValues = attributes match {
-      case oc: ObjectConfig => oc.root.values
-      case _                => Nil
-    }
+  private def config(attributes: Config, body: Option[Element], path: Path): ConfigValue = {
+    val attributeValues = attributes.get[ConfigValue](Key.root).map {
+      case ov: ObjectValue => ov.values
+      case _               => Nil
+    }.getOrElse(Nil)
     val bodyValue       =
       body.map(b => Field("embeddedBody", ASTValue(b), Origin(Origin.DirectiveScope, path)))
     ObjectValue(attributeValues ++ bodyValue.toSeq)

--- a/core/shared/src/main/scala/laika/internal/parse/hocon/ConfigBuilderValue.scala
+++ b/core/shared/src/main/scala/laika/internal/parse/hocon/ConfigBuilderValue.scala
@@ -18,7 +18,7 @@ package laika.internal.parse.hocon
 
 import laika.api.config.ConfigValue.SimpleValue
 import laika.api.config.Key
-import laika.parse.Failure
+import laika.parse.{ Failure, SourceCursor }
 
 /** The base trait of the interim configuration model (usually obtained from a HOCON parser).
   *
@@ -115,4 +115,5 @@ private[laika] case class IncludeClassPath(
 private[laika] case class IncludeAny(resourceId: StringBuilderValue, isRequired: Boolean = false)
     extends IncludeResource
 
-private[laika] case class IncludeBuilderValue(resource: IncludeResource) extends ConfigBuilderValue
+private[laika] case class IncludeBuilderValue(resource: IncludeResource, cursor: SourceCursor)
+    extends ConfigBuilderValue

--- a/core/shared/src/main/scala/laika/internal/parse/hocon/ConfigResolver.scala
+++ b/core/shared/src/main/scala/laika/internal/parse/hocon/ConfigResolver.scala
@@ -17,248 +17,158 @@
 package laika.internal.parse.hocon
 
 import cats.data.NonEmptyChain
-import laika.api.config.{ Config, ConfigError, ConfigValue, Field, Key, Origin }
+import laika.api.config.{ ConfigError, Key, Origin }
 import laika.internal.collection.TransitionalCollectionOps.*
 import laika.api.config.Config.IncludeMap
-import laika.api.config.ConfigError.{ InvalidField, InvalidFields, ResolverFailed }
+import laika.api.config.ConfigError.{ InvalidField, InvalidFields }
 import laika.api.config.ConfigValue.*
-import laika.parse.Failure
+import laika.parse.{ Failure, Message }
 
-import scala.collection.mutable
-
-/** Translates the interim configuration model (usually obtained from a HOCON parser)
-  * into the final object model. It turns a root `ObjectBuilderValue` into
-  * a root `ObjectValue`.
+/** Translates the configuration builder model (usually obtained from a HOCON parser)
+  * into and partially resolved interim model.
+  * It turns a root `ObjectBuilderValue` into a root `FieldRef`.
+  * The only fields the interim model leaves unresolved are those that need to
+  * query a fallback `Config`, since the fallback can change
+  * when a `Document` gets "re-homed" into a different `DocumentTree`.
   *
   * The translation step involves the following steps:
   *
-  * - Expand keys (e.g. `{ a.b.c = 7 }` will become `{ a = { b = { c = 7 }}}`
+  * - Expand keys (e.g. `{ a.b.c = 7 }` will become `{ a = { b = { c = 7 }}}`)
   * - Merge objects with a common base path
   * - Merge concatenated values (e.g. `[1,2] [3,4]` will become `[1,2,3,4]`
-  * - Resolve substitution variables (potentially using the provided fallback if not found in
-  *   in the provided unresolved root)
+  * - Resolve substitution variables if the referenced value is available within this scope.
+  * - Wrap unresolved substitution variables in a lazy reference that can later get
+  *   resolved against a parent configuration, which may change when a document is re-homed.
   *
   * @author Jens Halm
   */
 private[laika] object ConfigResolver {
 
-  /** Translates the interim configuration model (usually obtained from a HOCON parser)
-    * into the final object model. It turns a root `ObjectBuilderValue` into
-    * a root `ObjectValue`.
+  implicit class KeyOps(value: Key) {
+    def name: String = value.segments.lastOption.getOrElse("")
+  }
+
+  /** Translates the configuration builder model (usually obtained from a HOCON parser)
+    * into and partially resolved interim model.
+    * It turns a root `ObjectBuilderValue` into a root `FieldRef`.
+    * The only fields the interim model leaves unresolved are those that need to
+    * query a fallback `Config`, since the fallback can change
+    * when a `Document` gets "re-homed" into a different `DocumentTree`.
     *
     * The translation step involves the following steps:
     *
-    * - Expand keys (e.g. `{ a.b.c = 7 }` will become `{ a = { b = { c = 7 }}}`
+    * - Expand keys (e.g. `{ a.b.c = 7 }` will become `{ a = { b = { c = 7 }}}`)
     * - Merge objects with a common base path
     * - Merge concatenated values (e.g. `[1,2] [3,4]` will become `[1,2,3,4]`
-    * - Resolve substitution variables (potentially using the provided fallback if not found in
-    *   in the provided unresolved root)
+    * - Resolve substitution variables if the referenced value is available within this scope.
+    * - Wrap unresolved substitution variables in a lazy reference that can later get
+    *   resolved against a parent configuration, which may change when a document is re-homed.
     */
   def resolve(
       root: ObjectBuilderValue,
       origin: Origin,
-      fallback: Config,
       includes: IncludeMap
-  ): Either[ConfigError, ObjectValue] = {
+  ): Either[ConfigError, FieldRef] = {
 
-    val errors = extractErrors(root)
+    val resolvedIncludes = resolveIncludes(root, includes)
+    val errors           = extractErrors(resolvedIncludes)
 
     NonEmptyChain.fromSeq(errors) match {
-      case (Some(errs)) => Left(InvalidFields(errs))
-      case None         =>
-        val rootExpanded = mergeObjects(expandPaths(root))
+      case Some(errs) => Left(InvalidFields(errs))
+      case None       =>
+        val rootExpanded = mergeObjects(expandPaths(resolvedIncludes))
 
-        val activeFields   = mutable.Set.empty[Key]
-        val resolvedFields = mutable.Map.empty[Key, ConfigValue]
-        val startedObjects =
-          mutable.Map.empty[Key, ObjectBuilderValue] // may be in progress or resolved
-        val invalidPaths = mutable.Map.empty[Key, String]
-
-        def resolvedValue(path: Key): Option[ConfigValue] = resolvedFields.get(path)
-
-        def deepMerge(o1: ObjectValue, o2: ObjectValue): ObjectValue = {
-          val resolvedFields =
-            (o1.values ++ o2.values).groupBy(_.key).mapValuesStrict(_.map(_.value)).toSeq.map {
-              case (name, values) => Field(name, values.reduce(merge), origin)
+        def resolveValue(key: Key)(value: ConfigBuilderValue): Option[FieldRef] = value match {
+          case o: ObjectBuilderValue   => Some(resolveObject(key, o))
+          case a: ArrayBuilderValue    =>
+            val values = a.values.zipWithIndex.flatMap { case (value, index) =>
+              resolveValue(Key(key.segments :+ index.toString))(value)
             }
-          ObjectValue(resolvedFields.sortBy(_.key))
-        }
-
-        def resolveValue(key: Key)(value: ConfigBuilderValue): Option[ConfigValue] = value match {
-          case o: ObjectBuilderValue => Some(resolveObject(o, key))
-          case a: ArrayBuilderValue  =>
-            Some(ArrayValue(a.values.flatMap(resolveValue(key)))) // TODO - adjust path?
-          case r: ResolvedBuilderValue => Some(r.value)
-          case s: ValidStringValue     => Some(StringValue(s.value))
+            Some(FieldRef.arrayRef(key.name, origin, values.toList))
+          case r: ResolvedBuilderValue => Some(ScalarRef(key.name, origin, r.value))
+          case s: ValidStringValue     => Some(ScalarRef(key.name, origin, StringValue(s.value)))
           case c: ConcatValue          =>
-            c.allParts.flatMap(resolveConcatPart(key)).reduceOption(concat(key))
-          case m: MergedValue          => resolveMergedValue(key: Key)(m.values.reverse)
-          case SelfReference           => None
-          case _: InvalidStringValue   => None
-          case SubstitutionValue(ref, true) if ref == key => None
-          case SubstitutionValue(ref, optional)           =>
-            resolvedValue(ref).orElse(lookahead(ref)).orElse {
-              if (!optional) invalidPaths += ((key, s"Missing required reference: '$ref'"))
-              None
-            }
-          case _                                          => None
+            val parts = c.allParts.toList.flatMap(resolveConcatPart(key))
+            Some(FieldRef.concatRef(key.name, origin, parts))
+          case m: MergedValue          =>
+            Some(FieldRef.mergedRef(key.name, origin, m.values.toList.flatMap(resolveValue(key))))
+          case SubstitutionValue(ref, optional) if ref != key =>
+            Some(resolveSubstitution(key, ref, optional).withName(key.name))
+          case _                                              => None
         }
 
-        def resolveMergedValue(key: Key)(values: Seq[ConfigBuilderValue]): Option[ConfigValue] = {
-
-          def loop(values: Seq[ConfigBuilderValue]): Option[ConfigValue] =
-            (resolveValue(key)(values.head), values.tail) match {
-              case (Some(ov: ObjectValue), Nil)  => Some(ov)
-              case (Some(ov: ObjectValue), rest) =>
-                loop(rest) match {
-                  case Some(o2: ObjectValue) => Some(merge(o2, ov))
-                  case _                     => Some(ov)
-                }
-              case (Some(other), _)              => Some(other)
-              case (None, Nil)                   => None
-              case (None, rest)                  => loop(rest)
-            }
-
-          loop(values)
+        def resolveObject(key: Key, value: ObjectBuilderValue): FieldRef = {
+          val fields = value.values.toList.flatMap(fd => resolveValue(fd.validKey)(fd.value))
+          FieldRef.objectRef(key.name, origin, fields)
         }
 
-        def lookahead(key: Key): Option[ConfigValue] = {
-
-          def resolvedParent(current: Key): Option[(ObjectBuilderValue, Key)] = {
-            if (current.segments.isEmpty) Some((rootExpanded, current))
-            else {
-              val matching = startedObjects.toSeq.filter(o => current.isChild(o._1))
-              val sorted   = matching.sortBy(_._1.segments.length)
-              sorted.lastOption.fold(resolvedParent(current.parent)) { case (commonPath, obv) =>
-                Some((obv, Key(current.segments.take(commonPath.segments.size + 1))))
-              }
-            }
-          }
-
-          if (activeFields.contains(key)) {
-            invalidPaths += ((key, s"Circular Reference involving path '$key'"))
-            Some(NullValue)
-          }
-          else {
-            resolvedParent(key).flatMap { case (obj, fieldPath) =>
-              obj.values.find(_.validKey == fieldPath).map(_.value).foreach(
-                resolveField(fieldPath, _)
-              )
-              resolvedValue(key).orElse(fallback.get[ConfigValue](key).toOption)
-            }
-          }
+        def resolveSubstitution(parentKey: Key, refKey: Key, optional: Boolean): FieldRef = {
+          if (parentKey.isChild(refKey))
+            InvalidRef(refKey.name, origin, s"Circular Reference involving path '$refKey'")
+          else
+            FieldRef.substitution(parentKey.name, origin, refKey, optional)
         }
 
-        def resolveConcatPart(key: Key)(part: ConcatPart): Option[ConfigValue] = part.value match {
+        def resolveConcatPart(key: Key)(part: ConcatPart): Option[FieldRef] = part.value match {
           case SelfReference => None
           case other         =>
             resolveValue(key)(other) match {
-              case Some(simpleValue: SimpleValue) =>
-                Some(StringValue(part.whitespace + simpleValue.render))
-              case Some(_: ASTValue)              => None
-              case other                          => other
+              case Some(scalar: ScalarRef) =>
+                Some(scalar.copy(value = StringValue(part.whitespace + scalar.value.render)))
+              case other                   => other
             }
         }
 
-        def concat(key: Key)(v1: ConfigValue, v2: ConfigValue): ConfigValue = {
-          (v1, v2) match {
-            case (o1: ObjectValue, o2: ObjectValue) => deepMerge(o1, o2)
-            case (a1: ArrayValue, a2: ArrayValue)   => ArrayValue(a1.values ++ a2.values)
-            case (s1: StringValue, s2: StringValue) => StringValue(s1.value ++ s2.value)
-            case (NullValue, a2: ArrayValue)        => a2
-            case _                                  =>
-              invalidPaths += ((
-                key,
-                s"Invalid concatenation of values. It must contain either only objects, only arrays or only simple values"
-              ))
-              NullValue
-          }
-        }
-
-        def merge(v1: ConfigValue, v2: ConfigValue): ConfigValue = {
-          (v1, v2) match {
-            case (o1: ObjectValue, o2: ObjectValue) => deepMerge(o1, o2)
-            case (_, c2)                            => c2
-          }
-        }
-
-        def resolveField(
-            key: Key,
-            value: ConfigBuilderValue
-        ): Option[ConfigValue] = {
-          resolvedValue(key).orElse {
-            activeFields += key
-            val res = resolveValue(key)(value)
-            activeFields -= key
-            res.foreach { resolved =>
-              resolvedFields += ((key, resolved))
-            }
-            res
-          }
-        }
-
-        def resolveObject(obj: ObjectBuilderValue, key: Key): ObjectValue = {
-          startedObjects += ((key, obj))
-
-          def resolve(field: BuilderField): Option[Field] =
-            resolveField(field.validKey, field.value).map(
-              Field(field.validKey.local.toString, _, origin)
-            )
-
-          val resolvedFields = obj.values.flatMap {
-            case BuilderField(_, IncludeBuilderValue(resource)) =>
-              includes.get(resource) match {
-                case None                  =>
-                  if (resource.isRequired)
-                    invalidPaths += ((
-                      key,
-                      s"Missing required include '${resource.resourceId.value}'"
-                    ))
-                  Nil
-                case Some(Left(error))     =>
-                  invalidPaths += ((
-                    key,
-                    s"Error including '${resource.resourceId.value}': ${error.message}"
-                  ))
-                  Nil
-                case Some(Right(included)) =>
-                  resolveObject(included, key).values
-              }
-            case field                                          => resolve(field)
-          }
-          ObjectValue(resolvedFields.sortBy(_.key))
-        }
-
-        val res = resolveObject(rootExpanded, Key.root)
-
-        if (invalidPaths.nonEmpty)
-          Left(
-            ResolverFailed(
-              s"One or more errors resolving configuration: ${
-                  invalidPaths.map { case (key, msg) => s"'$key': $msg" }.mkString(", ")
-                }"
-            )
-          )
-        else Right(res)
+        Right(resolveObject(Key.root, rootExpanded))
     }
+  }
+
+  private def resolveIncludes(
+      obj: ObjectBuilderValue,
+      includes: IncludeMap
+  ): ObjectBuilderValue = {
+
+    val resolvedFields = obj.values.flatMap {
+      case bf @ BuilderField(key, value @ IncludeBuilderValue(resource, source)) =>
+        resource.resourceId match {
+          case _: InvalidStringValue => Seq(bf) // errors get extracted later
+          case _                     =>
+            includes.get(resource) match {
+              case Some(Left(error))           =>
+                val msg = s"Error including '${resource.resourceId.value}': ${error.message}"
+                Seq(
+                  BuilderField(key, InvalidBuilderValue(value, Failure(Message.fixed(msg), source)))
+                )
+              case None if resource.isRequired =>
+                val msg = s"Missing required include '${resource.resourceId.value}'"
+                Seq(
+                  BuilderField(key, InvalidBuilderValue(value, Failure(Message.fixed(msg), source)))
+                )
+              case None                        => Nil
+              case Some(Right(included))       =>
+                resolveIncludes(included, includes).values
+            }
+        }
+      case BuilderField(key, nested: ObjectBuilderValue)                         =>
+        Seq(BuilderField(key, resolveIncludes(nested, includes)))
+      case other                                                                 => Seq(other)
+    }
+    ObjectBuilderValue(resolvedFields.sortBy(_.validKey.toString))
   }
 
   /** Merges objects with a common base path into a single one.
     *
-    * ```
+    * {{{
     * a = { b = { c = 7 }}
     *
     * a = { b = { d = 9 }}
-    * ```
+    * }}}
     *
     * will become
     *
-    * ```
+    * {{{
     * a = { b = { c = 7, d = 9 }}
-    * ```
-    *
-    * @param obj
-    * @return
+    * }}}
     */
   def mergeObjects(obj: ObjectBuilderValue): ObjectBuilderValue = {
 
@@ -306,15 +216,15 @@ private[laika] object ConfigResolver {
 
   /** Expands all flattened path expressions to nested objects.
     *
-    * ```
-    * { a.b.c = 7 }
-    * ```
+    * {{{
+    * a.b.c = 7
+    * }}}
     *
     * will become
     *
-    * ```
-    * { a = { b = { c = 7 }}}
-    * ```
+    * {{{
+    * a = { b = { c = 7 }}
+    * }}}
     */
   def expandPaths(obj: ObjectBuilderValue, key: Key = Key.root): ObjectBuilderValue = {
 

--- a/core/shared/src/main/scala/laika/internal/parse/hocon/FieldRef.scala
+++ b/core/shared/src/main/scala/laika/internal/parse/hocon/FieldRef.scala
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.internal.parse.hocon
+
+import laika.api.config.ConfigValue.{
+  ASTValue,
+  ArrayValue,
+  NullValue,
+  ObjectValue,
+  SimpleValue,
+  StringValue
+}
+import laika.api.config.{ Config, ConfigEncoder, ConfigValue, Field, Key, ObjectConfig, Origin }
+import cats.syntax.all.*
+import laika.api.config.Config.ConfigResult
+import laika.api.config.ConfigError.ResolverFailed
+
+/** Interim structure that exists as a translation step between the `ConfigBuilderValue` ADT
+  * that closely reflects the HOCON model right after parsing and the final `ConfigValue` ADT
+  * that is the public API representing the fully resolved configuration values.
+  *
+  * The main purpose for this interim structure is to allow to defer the final resolution
+  * of some values, mainly for three reasons:
+  *
+  * - Allow some values to depend on a parent `Config` which may change when a document is "re-homed" into
+  *   a different tree
+  *
+  * - Allow errors to resolve on access only, preventing transformations to fail on values that are never accessed.
+  *
+  * - Allow the introduction of new public API that allows to create lazily evaluated configuration values
+  *   that may also depend on other configuration values dynamically.
+  */
+private[laika] sealed trait FieldRef {
+
+  def name: String
+
+  def origin: Origin
+
+  /* Navigates through nested structures to find the field with the specified key.
+     Will return this instance for the root key and `None` when arriving at a leaf node
+     with a key other than root.
+   */
+  def select(key: Key, context: ResolverContext): Option[ResolvedRef]
+
+  protected def selectChild(
+      name: String,
+      subKey: Key,
+      context: ResolverContext
+  ): Option[ResolvedRef]
+
+  def withName(name: String): FieldRef
+
+}
+
+/** A field reference that does not need access to the parent configuration
+  * to be fully resolved.
+  */
+private[laika] sealed trait ResolvedRef extends FieldRef {
+
+  type ValueType <: ConfigValue
+
+  /** Defined only for types of values that do not require access to the config instance.
+    * These types of values can be cached to avoid (potentially expensive) re-evaluations.
+    */
+  def cachedValue: ConfigResult[ValueType]
+
+  def select(key: Key, context: ResolverContext): Option[ResolvedRef] =
+    key.separateNextLevel.fold(Option(this)) { case (name, subKey) =>
+      selectChild(name, subKey, context)
+    }
+
+  /** Performs a deep merge only if both, this value and the specified other value
+    * are instances of `ObjectRef`.
+    *
+    * In all other cases the other object will take precedence and overwrite this value.
+    */
+  def merge(other: ResolvedRef): ResolvedRef = {
+    (this, other) match {
+      case (o1: ObjectRef, o2: ObjectRef) => o1.deepMerge(o2)
+      case (_, c2)                        => c2
+    }
+  }
+
+  def withName(name: String): ResolvedRef
+
+}
+
+private[laika] object ResolvedRef {
+
+  def fromField(field: Field): ResolvedRef = field.value match {
+    case s: SimpleValue => ScalarRef(field.key, field.origin, s)
+    case o: ObjectValue =>
+      ObjectRef(field.key, field.origin, o.values.map(fromField).toList)
+    case a: ArrayValue  =>
+      val fields = a.values.zipWithIndex.map { case (value, index) =>
+        Field(index.toString, value, field.origin)
+      }
+      ArrayRef(field.key, field.origin, fields.map(fromField).toList)
+    case ast: ASTValue  => ASTRef(field.key, field.origin, ast)
+  }
+
+  def fromRoot(root: ObjectValue, origin: Origin): ResolvedRef = fromField(Field("", root, origin))
+
+}
+
+private[laika] trait ResolvedLeafRef extends ResolvedRef {
+
+  protected def selectChild(
+      name: String,
+      subKey: Key,
+      context: ResolverContext
+  ): Option[ResolvedRef] = None
+
+}
+
+/** A field reference that needs access to the parent configuration to be fully resolved.
+  */
+private[laika] sealed abstract class UnresolvedRef(val name: String, val origin: Origin)
+    extends FieldRef {
+
+  def select(key: Key, context: ResolverContext): Option[ResolvedRef] =
+    key.separateNextLevel.fold(Option(resolve(context))) { case (name, subKey) =>
+      selectChild(name, subKey, context)
+    }
+
+  /** Resolves the value based on the specified config instance.
+    * The method always succeeds, potential errors will be encapsulated within the returned reference.
+    */
+  def resolve(context: ResolverContext): ResolvedRef
+
+}
+
+/**  Base trait for all fields that contain child nodes.
+  */
+private[laika] sealed trait ContainerRef extends ResolvedRef {
+
+  def valueDescription: String
+
+  def values: List[ResolvedRef]
+
+  def createContainer(values: List[ConfigValue]): ConfigResult[ValueType]
+
+  lazy val cachedValue: ConfigResult[ValueType] = {
+    val (errors, cachedValues) = values.map(_.cachedValue).separate
+    if (errors.isEmpty) createContainer(cachedValues)
+    else {
+      val msg =
+        s"One or more errors resolving $valueDescription: ${errors.map(_.message).mkString(", ")}"
+      Left(ResolverFailed(msg))
+    }
+  }
+
+}
+
+private[hocon] case class ScalarRef(name: String, origin: Origin, value: SimpleValue)
+    extends ResolvedLeafRef {
+  type ValueType = SimpleValue
+  val cachedValue                         = Right(value)
+  def withName(name: String): ResolvedRef = copy(name = name)
+}
+
+private[hocon] case class ASTRef(name: String, origin: Origin, value: ASTValue)
+    extends ResolvedLeafRef {
+  type ValueType = ASTValue
+  val cachedValue                         = Right(value)
+  def withName(name: String): ResolvedRef = copy(name = name)
+}
+
+private[hocon] case class InvalidRef(name: String, origin: Origin, error: String)
+    extends ResolvedLeafRef {
+  type ValueType = Nothing
+  val cachedValue                         = Left(ResolverFailed(s"Invalid Field '$name': $error"))
+  def withName(name: String): ResolvedRef = copy(name = name)
+
+  override protected def selectChild(
+      name: String,
+      subKey: Key,
+      context: ResolverContext
+  ): Option[ResolvedRef] =
+    Some(copy(error = s"Error in parent node of referenced object: $error"))
+
+}
+
+private[hocon] case class MissingOptionalRef(name: String, origin: Origin, substitutionKey: Key)
+    extends ResolvedLeafRef {
+  type ValueType = NullValue.type
+  val cachedValue                         = Right(NullValue)
+  def withName(name: String): ResolvedRef = copy(name = name)
+}
+
+private[laika] case class ArrayRef(name: String, origin: Origin, values: List[ResolvedRef])
+    extends ContainerRef {
+
+  type ValueType = ArrayValue
+
+  val valueDescription = "elements of array value"
+
+  def createContainer(children: List[ConfigValue]): ConfigResult[ValueType] =
+    Right(ArrayValue(children))
+
+  protected def selectChild(
+      name: String,
+      subKey: Key,
+      context: ResolverContext
+  ): Option[ResolvedRef] =
+    values.find(_.name == name).flatMap(_.select(subKey, context))
+
+  def withName(name: String): ResolvedRef = copy(name = name)
+}
+
+private[laika] case class ObjectRef(name: String, origin: Origin, values: List[ResolvedRef])
+    extends ContainerRef {
+
+  type ValueType = ObjectValue
+
+  val valueDescription = "fields of object value"
+
+  def createContainer(children: List[ConfigValue]): ConfigResult[ValueType] = {
+    val fields = children.zip(values).map { case (child, field) =>
+      Field(field.name, child, field.origin)
+    }
+    Right(ObjectValue(fields))
+  }
+
+  protected def selectChild(
+      name: String,
+      subKey: Key,
+      context: ResolverContext
+  ): Option[ResolvedRef] =
+    values.find(_.name == name).flatMap(_.select(subKey, context))
+
+  def deepMerge(other: ObjectRef): ObjectRef = {
+    val resolvedFields = (this.values ++ other.values)
+      .groupBy(_.name)
+      .values
+      .map(_.reduce(_.merge(_)))
+      .toList
+    ObjectRef(name, origin, resolvedFields.sortBy(_.name))
+  }
+
+  def withName(name: String): ResolvedRef = copy(name = name)
+
+}
+
+private[laika] object FieldRef {
+
+  def container(
+      fieldName: String,
+      configOrigin: Origin,
+      values: List[FieldRef],
+      selectResolved: Boolean
+  )(
+      createContainer: (String, Origin, List[ResolvedRef]) => ResolvedRef
+  ): FieldRef = {
+    def filterOptional(resolvedValues: List[ResolvedRef]) =
+      resolvedValues.filterNot(_.isInstanceOf[MissingOptionalRef]).sortBy(_.name)
+    val resolved = values.collect { case r: ResolvedRef => r }
+    if (resolved.size == values.size)
+      createContainer(fieldName, configOrigin, filterOptional(resolved))
+    else
+      new UnresolvedRef(fieldName, configOrigin) {
+
+        def resolve(context: ResolverContext): ResolvedRef = {
+          val resolvedValues = values.map {
+            case rr: ResolvedRef   => rr
+            case ur: UnresolvedRef => ur.resolve(context)
+          }
+          createContainer(name, origin, filterOptional(resolvedValues))
+        }
+
+        protected def selectChild(
+            name: String,
+            subKey: Key,
+            context: ResolverContext
+        ): Option[ResolvedRef] = {
+          if (selectResolved) resolve(context).selectChild(name, subKey, context)
+          else values.find(_.name == name).flatMap(_.select(subKey, context))
+        }
+
+        def withName(name: String): FieldRef =
+          container(name, configOrigin, values, selectResolved)(createContainer)
+      }
+  }
+
+  def arrayRef(name: String, origin: Origin, values: List[FieldRef]): FieldRef =
+    container(name, origin, values, selectResolved = false)(ArrayRef.apply)
+
+  def objectRef(name: String, origin: Origin, values: List[FieldRef]): FieldRef =
+    container(name, origin, values, selectResolved = false)(ObjectRef.apply)
+
+  def concatRef(name: String, origin: Origin, values: List[FieldRef]): FieldRef = {
+    container(name, origin, values, selectResolved = true) { (_, _, resolvedValues) =>
+      def concat(v1: ResolvedRef, v2: ResolvedRef): ResolvedRef = {
+        (v1, v2) match {
+          case (o1: ObjectRef, o2: ObjectRef) => o1.deepMerge(o2)
+          case (a1: ArrayRef, a2: ArrayRef)   => ArrayRef(name, origin, a1.values ++ a2.values)
+          case (s1: ScalarRef, s2: ScalarRef) =>
+            ScalarRef(name, origin, StringValue(s1.value.render + s2.value.render))
+          case (error: InvalidRef, _)         => error
+          case (_, error: InvalidRef)         => error
+          case _                              =>
+            val msg =
+              "Invalid concatenation of values. It must contain either only objects, only arrays or only scalar values"
+            InvalidRef(name, origin, msg)
+        }
+      }
+      resolvedValues match {
+        case Nil          => ScalarRef(name, origin, NullValue)
+        case List(single) => single
+        case multiple     => multiple.tail.foldLeft(multiple.head)(concat)
+      }
+    }
+  }
+
+  def mergedRef(name: String, origin: Origin, values: List[FieldRef]): FieldRef = {
+    container(name, origin, values, selectResolved = true) { (_, _, resolvedValues) =>
+      resolvedValues match {
+        case Nil          => ScalarRef(name, origin, NullValue)
+        case List(single) => single
+        case multiple     => multiple.reduce(_.merge(_))
+      }
+    }
+  }
+
+  def deferred[T](fieldName: String, configOrigin: Origin, value: => T)(implicit
+      encoder: ConfigEncoder[T]
+  ): ResolvedRef =
+    new ResolvedLeafRef {
+
+      type ValueType = ConfigValue
+
+      val name = fieldName
+
+      val origin = configOrigin
+
+      private lazy val encodedValue: ConfigValue = encoder(value)
+
+      lazy val cachedValue: ConfigResult[ValueType] = Right(encodedValue)
+
+      def withName(name: String): ResolvedRef = deferred(name, configOrigin, value)
+    }
+
+  def dependent[T](fieldName: String, configOrigin: Origin)(f: ResolverContext => ConfigResult[T])(
+      implicit encoder: ConfigEncoder[T]
+  ): FieldRef = new UnresolvedRef(fieldName, configOrigin) {
+    def resolve(context: ResolverContext): ResolvedRef = f(context) match {
+      case Left(error)  => InvalidRef(name, origin, error.message)
+      case Right(value) => ResolvedRef.fromField(Field(fieldName, encoder(value), origin))
+    }
+    protected def selectChild(
+        name: String,
+        subKey: Key,
+        context: ResolverContext
+    ): Option[ResolvedRef] =
+      resolve(context).selectChild(name, subKey, context)
+    def withName(name: String): FieldRef               = dependent(name, configOrigin)(f)
+  }
+
+  def substitution(
+      fieldName: String,
+      configOrigin: Origin,
+      substitutionRef: Key,
+      optional: Boolean
+  ): FieldRef = new UnresolvedRef(fieldName, configOrigin) {
+
+    def resolve(context: ResolverContext): ResolvedRef = {
+
+      def resolveSubstitution(currentConfig: Config): ResolvedRef = {
+        currentConfig match {
+          case foc: ObjectConfig =>
+            foc.root
+              .select(substitutionRef, context.withLookup(substitutionRef))
+              .getOrElse(resolveSubstitution(foc.fallback))
+              .withName(fieldName)
+          case _ if optional     => MissingOptionalRef(fieldName, configOrigin, substitutionRef)
+          case _                 =>
+            val msg = s"Missing required reference: '$substitutionRef'"
+            InvalidRef(fieldName, configOrigin, msg)
+        }
+      }
+
+      if (context.lookups.contains(substitutionRef)) {
+        val keys = context.lookups.toSeq.map(_.toString).sorted.mkString("'", "','", "'")
+        InvalidRef(fieldName, configOrigin, s"Circular Reference involving paths $keys")
+      }
+      else resolveSubstitution(context.config)
+    }
+
+    protected def selectChild(
+        name: String,
+        subKey: Key,
+        context: ResolverContext
+    ): Option[ResolvedRef] =
+      resolve(context).selectChild(name, subKey, context)
+    def withName(name: String): FieldRef =
+      substitution(name, configOrigin, substitutionRef, optional)
+  }
+
+}
+
+private[laika] case class ResolverContext(config: Config, lookups: Set[Key] = Set.empty) {
+  def withLookup(key: Key) = copy(lookups = lookups + key)
+}

--- a/core/shared/src/main/scala/laika/internal/parse/hocon/HoconParsers.scala
+++ b/core/shared/src/main/scala/laika/internal/parse/hocon/HoconParsers.scala
@@ -287,7 +287,9 @@ private[laika] object HoconParsers {
         }
       }
 
-    "include " ~> (required | includeResource).map(IncludeBuilderValue.apply) <~ ws
+    ("include " ~> (required | includeResource)).withCursor.map { case (res, cursor) =>
+      IncludeBuilderValue.apply(res, cursor)
+    } <~ ws
   }
 
   /** Parses a comment. */

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -32,6 +32,7 @@ import laika.api.bundle.{
   ExtensionBundle,
   SpanParserBuilder
 }
+import laika.api.config.Config.IncludeMap
 import laika.api.config.{ Config, ConfigBuilder, ConfigError, ConfigParser, Origin }
 import laika.ast.styles.{ StyleDeclaration, StylePredicate }
 import laika.internal.parse.css.CSSParsers
@@ -413,7 +414,7 @@ class ConfigProviderSpec extends FunSuite with BundleSetup {
     .markupConfigHeader
     .parse(input) match {
       case Success(builderRoot, _) =>
-        builderRoot.resolve(Origin.root, Config.empty, Map.empty)
+        builderRoot.resolve(Origin.root, Map.empty: IncludeMap)
       case f: Failure              => Left(ParsingFailed(f))
     }
 


### PR DESCRIPTION
This is a bigger refactoring inside the config resolver that became necessary for fixing a rather esoteric bug. But it will also enable some new functionality that was previously difficult to add which will be part of one or two follow-up PRs.

The bug itself: When using a substitution reference in HOCON `a = ${b}`, the value b may be read from a parent config, which for documents might be the directory config or the root config. The problem was that the value was evaluated only once, so in the rare case of a developer "re-homing" a document (moving it from one `DocumentTree` to another), the dependent value would still read from the old parent.

This PR also adds a new test case for this very specific scenario.