### PR TITLE
Add scrollbar to #page-nav

### DIFF
--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -346,7 +346,7 @@ ul.nav-list, #page-nav ul {
 #page-nav {
   display: none;
   position: fixed;
-  height: 80%;
+  max-height: calc(100% - 90px - var(--top-bar-height));
   overflow-y: auto;
   top: calc(45px + var(--top-bar-height));
   right: 45px;

--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -346,6 +346,8 @@ ul.nav-list, #page-nav ul {
 #page-nav {
   display: none;
   position: fixed;
+  height: 80%;
+  overflow-y: auto;
   top: calc(45px + var(--top-bar-height));
   right: 45px;
   width: 250px;


### PR DESCRIPTION
Took a quick stab at [issue 706](https://github.com/typelevel/Laika/issues/706). There are many ways to solve this, but simply adding a height and a scrollbar on vertical overflow is the easiest solution that does not require additional changes to the DOM. Again, with [http4s](https://http4s.org/changelog.html)'s changelog as an example it will look like this:

![Screenshot 2025-04-25 at 11 54 55](https://github.com/user-attachments/assets/c2959fdc-f0d7-46a7-a906-1db9818e6eda)


I picked `height: 80%` because it still looks somewhat ok an really short screens. I found that 90% was too cramped when the screen was getting really short.

With `height: 90%` it looks like the screenshot on the bottom, where you cannot actually scroll all the way down.

![Screenshot 2025-04-25 at 12 01 18](https://github.com/user-attachments/assets/92e0df4b-b92b-4279-96b6-66c395979677)

Compared that wight `height: 80%`:

![Screenshot 2025-04-25 at 11 55 33](https://github.com/user-attachments/assets/697eb2fd-2282-40c3-9b1b-9ebcad706d59)
