### PR TITLE
Config API - allow definition of lazy or dependent values

### DIFF
--- a/core/shared/src/test/scala/laika/api/config/ConfigBuilderSpec.scala
+++ b/core/shared/src/test/scala/laika/api/config/ConfigBuilderSpec.scala
@@ -1,0 +1,87 @@
+package laika.api.config
+
+import laika.api.config.ConfigError.{ DecodingFailed, ResolverFailed }
+import laika.api.config.ConfigValue.{ LongValue, ObjectValue }
+import munit.FunSuite
+
+class ConfigBuilderSpec extends FunSuite {
+
+  def getLeftValue: Either[ConfigError, Int] =
+    Left(DecodingFailed("expected error"))
+
+  test("ConfigValue.delay") {
+    val config   = ConfigBuilder.empty
+      .withValue("foo.bar", 7)
+      .withValue("foo.baz", ConfigValue.delay(9))
+      .build
+    val res      = config.get[ConfigValue]("foo")
+    val expected = ObjectValue(
+      Seq(
+        Field("bar", LongValue(7)),
+        Field("baz", LongValue(9))
+      )
+    )
+    assertEquals(res, Right(expected))
+  }
+
+  test("ConfigValue.eval - Right") {
+    val config   = ConfigBuilder.empty
+      .withValue("foo.bar", 7)
+      .withValue("foo.baz", ConfigValue.eval(Right(9)))
+      .build
+    val res      = config.get[ConfigValue]("foo")
+    val expected = ObjectValue(
+      Seq(
+        Field("bar", LongValue(7)),
+        Field("baz", LongValue(9))
+      )
+    )
+    assertEquals(res, Right(expected))
+  }
+
+  test("ConfigValue.eval - Left") {
+    val config   = ConfigBuilder.empty
+      .withValue("foo.bar", 7)
+      .withValue("foo.baz", ConfigValue.eval(getLeftValue))
+      .build
+    val res      = config.get[ConfigValue]("foo")
+    val expected =
+      ResolverFailed("One or more errors resolving fields of object value: expected error")
+    assertEquals(res, Left(expected))
+  }
+
+  test("ConfigValue.eval with Config - Right") {
+    val dependentValue = ConfigValue.eval { config =>
+      config.get[Int]("ref").map(_ + 5)
+    }
+    val config         = ConfigBuilder.empty
+      .withValue("ref", 10)
+      .withValue("foo.bar", 7)
+      .withValue("foo.baz", dependentValue)
+      .build
+    val res            = config.get[ConfigValue]("foo")
+    val expected       = ObjectValue(
+      Seq(
+        Field("bar", LongValue(7)),
+        Field("baz", LongValue(15))
+      )
+    )
+    assertEquals(res, Right(expected))
+  }
+
+  test("ConfigValue.eval with Config - Left") {
+    val dependentValue = ConfigValue.eval { config =>
+      config.get[Int]("ref")
+    }
+    val config         = ConfigBuilder.empty
+      .withValue("foo.bar", 7)
+      .withValue("foo.baz", dependentValue)
+      .build
+    val res            = config.get[ConfigValue]("foo")
+    val expected       = ResolverFailed(
+      "One or more errors resolving fields of object value: Invalid Field 'baz': Not found: 'ref'"
+    )
+    assertEquals(res, Left(expected))
+  }
+
+}

--- a/docs/src/06-sub-modules/03-laikas-hocon-api.md
+++ b/docs/src/06-sub-modules/03-laikas-hocon-api.md
@@ -267,6 +267,30 @@ They are in the companion, therefore do not require any imports.
 
 You can alternatively create your own encoder as shown above.
 
+The API also allows to define a value that will be evaluated lazily on first access.
+This can be an efficient option for library or theme authors who define values that are expensive to compute
+and might not even get accessed by the end user:
+
+```scala mdoc:compile-only
+import laika.api.config.ConfigValue
+
+def expensiveComputation: String = ???
+
+val config = ConfigBuilder.empty
+  .withValue("very.expensive", ConfigValue.delay(expensiveComputation))
+  .build
+```
+
+There is also a method called `eval` that allows to define values dependent on other configuration values:
+
+```scala mdoc:compile-only
+val config = ConfigBuilder.empty
+  .withValue("ten.more.pages", ConfigValue.eval { config => 
+    config.get[Int]("max.pages").map(_ + 10)
+  })
+  .build
+```
+
 If you have a fallback instance, you can pass it to the constructor:
 
 ```scala mdoc:compile-only


### PR DESCRIPTION
Based on the refactoring in #704 and the resulting indirection in resolving configuration values, we can now add new ways to programmatically declare configuration values that are evaluated lazily (on first access) or dependent on other configuration values and evaluated on each access. The new section in the manual below describes the functionality:

---

The API also allows to define a value that will be evaluated lazily on first access.
This can be an efficient option for library or theme authors who define values that are expensive to compute
and might not even get accessed by the end user:

```scala mdoc:compile-only
def expensiveComputation: String = ???

val config = ConfigBuilder.empty
  .withValue("very.expensive", ConfigValue.delay(expensiveComputation))
```

There is also a method called `eval` that allows to define values dependent on other configuration values:

```scala mdoc:compile-only
val config = ConfigBuilder.empty
  .withValue("ten.more.pages", ConfigValue.eval { config => 
    config.get[Int]("max.pages").map(_ + 10)
  })
```
