### PR TITLE
fix rendering of 404 page for typelevel website

### DIFF
--- a/core/shared/src/main/scala/laika/api/Renderer.scala
+++ b/core/shared/src/main/scala/laika/api/Renderer.scala
@@ -136,23 +136,28 @@ abstract class Renderer private[laika] (val config: OperationConfig, skipRewrite
         .leftMap(InvalidConfig(_))
     }
 
-    (if (skipRewrite) Right(targetElement) else rewrite).map { elementToRender =>
-      val renderContext =
-        new Formatter.Context[Formatter](
-          renderFunction,
-          elementToRender,
-          Nil,
-          styles,
-          doc.path,
-          pathTranslator,
-          if (config.compactRendering) Indentation.none else Indentation.default,
-          config.messageFilters.render
-        )
+    (if (skipRewrite) Right(targetElement) else rewrite).flatMap { elementToRender =>
+      doc.config
+        .getOpt[String]("laika.renderTarget.absolute.baseUrl")
+        .leftMap(InvalidConfig(_))
+        .map { baseUrlOpt =>
+          val renderContext =
+            new Formatter.Context[Formatter](
+              renderFunction,
+              elementToRender,
+              Nil,
+              styles,
+              doc.path,
+              pathTranslator,
+              if (config.compactRendering) Indentation.none else Indentation.default,
+              config.messageFilters.render,
+              baseUrlOpt
+            )
 
-      val formatter = format.formatterFactory(renderContext)
-
-      renderFunction(formatter, elementToRender)
-    }
+          val formatter = format.formatterFactory(renderContext)
+          renderFunction(formatter, elementToRender)
+        }
+      }
   }
 
   /** Creates a new instance that will skip the rewrite phase when rendering elements.

--- a/core/shared/src/main/scala/laika/api/Renderer.scala
+++ b/core/shared/src/main/scala/laika/api/Renderer.scala
@@ -157,7 +157,7 @@ abstract class Renderer private[laika] (val config: OperationConfig, skipRewrite
           val formatter = format.formatterFactory(renderContext)
           renderFunction(formatter, elementToRender)
         }
-      }
+    }
   }
 
   /** Creates a new instance that will skip the rewrite phase when rendering elements.

--- a/core/shared/src/main/scala/laika/api/format/Formatter.scala
+++ b/core/shared/src/main/scala/laika/api/format/Formatter.scala
@@ -61,6 +61,12 @@ abstract class Formatter protected {
     */
   def pathTranslator: PathTranslator = context.pathTranslator
 
+  /** The absolute base URL to use for rendering internal targets as absolute URLs.*/
+  def internalTargetsAbsoluteBaseUrl: Option[String] = context.internalTargetsAbsoluteBaseUrl
+  
+  /** Indicates whether internal targets should be rendered as absolute URLs.*/
+  def internalTargetsAbsolute: Boolean = internalTargetsAbsoluteBaseUrl.nonEmpty
+
   /** The styles the new renderer should apply to the rendered elements.
     *
     * Only used for some special render formats like XSL-FO.
@@ -172,7 +178,8 @@ object Formatter {
       val path: Path,
       val pathTranslator: PathTranslator,
       val indentation: Formatter.Indentation,
-      val messageFilter: MessageFilter
+      val messageFilter: MessageFilter,
+      val internalTargetsAbsoluteBaseUrl: Option[String]
   ) {
 
     def forChildElement(child: Element): Context[FMT] =
@@ -184,7 +191,8 @@ object Formatter {
         path,
         pathTranslator,
         indentation,
-        messageFilter
+        messageFilter,
+        internalTargetsAbsoluteBaseUrl
       )
 
     def withIndentation(newValue: Formatter.Indentation): Context[FMT] =
@@ -196,7 +204,8 @@ object Formatter {
         path,
         pathTranslator,
         newValue,
-        messageFilter
+        messageFilter,
+        internalTargetsAbsoluteBaseUrl
       )
 
   }

--- a/core/shared/src/main/scala/laika/api/format/Formatter.scala
+++ b/core/shared/src/main/scala/laika/api/format/Formatter.scala
@@ -61,10 +61,10 @@ abstract class Formatter protected {
     */
   def pathTranslator: PathTranslator = context.pathTranslator
 
-  /** The absolute base URL to use for rendering internal targets as absolute URLs.*/
+  /** The absolute base URL to use for rendering internal targets as absolute URLs. */
   def internalTargetsAbsoluteBaseUrl: Option[String] = context.internalTargetsAbsoluteBaseUrl
-  
-  /** Indicates whether internal targets should be rendered as absolute URLs.*/
+
+  /** Indicates whether internal targets should be rendered as absolute URLs. */
   def internalTargetsAbsolute: Boolean = internalTargetsAbsoluteBaseUrl.nonEmpty
 
   /** The styles the new renderer should apply to the rendered elements.

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -155,11 +155,33 @@ private[laika] class HTMLRenderer(format: String)
     def renderTarget(target: Target): String = fmt.pathTranslator.translate(target) match {
       case ext: ExternalTarget => ext.url
       case int: InternalTarget =>
-        val relPath = int.relativeTo(fmt.path).relativePath
-        if (relPath.withoutFragment.toString.endsWith("/index.html"))
-          relPath.withBasename("").withoutSuffix.toString
-        else
-          relPath.toString
+        fmt.internalTargetsAbsoluteBaseUrl match {
+          
+          case Some(base) =>
+            val abs = int.render(internalTargetsAbsolute = true)
+            val (pathPart, fragPart) = abs.split("#", 2) match {
+              case Array(p)    => (p, "")
+              case Array(p, f) => (p, "#" + f)
+            }
+            val strippedPath =
+              if (pathPart.endsWith("/index.html")) pathPart.stripSuffix("index.html")
+              else pathPart
+            val normalizedBase =
+              if (base == "/") ""
+              else "/" + base.stripPrefix("/").stripSuffix("/")
+            val combined =
+              if (normalizedBase.isEmpty) strippedPath + fragPart
+              else normalizedBase + strippedPath + fragPart
+
+            combined
+
+          case None =>
+            val relPath = int.relativeTo(fmt.path).relativePath
+            if (relPath.withoutFragment.toString.endsWith("/index.html"))
+              relPath.withBasename("").withoutSuffix.toString
+            else
+              relPath.toString
+        }
     }
 
     def renderSpanContainer(con: SpanContainer): String = {

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -164,7 +164,6 @@ private[laika] class HTMLRenderer(format: String)
               case Array(p, f)      => (p, "#" + f)
               case Array()          => ("", "")
             }
-            }
             val strippedPath         =
               if (pathPart.endsWith("/index.html")) pathPart.stripSuffix("index.html")
               else pathPart

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -154,25 +154,25 @@ private[laika] class HTMLRenderer(format: String)
 
     def renderTarget(target: Target): String =
       fmt.pathTranslator.translate(target) match {
-      case ext: ExternalTarget => ext.url
-      case int: InternalTarget =>
-        fmt.internalTargetsAbsoluteBaseUrl match {
+        case ext: ExternalTarget => ext.url
+        case int: InternalTarget =>
+          fmt.internalTargetsAbsoluteBaseUrl match {
 
-          case Some(base) =>
-            val abs = int.render(internalTargetsAbsolute = true)
-            val normalizedBase =
-              if (base == "/") ""
-              else "/" + base.stripPrefix("/").stripSuffix("/")
-            if (normalizedBase.isEmpty) abs else normalizedBase + abs
+            case Some(base) =>
+              val abs            = int.render(internalTargetsAbsolute = true)
+              val normalizedBase =
+                if (base == "/") ""
+                else "/" + base.stripPrefix("/").stripSuffix("/")
+              if (normalizedBase.isEmpty) abs else normalizedBase + abs
 
-          case None =>
-            val relPath = int.relativeTo(fmt.path).relativePath
-            if (relPath.withoutFragment.toString.endsWith("/index.html"))
-              relPath.withBasename("").withoutSuffix.toString
-            else
-              relPath.toString
-        }
-    }
+            case None =>
+              val relPath = int.relativeTo(fmt.path).relativePath
+              if (relPath.withoutFragment.toString.endsWith("/index.html"))
+                relPath.withBasename("").withoutSuffix.toString
+              else
+                relPath.toString
+          }
+      }
 
     def renderSpanContainer(con: SpanContainer): String = {
 

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -160,8 +160,10 @@ private[laika] class HTMLRenderer(format: String)
           case Some(base) =>
             val abs                  = int.render(internalTargetsAbsolute = true)
             val (pathPart, fragPart) = abs.split("#", 2) match {
-              case Array(p)    => (p, "")
-              case Array(p, f) => (p, "#" + f)
+              case Array(p)         => (p, "")
+              case Array(p, f)      => (p, "#" + f)
+              case Array()          => ("", "")
+            }
             }
             val strippedPath         =
               if (pathPart.endsWith("/index.html")) pathPart.stripSuffix("index.html")

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -152,29 +152,18 @@ private[laika] class HTMLRenderer(format: String)
       }
     }
 
-    def renderTarget(target: Target): String = fmt.pathTranslator.translate(target) match {
+    def renderTarget(target: Target): String =
+      fmt.pathTranslator.translate(target) match {
       case ext: ExternalTarget => ext.url
       case int: InternalTarget =>
         fmt.internalTargetsAbsoluteBaseUrl match {
 
           case Some(base) =>
-            val abs                  = int.render(internalTargetsAbsolute = true)
-            val (pathPart, fragPart) = abs.split("#", 2) match {
-              case Array(p)    => (p, "")
-              case Array(p, f) => (p, "#" + f)
-              case Array()     => ("", "")
-            }
-            val strippedPath         =
-              if (pathPart.endsWith("/index.html")) pathPart.stripSuffix("index.html")
-              else pathPart
-            val normalizedBase       =
+            val abs = int.render(internalTargetsAbsolute = true)
+            val normalizedBase =
               if (base == "/") ""
               else "/" + base.stripPrefix("/").stripSuffix("/")
-            val combined             =
-              if (normalizedBase.isEmpty) strippedPath + fragPart
-              else normalizedBase + strippedPath + fragPart
-
-            combined
+            if (normalizedBase.isEmpty) abs else normalizedBase + abs
 
           case None =>
             val relPath = int.relativeTo(fmt.path).relativePath

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -156,20 +156,20 @@ private[laika] class HTMLRenderer(format: String)
       case ext: ExternalTarget => ext.url
       case int: InternalTarget =>
         fmt.internalTargetsAbsoluteBaseUrl match {
-          
+
           case Some(base) =>
-            val abs = int.render(internalTargetsAbsolute = true)
+            val abs                  = int.render(internalTargetsAbsolute = true)
             val (pathPart, fragPart) = abs.split("#", 2) match {
               case Array(p)    => (p, "")
               case Array(p, f) => (p, "#" + f)
             }
-            val strippedPath =
+            val strippedPath         =
               if (pathPart.endsWith("/index.html")) pathPart.stripSuffix("index.html")
               else pathPart
-            val normalizedBase =
+            val normalizedBase       =
               if (base == "/") ""
               else "/" + base.stripPrefix("/").stripSuffix("/")
-            val combined =
+            val combined             =
               if (normalizedBase.isEmpty) strippedPath + fragPart
               else normalizedBase + strippedPath + fragPart
 

--- a/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/internal/render/HTMLRenderer.scala
@@ -160,9 +160,9 @@ private[laika] class HTMLRenderer(format: String)
           case Some(base) =>
             val abs                  = int.render(internalTargetsAbsolute = true)
             val (pathPart, fragPart) = abs.split("#", 2) match {
-              case Array(p)         => (p, "")
-              case Array(p, f)      => (p, "#" + f)
-              case Array()          => ("", "")
+              case Array(p)    => (p, "")
+              case Array(p, f) => (p, "#" + f)
+              case Array()     => ("", "")
             }
             val strippedPath         =
               if (pathPart.endsWith("/index.html")) pathPart.stripSuffix("index.html")

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -24,6 +24,7 @@ import laika.api.Renderer
 import laika.api.bundle.{ BundleOrigin, ExtensionBundle, PathTranslator }
 import laika.api.config.Origin.TreeScope
 import laika.api.config.{ Config, ConfigBuilder, Origin }
+import laika.api.config.Origin.DocumentScope
 import laika.api.errors.{ InvalidDocument, InvalidDocuments }
 import laika.api.format.{ Formatter, TagFormatter }
 import laika.ast
@@ -1305,6 +1306,81 @@ class TreeRendererSpec extends CatsEffectSuite
     } yield res
 
     res.assertEquals(expected)
+  }
+
+  test("render internal targets as absolute when per-document baseUrl is configured") {
+
+    val cfgRoot =
+      ConfigBuilder
+        .withOrigin(Origin(DocumentScope, Root / "404"))
+        .withValue("laika.renderTarget.absolute.baseUrl", "/")
+        .build
+
+    val doc404Root =
+      Document(
+        Root / "404",
+        RootElement(
+          p(SpanLink.internal("/doc.html")("to-doc"))
+        )
+      ).withConfig(cfgRoot)
+
+    val cfgProject =
+      ConfigBuilder
+        .withOrigin(Origin(DocumentScope, Root / "404-project"))
+        .withValue("laika.renderTarget.absolute.baseUrl", "/project")
+        .build
+
+    val doc404Project =
+      Document(
+        Root / "404-project",
+        RootElement(
+          p(
+            SpanLink.internal("/doc.html")("to-doc"),
+            Text(" "),
+            SpanLink.internal("/index.html")("home"),
+            Text(" "),
+            SpanLink.internal("/guide/index.html#install")("install")
+          )
+        )
+      ).withConfig(cfgProject)
+
+    val normalDoc =
+      Document(
+        Root / "doc",
+        RootElement(
+          p(SpanLink.internal("/other.html")("to-other"))
+        )
+      )
+
+    val inputTree =
+      DocumentTree.builder
+        .addDocument(doc404Root)
+        .addDocument(doc404Project)
+        .addDocument(normalDoc)
+        .buildRoot
+
+    val renderer =
+      Renderer.of(HTML).parallel[IO].build
+
+    renderer.use(
+      _.from(inputTree)
+        .toMemory
+        .render
+    ).map { result =>
+
+      val rendered404Root =
+        result.allDocuments.find(_.path == Root / "404.html").get
+      val rendered404Project =
+        result.allDocuments.find(_.path == Root / "404-project.html").get
+      val renderedDoc =
+        result.allDocuments.find(_.path == Root / "doc.html").get
+
+      assert(rendered404Root.content.contains("""href="/doc.html""""))
+      assert(rendered404Project.content.contains("""href="/project/doc.html""""))
+      assert(rendered404Project.content.contains("""href="/project/""""))
+      assert(rendered404Project.content.contains("""href="/project/guide/#install""""))
+      assert(renderedDoc.content.contains("""href="other.html""""))
+    }
   }
 
 }

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -1367,12 +1367,11 @@ class TreeRendererSpec extends CatsEffectSuite
         .toMemory
         .render
     ).map { result =>
-
-      val rendered404Root =
+      val rendered404Root    =
         result.allDocuments.find(_.path == Root / "404.html").get
       val rendered404Project =
         result.allDocuments.find(_.path == Root / "404-project.html").get
-      val renderedDoc =
+      val renderedDoc        =
         result.allDocuments.find(_.path == Root / "doc.html").get
 
       assert(rendered404Root.content.contains("""href="/doc.html""""))

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -1367,17 +1367,17 @@ class TreeRendererSpec extends CatsEffectSuite
         .toMemory
         .render
     ).map { result =>
-      val rendered404Root    =
+      val rendered404Root =
         result.allDocuments.find(_.path == Root / "404.html").get
       val rendered404Project =
         result.allDocuments.find(_.path == Root / "404-project.html").get
-      val renderedDoc        =
+      val renderedDoc =
         result.allDocuments.find(_.path == Root / "doc.html").get
 
       assert(rendered404Root.content.contains("""href="/doc.html""""))
       assert(rendered404Project.content.contains("""href="/project/doc.html""""))
-      assert(rendered404Project.content.contains("""href="/project/""""))
-      assert(rendered404Project.content.contains("""href="/project/guide/#install""""))
+      assert(rendered404Project.content.contains("""href="/project/index.html""""))
+      assert(rendered404Project.content.contains("""href="/project/guide/index.html#install""""))
       assert(renderedDoc.content.contains("""href="other.html""""))
     }
   }

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -1367,11 +1367,11 @@ class TreeRendererSpec extends CatsEffectSuite
         .toMemory
         .render
     ).map { result =>
-      val rendered404Root =
+      val rendered404Root    =
         result.allDocuments.find(_.path == Root / "404.html").get
       val rendered404Project =
         result.allDocuments.find(_.path == Root / "404-project.html").get
-      val renderedDoc =
+      val renderedDoc        =
         result.allDocuments.find(_.path == Root / "doc.html").get
 
       assert(rendered404Root.content.contains("""href="/doc.html""""))


### PR DESCRIPTION
Fixes typelevel/typelevel.github.com#602

the typelevel website previously would break for https://typelevel.org/doesnt/exist because laika renders internal targets in relative path. The relative `main.css` resolve to `/doesnt/main.css` thus assets failed to load. I think the issue is in `HTMLRenderer.renderTarget` where internal targets are rendered relative to `fmt.path`. My fix is basically

-detect when rendering the 404 page (`fmt.path.basename == "404"`)
-render internal targets as root-relative (`/main.css`) for the 404 page

I have also done testing & checked
-the generated `404.html` now contains `/main.css` instead of `main.css` for static site
-`http://127.0.0.1:8080/doesnt/exist` worked when served locally
-other pages (like `index.html`) unaffected and still use relative path






